### PR TITLE
operators [CI] storageos (2.4.4)

### DIFF
--- a/operators/storageos/2.4.4/storageos.v2.4.4.clusterserviceversion.yaml
+++ b/operators/storageos/2.4.4/storageos.v2.4.4.clusterserviceversion.yaml
@@ -1,0 +1,681 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: storageosoperator.v2.4.4
+  namespace: placeholder
+  annotations:
+    capabilities: Deep Insights
+    categories: Storage
+    description: Cloud-native, persistent storage for containers.
+    containerImage: storageos/cluster-operator:v2.4.4
+    repository: https://github.com/storageos/cluster-operator
+    createdAt: "2021-09-07T10:21:29Z"
+    support: StorageOS, Inc
+    certified: "false"
+    operators.operatorframework.io/internal-objects: |-
+      [
+        "jobs.storageos.com",
+        "storageosupgrades.storageos.com",
+        "nfsservers.storageos.com"
+      ]
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "storageos.com/v1",
+          "kind": "StorageOSCluster",
+          "metadata": {
+            "name": "example-storageos",
+            "namespace": "default"
+          },
+          "spec": {
+            "secretRefName": "storageos-api",
+            "secretRefNamespace": "default",
+            "kvBackend": {
+              "address": "http://<etcd-node-address>:2379"
+            }
+          }
+        }
+      ]
+spec:
+  displayName: StorageOS
+  description: |
+    StorageOS is a cloud native, software-defined storage platform that
+    transforms commodity server or cloud based disk capacity into
+    enterprise-class persistent storage for containers. StorageOS volumes
+    offer high throughput, low latency and consistent performance, and
+    are therefore ideal for deploying databases, message queues, and
+    other mission-critical stateful solutions. StorageOS Project edition
+    also offers ReadWriteMany volumes that are concurrently accessible
+    by multiple applications.
+
+    The StorageOS Operator installs and manages StorageOS within a cluster.
+    Cluster nodes may contribute local or attached disk-based storage into a
+    distributed pool, which is then available to all cluster members via a
+    global namespace.
+
+    Volumes are available across the cluster so if a container gets moved to
+    another node it has immediate access to re-attach its data.
+
+    StorageOS is extremely lightweight - minimum requirements are a
+    reserved CPU core and 2GB of free memory. There are minimal external
+    dependencies, and no custom kernel modules.
+
+    After StorageOS is installed, please register for a free Developer
+    license to enable 5TiB of capacity and HA with synchronous
+    replication by following the instructions
+    [here](https://docs.storageos.com/docs/operations/licensing). For
+    additional capacity, features and support plans contact
+    sales@storageos.com.
+
+    ## Highlighted Features
+
+    * **High Availability** - synchronous replication insulates you from node failure.
+
+    * **Delta Sync** - replicas out of sync due to transient failures only transfer changed blocks.
+
+    * **Multiple AccessModes** - dynamically provision ReadWriteOnce or ReadWriteMany volumes.
+
+    * **Rapid Failover** - quickly detects node failure and automates recovery actions without administrator intervention.
+    
+    * **Data Encryption** - both in transit and at rest.  
+
+    * **Scalability** - disaggregated consensus means no single scheduling point of failure.
+
+    * **Thin provisioning** - Only consume the space you need in a storage pool.
+
+    * **Data reduction** - transparent inline data compression to reduce the amount of storage used in a backing store as well as reducing the network bandwidth requirements for replication.
+
+    * **Flexible configuration** - all features can be enabled per volume, using PVC and StorageClass labels.
+
+    * **Multi-tenancy** - fully supports standard Namespace and RBAC methods.
+
+    * **Observability & instrumentation** - log streams for observability and Prometheus support for instrumentation.
+
+    * **Deployment flexibility** - scale up or scale out storage based on application requirements. Works with any infrastructure – on-premises, VM, bare metal or cloud.
+
+    ## Prerequisites
+
+    [StorageOS Prerequisites Docs](https://docs.storageos.com/docs/prerequisites)
+
+    ## Required Parameters
+
+    * `secretRefName` - the name of a secret that contains keys for the
+    credentials
+    ([documentation](https://docs.storageos.com/docs/reference/cluster-operator/examples))
+    * `secretRefNamespace` - the namespace where the api credentials secret is
+    stored
+    * `kvBackend.address` - address of the etcd cluster
+    ([documentation](https://docs.storageos.com/docs/prerequisites/etcd/))
+
+    ## About StorageOS
+
+    StorageOS is a software-defined cloud native storage platform
+    delivering persistent storage for Kubernetes. StorageOS is built from
+    the ground-up with no legacy restrictions to give enterprises working
+    with cloud native workloads a scalable storage platform with no
+    compromise on performance, availability or security. For additional
+    information, visit [www.storageos.com](www.storageos.com).
+  keywords:
+  - storageos
+  - storage
+  - persistent storage
+  - open source
+  version: 2.4.4
+  minKubeVersion: 1.13.0
+  maturity: stable
+  maintainers:
+  - name: StorageOS, Inc
+    email: support@storageos.com
+  provider:
+    name: StorageOS, Inc
+  labels:
+    operated-by: storageosoperator
+  selector:
+    matchLabels:
+      operated-by: storageosoperator
+  links:
+  - name: Documentation
+    url: https://docs.storageos.com/
+  - name: StorageOS Operator Source Code
+    url: https://github.com/storageos/cluster-operator
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4NCjwhLS0gR2VuZXJhdG9yOiBBZG9iZSBJbGx1c3RyYXRvciAxOS4wLjAsIFNWRyBFeHBvcnQgUGx1Zy1JbiAuIFNWRyBWZXJzaW9uOiA2LjAwIEJ1aWxkIDApICAtLT4NCjxzdmcgdmVyc2lvbj0iMS4xIiBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiDQoJIHZpZXdCb3g9Ii05MCAyODQuNyA0MzAgNDMwIiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IC05MCAyODQuNyA0MzAgNDMwIiB4bWw6c3BhY2U9InByZXNlcnZlIj4NCjxnPg0KCTxwYXRoIGZpbGw9IiM0RjUyNjMiIGQ9Ik0yNzguNSw0MjAuOWgtNzQuMWwtNS42LTkuN2wxMy42LTIzLjZsLTE4LjEtMzEuM0gxODBsMjcuNS00Ny43YzMtNS4xLDEuMi0xMS43LTMuOS0xNC42DQoJCWMtNS4xLTMtMTEuNy0xLjItMTQuNiwzLjlsLTM0LDU4LjhIOTMuMmwtMzQtNTguOGMtMi45LTUuMS05LjUtNi45LTE0LjYtMy45cy02LjksOS41LTMuOSwxNC42bDI3LjUsNDcuN0g1My45bC0xOC4xLDMxLjMNCgkJbDEzLjYsMjMuNmwtNS42LDkuOGgtNzQuMmwtNDMuMyw3NC45bDQzLjMsNzQuOWg3NC4xbDM0LDU4LjlMNzksNjI5bC0xLjIsMC44bDQ2LjQsNzcuMmw0Ni4yLTc3LjNsMCwwbDM0LTU4LjloNzQuMWw0My4zLTc0LjkNCgkJTDI3OC41LDQyMC45eiBNNTUuNSw0MDAuNWwtNy40LTEyLjhMNjAsMzY3aDE0LjNsMC4zLDAuNUw1NS41LDQwMC41eiBNMTczLjQsMzY3LjVsMC4zLTAuNUgxODhsMTEuOSwyMC42bC03LjQsMTIuOUwxNzMuNCwzNjcuNXoiDQoJCS8+DQoJPHBvbHlnb24gZmlsbD0iI0ZGRkZGRiIgcG9pbnRzPSI0My43LDQ0Mi4zIDQyLjgsNDQyLjMgLTE4LjEsNDQyLjMgLTQ4LjksNDk1LjggLTE4LjEsNTQ5LjMgNDMsNTQ5LjMgNDMuNyw1NDkuMyA3NC42LDQ5NS45IAkiLz4NCgk8cG9seWdvbiBmaWxsPSIjRkZGRkZGIiBwb2ludHM9IjI2Ni4xLDQ0Mi4zIDIwNC4zLDQ0Mi4zIDIwNC4zLDQ0Mi41IDE3My40LDQ5NS44IDIwNC4zLDU0OS4zIDIwNC40LDU0OS4zIDI2Ni4xLDU0OS4zIDI5Nyw0OTUuOCAJDQoJCSIvPg0KCTxwb2x5Z29uIGZpbGw9IiM2MUMyMDIiIHBvaW50cz0iMTU0LjksMzc4LjIgOTMuMSwzNzguMiA5My4xLDM3OC4zIDYyLjMsNDMxLjcgOTMuMSw0ODUuMiA5My4yLDQ4NS4yIDE1NC45LDQ4NS4yIDE4NS44LDQzMS43IAkiLz4NCgk8cG9seWdvbiBmaWxsPSIjNjFDMjAyIiBwb2ludHM9IjE1Mi4xLDYxOC40IDE1Mi4xLDYxOC40IDEyNCw2NjUuMiA5Ni4yLDYxOC45IDk2LjIsNjE4LjkgNjIuMiw1NjAuMSA4OC4zLDUxNC45IDkzLjEsNTA2LjYgDQoJCTE1NC45LDUwNi42IDE4NS44LDU2MC4xIAkiLz4NCjwvZz4NCjxyZWN0IHg9Ii0xMDUiIHk9IjI3MC43IiBmaWxsPSJub25lIiB3aWR0aD0iNDU4IiBoZWlnaHQ9IjQ1OCIvPg0KPC9zdmc+DQo=
+    mediatype: image/svg+xml
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: storageos-operator
+        rules:
+        - apiGroups:
+          - storageos.com
+          resources:
+          - storageosclusters
+          - storageosclusters/status
+          - storageosupgrades
+          - storageosupgrades/status
+          - jobs
+          - jobs/status
+          - nfsservers
+          - nfsservers/status
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          - daemonsets
+          - deployments
+          - replicasets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - list
+          - watch
+          - get
+          - update
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - list
+          - watch
+          - get
+          - update
+          - patch
+          - delete
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          - namespaces
+          - serviceaccounts
+          - secrets
+          - services
+          - services/finalizers
+          - persistentvolumeclaims
+          - persistentvolumeclaims/status
+          - persistentvolumes
+          - configmaps
+          - replicationcontrollers
+          - pods/binding
+          - pods/status
+          - endpoints
+          verbs:
+          - create
+          - patch
+          - get
+          - list
+          - delete
+          - watch
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          - clusterroles
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          - volumeattachments
+          - volumeattachments/status
+          - csinodeinfos
+          - csinodes
+          - csidrivers
+          verbs:
+          - create
+          - delete
+          - watch
+          - list
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
+          - delete
+        - apiGroups:
+          - csi.storage.k8s.io
+          resources:
+          - csidrivers
+          verbs:
+          - create
+          - delete
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - delete
+          - update
+          - get
+          - use
+          resourceNames:
+          - privileged
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          resourceNames:
+          - storageos-cluster-operator
+          verbs:
+          - update
+        - apiGroups:
+          - events.k8s.io
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - create
+          - update
+      deployments:
+      - name: storageos-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: storageos-operator
+          template:
+            metadata:
+              name: storageos-operator
+              labels:
+                name: storageos-operator
+            spec:
+              serviceAccountName: storageos-operator
+              containers:
+              - name: storageos-operator
+                command:
+                - cluster-operator
+                image: storageos/cluster-operator:v2.4.4
+                env:
+                - name: RELATED_IMAGE_STORAGEOS_NODE
+                  value: ""
+                - name: RELATED_IMAGE_STORAGEOS_INIT
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_CLUSTER_DRIVER_REGISTRAR
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_NODE_DRIVER_REGISTRAR
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_EXTERNAL_PROVISIONER
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V2
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V3
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_EXTERNAL_RESIZER
+                  value: ""
+                - name: RELATED_IMAGE_CSIV1_LIVENESS_PROBE
+                  value: ""
+                - name: RELATED_IMAGE_CSIV0_DRIVER_REGISTRAR
+                  value: ""
+                - name: RELATED_IMAGE_CSIV0_EXTERNAL_PROVISIONER
+                  value: ""
+                - name: RELATED_IMAGE_CSIV0_EXTERNAL_ATTACHER
+                  value: ""
+                - name: RELATED_IMAGE_NFS
+                  value: ""
+                - name: RELATED_IMAGE_KUBE_SCHEDULER
+                  value: ""
+                - name: RELATED_IMAGE_API_MANAGER
+                  value: ""
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: OPERATOR_NAME
+                  value: storageos-cluster-operator
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                ports:
+                - containerPort: 8383
+                  name: metrics
+                - containerPort: 8686
+                  name: operatormetrics
+  customresourcedefinitions:
+    owned:
+    - name: storageosclusters.storageos.com
+      version: v1
+      kind: StorageOSCluster
+      displayName: StorageOS Cluster
+      description: StorageOS Cluster installs StorageOS in the cluster. It contains
+        all the configuration for setting up a StorageOS cluster and also shows the
+        status of the running StorageOS cluster.
+      resources:
+      - kind: Namespace
+        version: v1
+      - kind: ServiceAccount
+        version: v1
+      - kind: Role
+        version: rbac.authorization.k8s.io/v1
+      - kind: RoleBinding
+        version: rbac.authorization.k8s.io/v1
+      - kind: ClusterRole
+        version: rbac.authorization.k8s.io/v1
+      - kind: ClusterRoleBinding
+        version: rbac.authorization.k8s.io/v1
+      - kind: Secret
+        version: v1
+      - kind: DaemonSet
+        version: apps/v1
+      - kind: Service
+        version: v1
+      - kind: Ingress
+        version: extensions/v1beta1
+      - kind: Deployment
+        version: apps/v1
+      - kind: StatefulSet
+        version: apps/v1
+      - kind: StorageClass
+        version: storage.k8s.io/v1
+      - kind: StorageOSCluster
+        version: v1
+      - kind: Job
+        version: v1
+      - kind: StorageOSUpgrade
+        version: v1
+      - kind: NFSServer
+        version: v1
+      - kind: Node
+        version: v1
+      - kind: StatefulSet
+        version: v1
+      - kind: DaemonSet
+        version: v1
+      specDescriptors:
+      - description: Defines the various container images used in the cluster.
+        displayName: Images
+        path: images
+      - description: The namespace to install the StorageOS cluster into. `kube-system`
+          is recommended so that StorageOS does not get evicted if a node becomes
+          over-allocated.
+        displayName: Namespace
+        path: namespace
+      - description: The name of the secret object that stores the api credentials.
+        displayName: Cluster Secret
+        path: secretRefName
+      - description: The name of the namespace where the secret object that stores
+          the api credentials exists.
+        displayName: Cluster Secret Namespace
+        path: secretRefNamespace
+      - description: The join token is used for cluster discovery.  When used with
+          the Operator, the token will be a comma-separated list of all cluster member
+          IP addresses.  The node that owns the first IP address listed will be responsible
+          for bootsrapping the cluster.
+        displayName: Cluster members
+        path: join
+      - description: KV store configuration to use. Defaults to embedded. `etcd` is
+          recommended for production deployments with the address set to an external
+          etcd instance.
+        displayName: KV Store
+        path: kvBackend
+      - description: Describes the Container Storage Interface (CSI) configuration.
+        displayName: Enable CSI
+        path: csi
+      - description: The cluster Service configuration.
+        displayName: Service configuration
+        path: service
+      - description: The shared directory where storage devices should be created.  This
+          directory must be available to both the StorageOS Node container and the
+          kubelet, and must have mount propagation enabled. When kubelet is running
+          in a container, `/var/lib/kubelet/plugins/kubernetes.io~storageos` should
+          normally be set, otherwise leave empty.
+        displayName: Device directory
+        path: sharedDir
+      - description: Describes the ingress configuration to be configured for the
+          cluster.
+        displayName: Ingress configuration
+        path: ingress
+      - description: The name of the secret object that contains the etcd TLS certificates.
+        displayName: etcd TLS Secret Name
+        path: tlsEtcdSecretRefName
+      - description: The namespace of the secret object that contains the etcd TLS
+          certificates.
+        displayName: etcd TLS Secret Namespace
+        path: tlsEtcdSecretRefNamespace
+      - description: Node selector terms can be set to control the placement of StorageOS
+          pods using node affiinity.
+        displayName: Node Selectors
+        path: nodeSelectorTerms
+      - description: Tolerations can be set to control the placement of StorageOS
+          pods.
+        displayName: Tolerations
+        path: tolerations
+      - description: Name of the Kubernetes distribution in use, e.g. `openshift`.  This
+          will be included in the product telemetry (if enabled), to help focus development
+          efforts.
+        displayName: Kubernetes Distribution Name
+        path: k8sDistro
+      - description: To disable anonymous usage reporting across the cluster, set
+          to true. Defaults to false. To help improve the product, data such as API
+          usage and StorageOS configuration information is collected.
+        displayName: Disable Telemetry
+        path: disableTelemetry
+      - description: When Pod Fencing is disabled, StorageOS will not perform any
+          interaction with Kubernetes when it detects that a node has gone offline.
+          Additionally, the Kubernetes permissions required for Fencing will not be
+          added to the StorageOS role.
+        displayName: Disable Fencing
+        path: disableFencing
+      - description: Disable TCMU can be set to true to disable the TCMU storage driver.  This
+          is required when there are multiple storage systems running on the same
+          node and you wish to avoid conflicts.  Only one TCMU-based storage system
+          can run on a node at a time.  Disabling TCMU will degrade performance.
+        displayName: Disable TCMU
+        path: disableTCMU
+      - description: Force TCMU can be set to true to ensure that TCMU is enabled
+          or cause StorageOS to abort startup.  At startup, StorageOS will automatically
+          fallback to non-TCMU mode if another TCMU-based storage system is running
+          on the node.  Since non-TCMU has performance drawbacks, this may not always
+          be desired.
+        displayName: Force TCMU
+        path: forceTCMU
+      - description: Disable StorageOS scheduler deployment. StorageOS scheduler helps
+          improve the scheduling decision of a pod, considering the location of volumes
+          and their replicas.
+        displayName: Disable Scheduler
+        path: disableScheduler
+      - description: When enabled, the Operator will not perform any actions on the
+          cluster.
+        displayName: Pause Operator
+        path: pause
+      - description: Enables debug logging when set to true.
+        displayName: Enable Debug
+        path: debug
+      statusDescriptors:
+      - description: Set of nodes that are part of the StorageOS Cluster.
+        displayName: Nodes
+        path: nodes
+      - description: The status of each of the members of StorageOS Cluster.
+        displayName: Member Status
+        path: members
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      - description: The current status of the StorageOS Cluster.
+        displayName: Status
+        path: phase
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.phase
+      - description: Ready Nodes
+        displayName: Ready
+        path: ready
+      - description: Health status of StorageOS nodes.
+        displayName: Node Health Status
+        path: nodeHealthStatus
+    - name: jobs.storageos.com
+      version: v1
+      kind: Job
+      displayName: StorageOS Job
+      description: StorageOS Job creates special pods that run on all the node and
+        perform an administrative task. This could be used for cluster maintenance
+        tasks.
+      resources:
+      - kind: DaemonSet
+        version: apps/v1
+      specDescriptors:
+      - description: The container image to run as the job.
+        displayName: Image
+        path: image
+      - description: The arguments to pass to the job container.
+        displayName: Arguments
+        path: args
+      - description: The path in the job container where a volume is mounted.
+        displayName: Target Path
+        path: mountPath
+      - description: The path on the host that is mounted into the job container.
+        displayName: Source path
+        path: hostPath
+      - description: The job is marked as completed when the completion word is found
+          in the pod logs.
+        displayName: Source Path
+        path: completionWord
+      - description: A label selector can be set to identify Pods created by the job.
+        displayName: Label Selector
+        path: labelSelector
+      - description: Node selector terms can be set to control the placement of job
+          pods using node affiinity.
+        displayName: Node Selectors
+        path: nodeSelectorTerms
+      - description: Tolerations can be set to control the placement of job pods.
+        displayName: Tolerations
+        path: tolerations
+      statusDescriptors:
+      - description: Set to true if the job completed.
+        displayName: Completed
+        path: completed
+    - name: storageosupgrades.storageos.com
+      version: v1
+      kind: StorageOSUpgrade
+      displayName: StorageOS Upgrade
+      description: StorageOS Upgrade automatically upgrades an existing StorageOS
+        cluster as per the upgrade configuration.
+      resources:
+      - kind: ServiceAccount
+        version: v1
+      - kind: ClusterRole
+        version: rbac.authorization.k8s.io/v1
+      - kind: ClusterRoleBinding
+        version: rbac.authorization.k8s.io/v1
+      - kind: Job
+        version: batch/v1
+      specDescriptors:
+      - description: The StorageOS Node image to upgrade to. e.g. `storageos/node:latest`
+        displayName: New Image
+        path: newImage
+      statusDescriptors:
+      - description: Set to true if the upgrade completed.
+        displayName: Completed
+        path: completed
+    - name: nfsservers.storageos.com
+      version: v1
+      kind: NFSServer
+      displayName: NFS Server
+      description: StorageOS NFS Server provides support for shared volumes. The StorageOS
+        control plane will automatically create and manage NFS Server instances when
+        a PersistentVolumeClaim requests a volume with AccessMode=ReadWriteMany.
+      resources:
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: ServiceAccount
+        version: v1
+      - kind: ClusterRoleBinding
+        version: rbac.authorization.k8s.io/v1
+      - kind: StatefulSet
+        version: apps/v1
+      specDescriptors:
+      - description: The annotations-related configuration to add/set on each Pod
+          related object.
+        displayName: Pod annotations
+        path: annotations
+      - description: The parameters to configure the NFS export.
+        displayName: NFS export
+        path: export
+      - description: PV mount options. Not validated - mount of the PVs will simply
+          fail if one is invalid.
+        displayName: Mount Options
+        path: mountOptions
+      - description: The container image of the NFS server.
+        displayName: Image
+        path: nfsContainer
+      - description: Reclamation policy for the persistent volume shared to the user's
+          pod.
+        displayName: PVC Reclaimation Policy
+        path: persistentVolumeReclaimPolicy
+      - description: Resources represents the minimum resources required.
+        displayName: Resources
+        path: resources
+      - description: StorageClassName is the name of the StorageClass used by the
+          NFS volume.
+        displayName: StorageClass Name
+        path: storageClassName
+      - description: Tolerations is to set the placement of NFS server pods using
+          pod toleration.
+        displayName: Pod Tolerations.
+        path: tolerations
+      - description: PersistentVolumeClaim is the PVC source of the PVC to be used
+          with the NFS Server. If not specified, a new PVC is provisioned and used.
+        displayName: Persistent Volume Claim
+        path: persistentVolumeClaim
+  replaces: storageosoperator.v2.4.2

--- a/operators/storageos/2.4.4/storageoscluster.crd.yaml
+++ b/operators/storageos/2.4.4/storageoscluster.crd.yaml
@@ -1,0 +1,444 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: storageosclusters.storageos.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.ready
+    description: Ready status of the storageos nodes.
+    name: ready
+    type: string
+  - JSONPath: .status.phase
+    description: Status of the whole cluster.
+    name: status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
+  group: storageos.com
+  names:
+    kind: StorageOSCluster
+    listKind: StorageOSClusterList
+    plural: storageosclusters
+    shortNames:
+    - stos
+    singular: storageoscluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: StorageOSCluster is the Schema for the storageosclusters API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: StorageOSClusterSpec defines the desired state of StorageOSCluster
+          properties:
+            csi:
+              description: CSI defines the configurations for CSI.
+              properties:
+                deploymentStrategy:
+                  type: string
+                deviceDir:
+                  type: string
+                driverRegisterationMode:
+                  type: string
+                driverRequiresAttachment:
+                  type: string
+                enable:
+                  type: boolean
+                enableControllerExpandCreds:
+                  type: boolean
+                enableControllerPublishCreds:
+                  type: boolean
+                enableNodePublishCreds:
+                  type: boolean
+                enableProvisionCreds:
+                  type: boolean
+                endpoint:
+                  type: string
+                kubeletDir:
+                  type: string
+                kubeletRegistrationPath:
+                  type: string
+                pluginDir:
+                  type: string
+                registrarSocketDir:
+                  type: string
+                registrationDir:
+                  type: string
+                version:
+                  type: string
+              type: object
+            debug:
+              description: Debug is to set debug mode of the cluster.
+              type: boolean
+            disableFencing:
+              description: "Disable Pod Fencing.  With StatefulSets, Pods are only
+                re-scheduled if the Pod has been marked as killed.  In practice this
+                means that failover of a StatefulSet pod is a manual operation. \n
+                By enabling Pod Fencing and setting the `storageos.com/fenced=true`
+                label on a Pod, StorageOS will enable automated Pod failover (by killing
+                the application Pod on the failed node) if the following conditions
+                exist: \n - Pod fencing has not been explicitly disabled. - StorageOS
+                has determined that the node the Pod is running on is   offline.  StorageOS
+                uses Gossip and TCP checks and will retry for 30   seconds.  At this
+                point all volumes on the failed node are marked   offline (irrespective
+                of whether fencing is enabled) and volume   failover starts. - The
+                Pod has the label `storageos.com/fenced=true` set. - The Pod has at
+                least one StorageOS volume attached. - Each StorageOS volume has at
+                least 1 healthy replica. \n When Pod Fencing is disabled, StorageOS
+                will not perform any interaction with Kubernetes when it detects that
+                a node has gone offline. Additionally, the Kubernetes permissions
+                required for Fencing will not be added to the StorageOS role."
+              type: boolean
+            disableScheduler:
+              description: Disable StorageOS scheduler extender.
+              type: boolean
+            disableTCMU:
+              description: "Disable TCMU can be set to true to disable the TCMU storage
+                driver.  This is required when there are multiple storage systems
+                running on the same node and you wish to avoid conflicts.  Only one
+                TCMU-based storage system can run on a node at a time. \n Disabling
+                TCMU will degrade performance."
+              type: boolean
+            disableTelemetry:
+              description: Disable Telemetry.
+              type: boolean
+            forceTCMU:
+              description: "Force TCMU can be set to true to ensure that TCMU is enabled
+                or cause StorageOS to abort startup. \n At startup, StorageOS will
+                automatically fallback to non-TCMU mode if another TCMU-based storage
+                system is running on the node.  Since non-TCMU will degrade performance,
+                this may not always be desired."
+              type: boolean
+            images:
+              description: Images defines the various container images used in the
+                cluster.
+              properties:
+                apiManagerContainer:
+                  type: string
+                csiClusterDriverRegistrarContainer:
+                  type: string
+                csiExternalAttacherContainer:
+                  type: string
+                csiExternalProvisionerContainer:
+                  type: string
+                csiExternalResizerContainer:
+                  type: string
+                csiLivenessProbeContainer:
+                  type: string
+                csiNodeDriverRegistrarContainer:
+                  type: string
+                hyperkubeContainer:
+                  type: string
+                initContainer:
+                  type: string
+                kubeSchedulerContainer:
+                  type: string
+                nfsContainer:
+                  type: string
+                nodeContainer:
+                  type: string
+              type: object
+            ingress:
+              description: Ingress defines the ingress configurations used in the
+                cluster.
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                enable:
+                  type: boolean
+                hostname:
+                  type: string
+                tls:
+                  type: boolean
+              type: object
+            join:
+              description: Join is the join token used for service discovery.
+              type: string
+            k8sDistro:
+              description: "K8sDistro is the name of the Kubernetes distribution where
+                the operator is being deployed.  It should be in the format: `name[-1.0]`,
+                where the version is optional and should only be appended if known.
+                \ Suitable names include: `openshift`, `rancher`, `aks`, `gke`, `eks`,
+                or the deployment method if using upstream directly, e.g `minishift`
+                or `kubeadm`. \n Setting k8sDistro is optional, and will be used to
+                simplify cluster configuration by setting appropriate defaults for
+                the distribution.  The distribution information will also be included
+                in the product telemetry (if enabled), to help focus development efforts."
+              type: string
+            kvBackend:
+              description: KVBackend defines the key-value store backend used in the
+                cluster.
+              properties:
+                address:
+                  type: string
+                backend:
+                  type: string
+              type: object
+            namespace:
+              description: Namespace is the kubernetes Namespace where storageos resources
+                are provisioned.
+              type: string
+            nodeSelectorTerms:
+              description: NodeSelectorTerms is to set the placement of storageos
+                pods using node affinity requiredDuringSchedulingIgnoredDuringExecution.
+              items:
+                description: A null or empty node selector term matches no objects.
+                  The requirements of them are ANDed. The TopologySelectorTerm type
+                  implements a subset of the NodeSelectorTerm.
+                properties:
+                  matchExpressions:
+                    description: A list of node selector requirements by node's labels.
+                    items:
+                      description: A node selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: The label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: Represents a key's relationship to a set of
+                            values. Valid operators are In, NotIn, Exists, DoesNotExist.
+                            Gt, and Lt.
+                          type: string
+                        values:
+                          description: An array of string values. If the operator
+                            is In or NotIn, the values array must be non-empty. If
+                            the operator is Exists or DoesNotExist, the values array
+                            must be empty. If the operator is Gt or Lt, the values
+                            array must have a single element, which will be interpreted
+                            as an integer. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchFields:
+                    description: A list of node selector requirements by node's fields.
+                    items:
+                      description: A node selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: The label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: Represents a key's relationship to a set of
+                            values. Valid operators are In, NotIn, Exists, DoesNotExist.
+                            Gt, and Lt.
+                          type: string
+                        values:
+                          description: An array of string values. If the operator
+                            is In or NotIn, the values array must be non-empty. If
+                            the operator is Exists or DoesNotExist, the values array
+                            must be empty. If the operator is Gt or Lt, the values
+                            array must have a single element, which will be interpreted
+                            as an integer. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                type: object
+              type: array
+            pause:
+              description: Pause is to pause the operator for the cluster.
+              type: boolean
+            resources:
+              description: Resources is to set the resource requirements of the storageos
+                containers.
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            secretRefName:
+              description: SecretRefName is the name of the secret object that contains
+                all the sensitive cluster configurations.
+              type: string
+            secretRefNamespace:
+              description: SecretRefNamespace is the namespace of the secret reference.
+              type: string
+            service:
+              description: Service is the Service configuration for the cluster nodes.
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                externalPort:
+                  type: integer
+                internalPort:
+                  type: integer
+                name:
+                  type: string
+                type:
+                  type: string
+              required:
+              - name
+              - type
+              type: object
+            sharedDir:
+              description: 'SharedDir is the shared directory to be used when the
+                kubelet is running in a container. Typically: "/var/lib/kubelet/plugins/kubernetes.io~storageos".
+                If not set, defaults will be used.'
+              type: string
+            storageClassName:
+              description: StorageClassName is the name of default StorageClass created
+                for StorageOS volumes.
+              type: string
+            tlsEtcdSecretRefName:
+              description: TLSEtcdSecretRefName is the name of the secret object that
+                contains the etcd TLS certs. This secret is shared with etcd, therefore
+                it's not part of the main storageos secret.
+              type: string
+            tlsEtcdSecretRefNamespace:
+              description: TLSEtcdSecretRefNamespace is the namespace of the etcd
+                TLS secret object.
+              type: string
+            tolerations:
+              description: Tolerations is to set the placement of storageos pods using
+                pod toleration.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              type: array
+          required:
+          - secretRefName
+          - secretRefNamespace
+          type: object
+        status:
+          description: StorageOSClusterStatus defines the observed state of StorageOSCluster
+          properties:
+            members:
+              description: MembersStatus stores the status details of cluster member
+                nodes.
+              properties:
+                ready:
+                  description: Ready are the storageos cluster members that are ready
+                    to serve requests. The member names are the same as the node IPs.
+                  items:
+                    type: string
+                  type: array
+                unready:
+                  description: Unready are the storageos cluster nodes not ready to
+                    serve requests.
+                  items:
+                    type: string
+                  type: array
+              type: object
+            nodeHealthStatus:
+              additionalProperties:
+                description: NodeHealth contains health status of a node.
+                properties:
+                  directfsInitiator:
+                    type: string
+                  director:
+                    type: string
+                  kv:
+                    type: string
+                  kvWrite:
+                    type: string
+                  nats:
+                    type: string
+                  presentation:
+                    type: string
+                  rdb:
+                    type: string
+                type: object
+              type: object
+            nodes:
+              items:
+                type: string
+              type: array
+            phase:
+              description: ClusterPhase is the phase of the storageos cluster at a
+                given point in time.
+              type: string
+            ready:
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/operators/storageos/2.4.4/storageosjob.crd.yaml
+++ b/operators/storageos/2.4.4/storageosjob.crd.yaml
@@ -1,0 +1,190 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: jobs.storageos.com
+spec:
+  group: storageos.com
+  names:
+    kind: Job
+    listKind: JobList
+    plural: jobs
+    singular: job
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Job is the Schema for the jobs API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: JobSpec defines the desired state of Job
+          properties:
+            args:
+              description: Args is an array of strings passed as an argument to the
+                job container.
+              items:
+                type: string
+              type: array
+            completionWord:
+              description: CompletionWord is the word that's looked for in the pod
+                logs to find out if a DaemonSet Pod has completed its task.
+              type: string
+            hostPath:
+              description: HostPath is the path in the host that's mounted into a
+                job container.
+              type: string
+            image:
+              description: Image is the container image to run as the job.
+              type: string
+            labelSelector:
+              description: LabelSelector is the label selector for the job Pods.
+              type: string
+            mountPath:
+              description: MountPath is the path in the job container where a volume
+                is mounted.
+              type: string
+            nodeSelectorTerms:
+              description: NodeSelectorTerms is the set of placement of the job pods
+                using node affinity requiredDuringSchedulingIgnoredDuringExecution.
+              items:
+                description: A null or empty node selector term matches no objects.
+                  The requirements of them are ANDed. The TopologySelectorTerm type
+                  implements a subset of the NodeSelectorTerm.
+                properties:
+                  matchExpressions:
+                    description: A list of node selector requirements by node's labels.
+                    items:
+                      description: A node selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: The label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: Represents a key's relationship to a set of
+                            values. Valid operators are In, NotIn, Exists, DoesNotExist.
+                            Gt, and Lt.
+                          type: string
+                        values:
+                          description: An array of string values. If the operator
+                            is In or NotIn, the values array must be non-empty. If
+                            the operator is Exists or DoesNotExist, the values array
+                            must be empty. If the operator is Gt or Lt, the values
+                            array must have a single element, which will be interpreted
+                            as an integer. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchFields:
+                    description: A list of node selector requirements by node's fields.
+                    items:
+                      description: A node selector requirement is a selector that
+                        contains values, a key, and an operator that relates the key
+                        and values.
+                      properties:
+                        key:
+                          description: The label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: Represents a key's relationship to a set of
+                            values. Valid operators are In, NotIn, Exists, DoesNotExist.
+                            Gt, and Lt.
+                          type: string
+                        values:
+                          description: An array of string values. If the operator
+                            is In or NotIn, the values array must be non-empty. If
+                            the operator is Exists or DoesNotExist, the values array
+                            must be empty. If the operator is Gt or Lt, the values
+                            array must have a single element, which will be interpreted
+                            as an integer. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                type: object
+              type: array
+            tolerations:
+              description: Tolerations is to set the placement of storageos pods using
+                pod toleration.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              type: array
+          required:
+          - args
+          - completionWord
+          - hostPath
+          - image
+          - mountPath
+          type: object
+        status:
+          description: JobStatus defines the observed state of Job
+          properties:
+            completed:
+              description: Completed indicates the complete status of job.
+              type: boolean
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/operators/storageos/2.4.4/storageosnfsserver.crd.yaml
+++ b/operators/storageos/2.4.4/storageosnfsserver.crd.yaml
@@ -1,0 +1,238 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: nfsservers.storageos.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Status of the NFS server.
+    name: status
+    type: string
+  - JSONPath: .spec.resources.requests.storage
+    description: Capacity of the NFS server.
+    name: capacity
+    type: string
+  - JSONPath: .status.remoteTarget
+    description: Remote target address of the NFS server.
+    name: target
+    type: string
+  - JSONPath: .status.accessModes
+    description: Access modes supported by the NFS server.
+    name: access modes
+    type: string
+  - JSONPath: .spec.storageClassName
+    description: StorageClass used for creating the NFS volume.
+    name: storageclass
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
+  group: storageos.com
+  names:
+    kind: NFSServer
+    listKind: NFSServerList
+    plural: nfsservers
+    shortNames:
+    - nfsserver
+    singular: nfsserver
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: NFSServer is the Schema for the nfsservers API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: NFSServerSpec defines the desired state of NFSServer
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              description: The annotations-related configuration to add/set on each
+                Pod related object.
+              type: object
+            export:
+              description: The parameters to configure the NFS export
+              properties:
+                name:
+                  description: Name of the export
+                  type: string
+                persistentVolumeClaim:
+                  description: PVC from which the NFS daemon gets storage for sharing
+                  properties:
+                    claimName:
+                      description: 'ClaimName is the name of a PersistentVolumeClaim
+                        in the same namespace as the pod using this volume. More info:
+                        https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                      type: string
+                    readOnly:
+                      description: Will force the ReadOnly setting in VolumeMounts.
+                        Default false.
+                      type: boolean
+                  required:
+                  - claimName
+                  type: object
+                server:
+                  description: The NFS server configuration
+                  properties:
+                    accessMode:
+                      description: Reading and Writing permissions on the export Valid
+                        values are "ReadOnly", "ReadWrite" and "none"
+                      type: string
+                    squash:
+                      description: This prevents the root users connected remotely
+                        from having root privileges Valid values are "none", "rootid",
+                        "root", and "all"
+                      type: string
+                  type: object
+              type: object
+            mountOptions:
+              description: PV mount options. Not validated - mount of the PVs will
+                simply fail if one is invalid.
+              items:
+                type: string
+              type: array
+            nfsContainer:
+              description: NFSContainer is the container image to use for the NFS
+                server.
+              type: string
+            persistentVolumeClaim:
+              description: PersistentVolumeClaim is the PVC source of the PVC to be
+                used with the NFS Server. If not specified, a new PVC is provisioned
+                and used.
+              properties:
+                claimName:
+                  description: 'ClaimName is the name of a PersistentVolumeClaim in
+                    the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                  type: string
+                readOnly:
+                  description: Will force the ReadOnly setting in VolumeMounts. Default
+                    false.
+                  type: boolean
+              required:
+              - claimName
+              type: object
+            persistentVolumeReclaimPolicy:
+              description: Reclamation policy for the persistent volume shared to
+                the user's pod.
+              type: string
+            resources:
+              description: Resources represents the minimum resources required
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Limits describes the maximum amount of compute resources
+                    allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  description: 'Requests describes the minimum amount of compute resources
+                    required. If Requests is omitted for a container, it defaults
+                    to Limits if that is explicitly specified, otherwise to an implementation-defined
+                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                  type: object
+              type: object
+            storageClassName:
+              description: StorageClassName is the name of the StorageClass used by
+                the NFS volume.
+              type: string
+            tolerations:
+              description: Tolerations is to set the placement of NFS server pods
+                using pod toleration.
+              items:
+                description: The pod this Toleration is attached to tolerates any
+                  taint that matches the triple <key,value,effect> using the matching
+                  operator <operator>.
+                properties:
+                  effect:
+                    description: Effect indicates the taint effect to match. Empty
+                      means match all taint effects. When specified, allowed values
+                      are NoSchedule, PreferNoSchedule and NoExecute.
+                    type: string
+                  key:
+                    description: Key is the taint key that the toleration applies
+                      to. Empty means match all taint keys. If the key is empty, operator
+                      must be Exists; this combination means to match all values and
+                      all keys.
+                    type: string
+                  operator:
+                    description: Operator represents a key's relationship to the value.
+                      Valid operators are Exists and Equal. Defaults to Equal. Exists
+                      is equivalent to wildcard for value, so that a pod can tolerate
+                      all taints of a particular category.
+                    type: string
+                  tolerationSeconds:
+                    description: TolerationSeconds represents the period of time the
+                      toleration (which must be of effect NoExecute, otherwise this
+                      field is ignored) tolerates the taint. By default, it is not
+                      set, which means tolerate the taint forever (do not evict).
+                      Zero and negative values will be treated as 0 (evict immediately)
+                      by the system.
+                    format: int64
+                    type: integer
+                  value:
+                    description: Value is the taint value the toleration matches to.
+                      If the operator is Exists, the value should be empty, otherwise
+                      just a regular string.
+                    type: string
+                type: object
+              type: array
+          type: object
+        status:
+          description: NFSServerStatus defines the observed state of NFSServer
+          properties:
+            accessModes:
+              description: AccessModes is the access modes supported by the NFS server.
+              type: string
+            phase:
+              description: "Phase is a simple, high-level summary of where the NFS
+                Server is in its lifecycle. Phase will be set to Ready when the NFS
+                Server is ready for use.  It is intended to be similar to the PodStatus
+                Phase described at: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podstatus-v1-core
+                \n There are five possible phase values:   - Pending: The NFS Server
+                has been accepted by the Kubernetes system,     but one or more of
+                the components has not been created. This includes     time before
+                being scheduled as well as time spent downloading images     over
+                the network, which could take a while.   - Running: The NFS Server
+                has been bound to a node, and all of the     dependencies have been
+                created.   - Succeeded: All NFS Server dependencies have terminated
+                in success,     and will not be restarted.   - Failed: All NFS Server
+                dependencies in the pod have terminated, and     at least one container
+                has terminated in failure. The container     either exited with non-zero
+                status or was terminated by the system.   - Unknown: For some reason
+                the state of the NFS Server could not be     obtained, typically due
+                to an error in communicating with the host of     the pod."
+              type: string
+            remoteTarget:
+              description: RemoteTarget is the connection string that clients can
+                use to access the shared filesystem.
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/operators/storageos/2.4.4/storageosupgrade.crd.yaml
+++ b/operators/storageos/2.4.4/storageosupgrade.crd.yaml
@@ -1,0 +1,52 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: storageosupgrades.storageos.com
+spec:
+  group: storageos.com
+  names:
+    kind: StorageOSUpgrade
+    listKind: StorageOSUpgradeList
+    plural: storageosupgrades
+    singular: storageosupgrade
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: StorageOSUpgrade is the Schema for the storageosupgrades API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: StorageOSUpgradeSpec defines the desired state of StorageOSUpgrade
+          properties:
+            newImage:
+              description: NewImage is the new StorageOS node container image.
+              type: string
+          required:
+          - newImage
+          type: object
+        status:
+          description: StorageOSUpgradeStatus defines the observed state of StorageOSUpgrade
+          properties:
+            completed:
+              description: Completed is the status of upgrade process.
+              type: boolean
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/operators/storageos/ci.yaml
+++ b/operators/storageos/ci.yaml
@@ -4,3 +4,6 @@ updateGraph: replaces-mode
 
 reviewers:
   - croomes
+  - mhmxs
+  - nolancon
+  

--- a/operators/storageos/storageos.package.yaml
+++ b/operators/storageos/storageos.package.yaml
@@ -1,4 +1,4 @@
 packageName: storageos
 channels:
 - name: stable
-  currentCSV: storageosoperator.v2.4.2
+  currentCSV: storageosoperator.v2.4.4


### PR DESCRIPTION
Signed-off-by: Simon Croome <simon.croome@storageos.com>

### Updates to existing Operators

* [x] Did you create a `ci.yaml` file according to the [update instructions](https://github.com/operator-framework/community-operators/blob/master/docs/operator-ci-yaml.md)?
* [x] Is your new CSV pointing to the previous version with the `replaces` property if you chose `replaces-mode` via the `updateGraph` property in `ci.yaml`?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#channels) defined in the `package.yaml` or `annotations.yaml` ?
* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-prerequisites.md#sign-your-work)?

### Your submission should not

* [x] Modify more than one operator
* [x] Modify an Operator you don't own
* [x] Rename an operator - please remove and add with a different name instead
* [x] Modify any files outside the above mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [x] Description about the managed Application and where to find more information
2. [x] Features and capabilities of your Operator and how to use it
3. [x] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human readable name and 1-liner description about your Operator
* [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#categories)<sup>1</sup>
* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used
* [x] A quadratic logo
