### PR TITLE
operators deployment-validation-operator (0.1.0)

### DIFF
--- a/operators/deployment-validation-operator/0.1.0/deploymentvalidationoperator.0.1.0.clusterserviceversion.yaml
+++ b/operators/deployment-validation-operator/0.1.0/deploymentvalidationoperator.0.1.0.clusterserviceversion.yaml
@@ -1,0 +1,137 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Basic Install
+    categories: Application Runtime, Monitoring, Security
+    certified: "false"
+    containerImage: quay.io/deployment-validation-operator/dv-operator:0.1.0
+    createdAt: 09/29/2021
+    description: The deployment validation operator
+    repository: https://github.com/app-sre/deployment-validation-operator
+    support: Best Effort
+  name: deployment-validation-operator.v0.1.0
+spec:
+  description: "The Deployment Validator Operator(DVO) checks deployments and other\
+    \ resources against a curated collection of best practices.\nThese best practices\
+    \ focus mainly on ensuring that the applications are fault-tolerant.\n\n### Installation\n\
+    \ This operator requires a Kubernetes ConfigMap to be created in the **same namespace**\
+    \ as operator itself. ConfigMap should be named as *deployment-validation-operator* and\
+    \ contain *deployment-validation-operator-config.yaml* as data. [Example](https://github.com/app-sre/deployment-validation-operator/blob/master/deploy/openshift/configmap.yaml)\n\
+    \ \n### Metrics\nDVO will report failed validations via Prometheus metrics. All the metrics\
+    \ are gauges that will report `1` if the best-practice has failed.\nThere is [Instruction](https://github.com/app-sre/deployment-validation-operator#install-dashboard)\
+    \ to install a simple grafana dashboard."
+  displayName: Deployment Validation Operator
+  replaces: deployment-validation-operator.v0.0.10
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - '*'
+          resources:
+          - '*'
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: deployment-validation-operator
+      deployments:
+      - name: deployment-validation-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: deployment-validation-operator
+          strategy:
+            rollingUpdate:
+              maxSurge: 1
+              maxUnavailable: 0
+            type: RollingUpdate
+          template:
+            metadata:
+              labels:
+                app: deployment-validation-operator
+                name: deployment-validation-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  value: ""
+                - name: OPERATOR_NAME
+                  value: deployment-validation-operator
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                image: quay.io/deployment-validation-operator/dv-operator:0.1.0
+                imagePullPolicy: Always
+                name: deployment-validation-operator
+                args:
+                - --config /config/deployment-validation-operator-config.yaml
+              restartPolicy: Always
+              serviceAccount: deployment-validation-operator
+              terminationGracePeriodSeconds: 30
+              volumes:
+                - configMap:
+                    name: deployment-validation-operator-config
+                  name: dvo-config
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - services
+          - services/finalizers
+          verbs:
+          - get
+          - create
+          - list
+          - delete
+          - update
+          - watch
+          - patch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - deployment-validation-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - '*'
+        serviceAccountName: deployment-validation-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: AllNamespaces
+  - supported: false
+    type: MultiNamespace
+  keywords:
+  - dvo
+  labels:
+    alm-owner-dvo: deployment-validation-operator
+    operated-by: deployment-validation-operator
+  links:
+  - name: repository
+    url: https://github.com/app-sre/deployment-validation-operator
+  - name: containerImage
+    url: https://quay.io/deployment-validation-operator/dv-operator:0.1.0
+  maturity: alpha
+  provider:
+    name: Red Hat
+  selector:
+    matchLabels:
+      alm-owner-dvo: deployment-validation-operator
+      operated-by: deployment-validation-operator
+  version: 0.1.0

--- a/operators/deployment-validation-operator/deployment-validation-operator.package.yaml
+++ b/operators/deployment-validation-operator/deployment-validation-operator.package.yaml
@@ -1,5 +1,5 @@
 packageName: deployment-validation-operator
 channels:
 - name: alpha
-  currentCSV: deployment-validation-operator.v0.0.10
+  currentCSV: deployment-validation-operator.v0.1.0
 defaultChannel: alpha


### PR DESCRIPTION
Signed-off-by: Feng Huang <fehuang@redhat.com>

### Updates to existing Operators

* [x] Did you create a `ci.yaml` file according to the [update instructions](https://github.com/operator-framework/community-operators/blob/master/docs/operator-ci-yaml.md)?
* [x] Is your new CSV pointing to the previous version with the `replaces` property if you chose `replaces-mode` via the `updateGraph` property in `ci.yaml`?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#channels) defined in the `package.yaml` or `annotations.yaml` ?
* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-prerequisites.md#sign-your-work)?

### Your submission should not

* [x] Modify more than one operator
* [x] Modify an Operator you don't own
* [x] Rename an operator - please remove and add with a different name instead
* [x] Modify any files outside the above mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [x] Description about the managed Application and where to find more information
2. [x] Features and capabilities of your Operator and how to use it
3. [x] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human readable name and 1-liner description about your Operator
* [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#categories)<sup>1</sup>
* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used
* [x] A quadratic logo
