### PR TITLE
operators cloud-native-postgresql (1.9.2)

### DIFF
--- a/operators/cloud-native-postgresql/1.9.2/manifests/cloud-native-postgresql.clusterserviceversion.yaml
+++ b/operators/cloud-native-postgresql/1.9.2/manifests/cloud-native-postgresql.clusterserviceversion.yaml
@@ -1,0 +1,991 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+          "kind": "Backup",
+          "metadata": {
+            "name": "backup-sample"
+          },
+          "spec": {
+            "cluster": {
+              "name": "cluster-sample"
+            }
+          }
+        },
+        {
+          "apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+          "kind": "Cluster",
+          "metadata": {
+            "name": "cluster-sample"
+          },
+          "spec": {
+            "instances": 3,
+            "primaryUpdateStrategy": "unsupervised",
+            "storage": {
+              "size": "1Gi"
+            }
+          }
+        },
+        {
+          "apiVersion": "postgresql.k8s.enterprisedb.io/v1",
+          "kind": "ScheduledBackup",
+          "metadata": {
+            "name": "scheduledbackup-sample"
+          },
+          "spec": {
+            "cluster": {
+              "name": "cluster-sample"
+            },
+            "schedule": "0 0 0 * * *"
+          }
+        }
+      ]
+    capabilities: Auto Pilot
+    categories: Database
+    certified: "true"
+    containerImage: quay.io/enterprisedb/cloud-native-postgresql:1.9.2
+    createdAt: 2021-10-15T21:15:43+00:00
+    description: Operator to manage Postgres high availability clusters with a primary/standby architecture.
+    operators.operatorframework.io/builder: operator-sdk-v1.1.0
+    operators.operatorframework.io/project_layout: go
+    support: EnterpriseDB Corporation
+    olm.skipRange: '>=0.6.0 <1.9.2'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]'
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.s390x: supported
+  name: cloud-native-postgresql.v1.9.2
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: PostgreSQL backup manager
+        displayName: Backups
+        kind: Backup
+        name: backups.postgresql.k8s.enterprisedb.io
+        specDescriptors:
+          - description: The PostgreSQL cluster name to backup
+            displayName: Cluster Name
+            path: cluster.name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Clusters
+        statusDescriptors:
+          - description: Current backupphase
+            displayName: Phase
+            path: phase
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.phase
+        version: v1
+      - description: PostgreSQL cluster manager
+        displayName: Cluster
+        kind: Cluster
+        name: clusters.postgresql.k8s.enterprisedb.io
+        specDescriptors:
+          - displayName: Description
+            path: description
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+          - description: Name of the container image
+            displayName: Image Name
+            path: imageName
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+          - description: Postgres user Id used inside the container
+            displayName: Postgres UID
+            path: postgresUID
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+          - description: Postgres group Id used inside the container
+            displayName: Postgres GID
+            path: postgresGID
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+          - description: Number of instances required in the cluster
+            displayName: Instances
+            path: instances
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:podCount
+          - description: Minimum number of instances required in synchronous replication with the primary. Undefined or 0 allow writes to complete when no standby is available.
+            displayName: Min Synchronous Replicas
+            path: minSyncReplicas
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+          - description: The target value for the synchronous replication quorum, that can be decreased if the number of ready standbys is lower than this. Undefined or 0 disable synchronous replication.
+            displayName: Max Synchronous Replicas
+            path: maxSyncReplicas
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+          - displayName: Superuser Secret
+            path: superuserSecret.name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Secret
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+          - description: Secret for pulling the image. If empty, no secret will be used
+            displayName: Image Pull Secret
+            path: imagePullSecrets[0].name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Secret
+          - description: The time in seconds that is allowed for a PostgreSQL instance to successfully start up (default 30)
+            displayName: Maximum Start Delay
+            path: startDelay
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+          - description: The time in seconds that is allowed for a PostgreSQL instance node to gracefully shutdown (default 30)
+            displayName: Maximum Stop Delay
+            path: stopDelay
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+          - path: resources
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+          - displayName: Primary Update Strategy
+            path: primaryUpdateStrategy
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+              - urn:alm:descriptor:com.tectonic.ui:select:supervised
+              - urn:alm:descriptor:com.tectonic.ui:select:unsupervised
+          - displayName: License Key
+            path: licenseKey
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+          - displayName: pg_hba rule
+            path: postgresql.pg_hba[0]
+          - displayName: PostgreSQL configuration parameter
+            path: postgresql.parameters[0]
+          - description: StorageClass to use for database data (PGDATA). Applied after evaluating the PVC template, if available.
+            displayName: Storage Class
+            path: storage.storageClass
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:StorageClass
+          - description: Storage size for database data (PGDATA). (default size 1G)
+            displayName: Storage Size
+            path: storage.size
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - displayName: Resize in-use volumes
+            path: storage.resizeInUseVolumes
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - description: Template to be used to generate the Persistent Volume Claim
+            displayName: PVC template
+            path: storage.pvcTemplate
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+          - path: affinity.enablePodAntiAffinity
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - path: affinity.nodeSelector
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Node
+          - description: S3-compatible object storage Endpoint. If empty the S3 default is used
+            displayName: Object Storage Endpoint
+            path: backup.barmanObjectStore.endpointURL
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: Name of the Secret containing the Secret Access Key
+            path: backup.barmanObjectStore.s3Credentials.secretAccessKey.name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Secret
+          - description: Key inside the Secret containing the Secret Access Key
+            path: backup.barmanObjectStore.s3Credentials.secretAccessKey.key
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:text
+          - description: Name of the Secret containing the Access Key Id
+            path: backup.barmanObjectStore.s3Credentials.accessKeyId.name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Secret
+          - description: Key inside the Secret containing the Access Key Id
+            path: backup.barmanObjectStore.s3Credentials.accessKeyId.key
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:text
+          - description: WAL compression algorithm
+            displayName: WAL compression
+            path: backup.barmanObjectStore.wal.compression
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:text
+          - description: WAL encryprion algorithm
+            displayName: WAL encryption
+            path: backup.barmanObjectStore.wal.encryption
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:text
+          - description: Data compression algorithm
+            displayName: Data compression
+            path: backup.barmanObjectStore.data.compression
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:text
+          - description: Data encryprion algorithm
+            displayName: Data encryption
+            path: backup.barmanObjectStore.data.encryption
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:text
+          - displayName: Immediate Checkpoint
+            path: backup.barmanObjectStore.data.immediateCheckpoint
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - displayName: Jobs
+            path: backup.barmanObjectStore.data.jobs
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:number
+          - path: nodeMaintenanceWindow.reusePVC
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - path: nodeMaintenanceWindow.inProgress
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+          - path: monitoring.customQueriesConfigMap[0].name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:ConfigMap
+          - path: monitoring.customQueriesConfigMap[0].key
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:text
+          - path: monitoring.customQueriesSecret[0].name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Secret
+          - path: monitoring.customQueriesSecret[0].key
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:text
+          - path: bootstrap.initdb.secret.name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Secret
+        statusDescriptors:
+          - description: Status Pods
+            displayName: Working Pods
+            path: instancesStatus
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:podStatuses
+          - description: License Status, trial or active
+            displayName: License Status
+            path: licenseStatus.licenseStatus
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - description: License expiration date
+            displayName: License expiration date
+            path: licenseStatus.licenseExpiration
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - description: License is Valid
+            displayName: License is Valid
+            path: licenseStatus.valid
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - description: Current Primary Pod
+            displayName: Current Primary Pod
+            path: currentPrimary
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Pod
+          - description: Service for written process
+            displayName: Write Service
+            path: writeService
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Service
+          - description: Service for read process
+            displayName: Read Service
+            path: readService
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Service
+          - description: Current cluster phase
+            displayName: Phase
+            path: phase
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.phase
+          - description: Current phase reason
+            displayName: Phase Reason
+            path: phaseReason
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.phase:reason
+        version: v1
+      - description: PostgreSQL backups schedule
+        displayName: Scheduled Backups
+        kind: ScheduledBackup
+        name: scheduledbackups.postgresql.k8s.enterprisedb.io
+        specDescriptors:
+          - description: The PostgreSQL cluster to backup
+            displayName: Cluster name
+            path: cluster.name
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes:Clusters
+          - description: The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+            displayName: Schedule
+            path: schedule
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - description: If this is true, the schedule is suspended, defaults to False
+            displayName: Schedule is suspended
+            path: suspend
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+              - urn:alm:descriptor:com.tectonic.ui:advanced
+        statusDescriptors:
+          - description: When it's the next backup scheduled
+            displayName: Next backup
+            path: nextScheduleTime
+          - description: When it was the last backup
+            displayName: Last backup
+            path: lastScheduleTime
+        version: v1
+  description: |
+    Cloud Native PostgreSQL is an operator designed by EnterpriseDB
+    to manage PostgreSQL workloads on any supported Kubernetes
+    cluster running in private, public, or hybrid cloud environments,
+    including OpenShift.
+    Cloud Native PostgreSQL adheres to DevOps principles and concepts
+    such as declarative configuration and immutable infrastructure.
+
+    It defines a new Kubernetes resource called "Cluster" representing a PostgreSQL
+    cluster made up of a single primary and an optional number of replicas that co-exist
+    in a chosen Kubernetes namespace for High Availability and offloading of
+    read-only queries.
+
+    Applications that reside in the same Kubernetes cluster can access the
+    PostgreSQL database using a service which is solely managed by the operator,
+    without having to worry about changes of the primary role following a failover
+    or a switchover. Applications that reside outside the Kubernetes cluster need
+    to configure an Ingress object to expose the service via TCP.
+
+    Cloud Native PostgreSQL works with PostgreSQL (13, 12, 11 and 10) and
+    EDB Postgres Advanced (13, 12, 11 and 10), and it is available under
+    the EnterpriseDB Limited Use License.
+    You can evaluate Cloud Native PostgreSQL for free.
+    You need a valid license key to use Cloud Native PostgreSQL in production.
+
+    # Main features
+
+    * Direct integration with Kubernetes API server for High Availability,
+      without requiring an external tool
+    * Self-Healing capability, through:
+        * failover of the primary instance by promoting the most aligned replica
+        * automated recreation of a replica
+    * Planned switchover of the primary instance by promoting a selected replica
+    * Scale up/down capabilities
+    * Definition of an arbitrary number of instances (minimum 1 - one primary server)
+    * Definition of the *read-write* service, to connect your applications to the only primary server of the cluster
+    * Definition of the *read-only* service, to connect your applications to any of the instances for reading workloads
+    * Support for Local Persistent Volumes with PVC templates
+    * Reuse of Persistent Volumes storage in Pods
+    * Rolling updates for PostgreSQL minor versions and operator upgrades
+    * TLS connections and client certificate authentication
+    * Support for custom TLS certificates (including integration with cert-manager)
+    * Continuous backup to an S3 compatible object store
+    * Full recovery and Point-In-Time recovery from an S3 compatible object store backup
+    * Replica clusters for PostgreSQL deployments across multiple Kubernetes
+      clusters, enabling private, public, hybrid, and multi-cloud architectures
+    * Support for Synchronous Replicas
+    * Support for node affinity via `nodeSelector`
+    * Native customizable exporter of user defined metrics for Prometheus through the `metrics` port (9187)
+    * Standard output logging of PostgreSQL error messages in JSON format
+    * Support for the `restricted` security context constraint (SCC) in Red Hat OpenShift
+    * `cnp` plugin for `kubectl`
+  displayName: Cloud Native PostgreSQL
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI1LjIuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxNjAgODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDE2MCA4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiNGRjNFMDA7fQoJLnN0MXtmaWxsOiNGRkZGRkY7fQoJLnN0MntmaWxsOiMxMjE2NDY7fQo8L3N0eWxlPgo8Zz4KCTxnPgoJCTxnPgoJCQk8Y2lyY2xlIGNsYXNzPSJzdDAiIGN4PSIyNi41IiBjeT0iNDAiIHI9IjI2Ii8+CgkJPC9nPgoJCTxnPgoJCQk8Zz4KCQkJCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik00MiwzOC43YzEtMSwxLjYtMi4zLDEuNi0zLjdjMC0yLjYtMi4xLTQuNS00LjgtNC4ybC00LDAuNGMtMC40LDAtMC44LDAuNC0wLjgsMC44djdWNDB2NwoJCQkJCWMwLDAuNCwwLjMsMC43LDAuOCwwLjdsNC0wLjRjMi42LTAuMyw0LjgtMi42LDQuOC01LjJ2MEM0My42LDQwLjcsNDMsMzkuNSw0MiwzOC43eiIvPgoJCQk8L2c+CgkJCTxnPgoJCQkJPHBhdGggY2xhc3M9InN0MSIgZD0iTTE4LjIsMzEuMmwtNC0wLjRjLTIuNi0wLjMtNC44LDEuNi00LjgsNC4yYzAsMS40LDAuNiwyLjcsMS42LDMuN2MtMSwwLjgtMS42LDItMS42LDMuM3YwCgkJCQkJYzAsMi42LDIuMSw0LjksNC44LDUuMmw0LDAuNGMwLjQsMCwwLjgtMC4zLDAuOC0wLjd2LTd2LTAuOXYtN0MxOC45LDMxLjcsMTguNiwzMS4zLDE4LjIsMzEuMnoiLz4KCQkJPC9nPgoJCQk8Zz4KCQkJCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0yNi41LDM0LjZoLTRjLTAuNCwwLTAuOCwwLjMtMC44LDAuOHYxMC40djEuMWMwLDAuNCwwLjMsMC45LDAuOCwwLjloNGMwLDAuOC0xLjIsMS44LTMuOSwyLjFsLTAuMywwCgkJCQkJYy0wLjIsMC0wLjYsMC0wLjYsMC44djAuMmMwLDAuNCwwLjMsMC44LDAuOCwwLjhoNGMyLjYsMCw0LjgtMi41LDQuOC01LjJ2LTcuMUMzMS4yLDM2LjcsMjkuMSwzNC42LDI2LjUsMzQuNnoiLz4KCQkJPC9nPgoJCTwvZz4KCTwvZz4KCTxnPgoJCTxnPgoJCQk8cGF0aCBjbGFzcz0ic3QyIiBkPSJNMTU1LjcsMjQuNnYwLjVoLTAuOXYyLjZoLTAuNnYtMi42aC0wLjl2LTAuNUgxNTUuN3ogTTE1OC45LDI3LjdsLTAuMS0xLjhjMC0wLjIsMC0wLjUsMC0wLjloMAoJCQkJYy0wLjEsMC4zLTAuMiwwLjYtMC4yLDAuOWwtMC41LDEuN2gtMC42bC0wLjUtMS44Yy0wLjEtMC4yLTAuMS0wLjYtMC4yLTAuOWgwYzAsMC4zLDAsMC42LDAsMC45bC0wLjEsMS44aC0wLjZsMC4yLTMuMWgwLjkKCQkJCWwwLjUsMS41YzAuMSwwLjIsMC4xLDAuNSwwLjIsMC44aDBjMC4xLTAuMywwLjEtMC42LDAuMi0wLjhsMC41LTEuNWgwLjhsMC4yLDMuMUgxNTguOXoiLz4KCQk8L2c+CgkJPHBhdGggY2xhc3M9InN0MiIgZD0iTTY4LjgsNDMuMnY3LjJoMTcuNGMwLjMsMCwwLjcsMC40LDAuNywwLjd2NC42YzAsMC4zLTAuNCwwLjctMC43LDAuN0g2Mi42Yy0wLjMsMC0wLjYtMC4zLTAuNi0wLjZWMjUuMwoJCQljMC0wLjMsMC4zLTAuNiwwLjYtMC42aDIzLjZjMC4zLDAsMC43LDAuNCwwLjcsMC43djQuNmMwLDAuMy0wLjQsMC43LTAuNywwLjdINjguOHY2LjVoMTUuOWMwLjMsMCwwLjcsMC40LDAuNywwLjd2NC42CgkJCWMwLDAuMy0wLjQsMC43LTAuNywwLjdINjguOHoiLz4KCQk8cGF0aCBjbGFzcz0ic3QyIiBkPSJNOTEuOSw1Ni41Yy0wLjMsMC0wLjYtMC4zLTAuNi0wLjZWMjUuM2MwLTAuMywwLjMtMC42LDAuNi0wLjZoMTIuN2M5LjUsMCwxNi43LDYuMiwxNi43LDE2CgkJCWMwLDkuNi02LDE2LTE2LjYsMTZIOTEuOXogTTk4LjEsMzAuN3YxOS44aDYuNmM2LjQsMCw5LjctMy44LDkuNy05LjljMC02LjEtNC4xLTkuOS05LjgtOS45SDk4LjF6Ii8+CgkJPHBhdGggY2xhc3M9InN0MiIgZD0iTTEyNi4zLDU2LjVjLTAuMywwLTAuNi0wLjMtMC42LTAuNlYyNS4zYzAtMC4zLDAuMy0wLjYsMC42LTAuNmgxNS40YzYuOCwwLDEwLjQsMy44LDEwLjQsOC44CgkJCWMwLDIuNi0xLDQuNi0yLjYsNnYwLjFjMi40LDEuNiwzLjgsNC4yLDMuOCw3LjRjMCw2LjEtNC4yLDkuNi0xMS40LDkuNkgxMjYuM3ogTTEzMi41LDMwLjd2Ni41aDguN2MzLDAsNC4xLTEuNSw0LjEtMy4yCgkJCWMwLTEuOC0xLjQtMy4zLTQuNi0zLjNIMTMyLjV6IE0xNDEuMSw1MC41YzMuOCwwLDUuMy0xLjMsNS4zLTMuOGMwLTIuMy0xLjctMy45LTUuNS0zLjloLTguNXY3LjhIMTQxLjF6Ii8+Cgk8L2c+Cgk8Zz4KCQk8Zz4KCQkJPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMjYuNSIgY3k9IjQwIiByPSIyNiIvPgoJCTwvZz4KCQk8Zz4KCQkJPGc+CgkJCQk8cGF0aCBjbGFzcz0ic3QxIiBkPSJNNDIsMzguN2MxLTEsMS42LTIuMywxLjYtMy43YzAtMi42LTIuMS00LjUtNC44LTQuMmwtNCwwLjRjLTAuNCwwLTAuOCwwLjQtMC44LDAuOHY3VjQwdjcKCQkJCQljMCwwLjQsMC4zLDAuNywwLjgsMC43bDQtMC40YzIuNi0wLjMsNC44LTIuNiw0LjgtNS4ydjBDNDMuNiw0MC43LDQzLDM5LjUsNDIsMzguN3oiLz4KCQkJPC9nPgoJCQk8Zz4KCQkJCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0xOC4yLDMxLjJsLTQtMC40Yy0yLjYtMC4zLTQuOCwxLjYtNC44LDQuMmMwLDEuNCwwLjYsMi43LDEuNiwzLjdjLTEsMC44LTEuNiwyLTEuNiwzLjN2MAoJCQkJCWMwLDIuNiwyLjEsNC45LDQuOCw1LjJsNCwwLjRjMC40LDAsMC44LTAuMywwLjgtMC43di03di0wLjl2LTdDMTguOSwzMS43LDE4LjYsMzEuMywxOC4yLDMxLjJ6Ii8+CgkJCTwvZz4KCQkJPGc+CgkJCQk8cGF0aCBjbGFzcz0ic3QxIiBkPSJNMjYuNSwzNC42aC00Yy0wLjQsMC0wLjgsMC4zLTAuOCwwLjh2MTAuNHYxLjFjMCwwLjQsMC4zLDAuOSwwLjgsMC45aDRjMCwwLjgtMS4yLDEuOC0zLjksMi4xbC0wLjMsMAoJCQkJCWMtMC4yLDAtMC42LDAtMC42LDAuOHYwLjJjMCwwLjQsMC4zLDAuOCwwLjgsMC44aDRjMi42LDAsNC44LTIuNSw0LjgtNS4ydi03LjFDMzEuMiwzNi43LDI5LjEsMzQuNiwyNi41LDM0LjZ6Ii8+CgkJCTwvZz4KCQk8L2c+Cgk8L2c+Cgk8Zz4KCQk8Zz4KCQkJPHBhdGggY2xhc3M9InN0MiIgZD0iTTE1NS43LDI0LjZ2MC41aC0wLjl2Mi42aC0wLjZ2LTIuNmgtMC45di0wLjVIMTU1Ljd6IE0xNTguOSwyNy43bC0wLjEtMS44YzAtMC4yLDAtMC41LDAtMC45aDAKCQkJCWMtMC4xLDAuMy0wLjIsMC42LTAuMiwwLjlsLTAuNSwxLjdoLTAuNmwtMC41LTEuOGMtMC4xLTAuMi0wLjEtMC42LTAuMi0wLjloMGMwLDAuMywwLDAuNiwwLDAuOWwtMC4xLDEuOGgtMC42bDAuMi0zLjFoMC45CgkJCQlsMC41LDEuNWMwLjEsMC4yLDAuMSwwLjUsMC4yLDAuOGgwYzAuMS0wLjMsMC4xLTAuNiwwLjItMC44bDAuNS0xLjVoMC44bDAuMiwzLjFIMTU4Ljl6Ii8+CgkJPC9nPgoJCTxwYXRoIGNsYXNzPSJzdDIiIGQ9Ik02OC44LDQzLjJ2Ny4yaDE3LjRjMC4zLDAsMC43LDAuNCwwLjcsMC43djQuNmMwLDAuMy0wLjQsMC43LTAuNywwLjdINjIuNmMtMC4zLDAtMC42LTAuMy0wLjYtMC42VjI1LjMKCQkJYzAtMC4zLDAuMy0wLjYsMC42LTAuNmgyMy42YzAuMywwLDAuNywwLjQsMC43LDAuN3Y0LjZjMCwwLjMtMC40LDAuNy0wLjcsMC43SDY4Ljh2Ni41aDE1LjljMC4zLDAsMC43LDAuNCwwLjcsMC43djQuNgoJCQljMCwwLjMtMC40LDAuNy0wLjcsMC43SDY4Ljh6Ii8+CgkJPHBhdGggY2xhc3M9InN0MiIgZD0iTTkxLjksNTYuNWMtMC4zLDAtMC42LTAuMy0wLjYtMC42VjI1LjNjMC0wLjMsMC4zLTAuNiwwLjYtMC42aDEyLjdjOS41LDAsMTYuNyw2LjIsMTYuNywxNgoJCQljMCw5LjYtNiwxNi0xNi42LDE2SDkxLjl6IE05OC4xLDMwLjd2MTkuOGg2LjZjNi40LDAsOS43LTMuOCw5LjctOS45YzAtNi4xLTQuMS05LjktOS44LTkuOUg5OC4xeiIvPgoJCTxwYXRoIGNsYXNzPSJzdDIiIGQ9Ik0xMjYuMyw1Ni41Yy0wLjMsMC0wLjYtMC4zLTAuNi0wLjZWMjUuM2MwLTAuMywwLjMtMC42LDAuNi0wLjZoMTUuNGM2LjgsMCwxMC40LDMuOCwxMC40LDguOAoJCQljMCwyLjYtMSw0LjYtMi42LDZ2MC4xYzIuNCwxLjYsMy44LDQuMiwzLjgsNy40YzAsNi4xLTQuMiw5LjYtMTEuNCw5LjZIMTI2LjN6IE0xMzIuNSwzMC43djYuNWg4LjdjMywwLDQuMS0xLjUsNC4xLTMuMgoJCQljMC0xLjgtMS40LTMuMy00LjYtMy4zSDEzMi41eiBNMTQxLjEsNTAuNWMzLjgsMCw1LjMtMS4zLDUuMy0zLjhjMC0yLjMtMS43LTMuOS01LjUtMy45aC04LjV2Ny44SDE0MS4xeiIvPgoJPC9nPgo8L2c+Cjwvc3ZnPgo=
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - persistentvolumeclaims
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods/exec
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods/status
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - services
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - mutatingwebhookconfigurations
+              verbs:
+                - get
+                - list
+                - update
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - validatingwebhookconfigurations
+              verbs:
+                - get
+                - list
+                - update
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - get
+                - list
+                - update
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - get
+                - update
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - postgresql.k8s.enterprisedb.io
+              resources:
+                - backups
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - postgresql.k8s.enterprisedb.io
+              resources:
+                - backups/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - postgresql.k8s.enterprisedb.io
+              resources:
+                - clusters
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - postgresql.k8s.enterprisedb.io
+              resources:
+                - clusters/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - postgresql.k8s.enterprisedb.io
+              resources:
+                - clusters/status
+              verbs:
+                - get
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - postgresql.k8s.enterprisedb.io
+              resources:
+                - scheduledbackups
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - postgresql.k8s.enterprisedb.io
+              resources:
+                - scheduledbackups/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - rolebindings
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+                - watch
+          serviceAccountName: postgresql-operator-manager
+      deployments:
+        - name: postgresql-operator-controller-manager-1-9-2
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: cloud-native-postgresql
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: cloud-native-postgresql
+              spec:
+                containers:
+                  - args:
+                      - controller
+                      - --enable-leader-election
+                      - --config-map-name=postgresql-operator-controller-manager-config
+                      - --secret-name=postgresql-operator-controller-manager-config
+                      - --webhook-port=9443
+                    command:
+                      - /manager
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: WEBHOOK_CERT_DIR
+                        value: /apiserver.local.config/certificates
+                      - name: OPERATOR_IMAGE_NAME
+                        value: quay.io/enterprisedb/cloud-native-postgresql:1.9.2
+                      - name: OPERATOR_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    image: quay.io/enterprisedb/cloud-native-postgresql:1.9.2
+                    livenessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 9443
+                        scheme: HTTPS
+                    name: manager
+                    ports:
+                      - containerPort: 8080
+                        name: metrics
+                        protocol: TCP
+                      - containerPort: 9443
+                        name: webhook-server
+                        protocol: TCP
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 9443
+                        scheme: HTTPS
+                    resources: {}
+                    securityContext:
+                      readOnlyRootFilesystem: true
+                    volumeMounts:
+                      - mountPath: /controller
+                        name: scratch-data
+                imagePullSecrets:
+                  - name: postgresql-operator-pull-secret
+                serviceAccountName: postgresql-operator-manager
+                terminationGracePeriodSeconds: 10
+                volumes:
+                  - emptyDir: {}
+                    name: scratch-data
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: true
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - postgresql
+    - postgres
+    - database
+    - sql
+    - cloud
+    - native
+    - edb
+    - enterprisedb
+    - cnp
+  links:
+    - name: Cloud Native Postgresql
+      url: https://www.enterprisedb.com/products/postgresql-on-kubernetes-ha-clusters-k8s-containers-scalable
+    - name: Documentation
+      url: https://docs.enterprisedb.io/cloud-native-postgresql/
+  maintainers:
+    - email: sales@enterprisedb.com
+      name: Sales
+    - email: support@enterprisedb.com
+      name: Support
+  maturity: stable
+  provider:
+    name: EnterpriseDB Corporation
+  version: 1.9.2
+  webhookdefinitions:
+    - admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      deploymentName: postgresql-operator-controller-manager-1-9-2
+      failurePolicy: Fail
+      generateName: vcluster.kb.io
+      rules:
+        - apiGroups:
+            - postgresql.k8s.enterprisedb.io
+          apiVersions:
+            - v1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - clusters
+      sideEffects: None
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-postgresql-k8s-enterprisedb-io-v1-cluster
+    - admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      deploymentName: postgresql-operator-controller-manager-1-9-2
+      failurePolicy: Fail
+      generateName: vclusterv1alpha1.kb.io
+      rules:
+        - apiGroups:
+            - postgresql.k8s.enterprisedb.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - clusters
+      sideEffects: None
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-postgresql-k8s-enterprisedb-io-v1alpha1-cluster
+    - admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      deploymentName: postgresql-operator-controller-manager-1-9-2
+      failurePolicy: Fail
+      generateName: vbackup.kb.io
+      rules:
+        - apiGroups:
+            - postgresql.k8s.enterprisedb.io
+          apiVersions:
+            - v1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - backups
+      sideEffects: None
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-postgresql-k8s-enterprisedb-io-v1-backup
+    - admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      deploymentName: postgresql-operator-controller-manager-1-9-2
+      failurePolicy: Fail
+      generateName: vbackupv1alpha1.kb.io
+      rules:
+        - apiGroups:
+            - postgresql.k8s.enterprisedb.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - backups
+      sideEffects: None
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-postgresql-k8s-enterprisedb-io-v1alpha1-backup
+    - admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      deploymentName: postgresql-operator-controller-manager-1-9-2
+      failurePolicy: Fail
+      generateName: vscheduledbackup.kb.io
+      rules:
+        - apiGroups:
+            - postgresql.k8s.enterprisedb.io
+          apiVersions:
+            - v1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - scheduledbackups
+      sideEffects: None
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-postgresql-k8s-enterprisedb-io-v1-scheduledbackup
+    - admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      deploymentName: postgresql-operator-controller-manager-1-9-2
+      failurePolicy: Fail
+      generateName: vscheduledbackupv1alpha1.kb.io
+      rules:
+        - apiGroups:
+            - postgresql.k8s.enterprisedb.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - scheduledbackups
+      sideEffects: None
+      type: ValidatingAdmissionWebhook
+      webhookPath: /validate-postgresql-k8s-enterprisedb-io-v1alpha1-scheduledbackup
+    - admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      deploymentName: postgresql-operator-controller-manager-1-9-2
+      failurePolicy: Fail
+      generateName: mcluster.kb.io
+      rules:
+        - apiGroups:
+            - postgresql.k8s.enterprisedb.io
+          apiVersions:
+            - v1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - clusters
+      sideEffects: None
+      type: MutatingAdmissionWebhook
+      webhookPath: /mutate-postgresql-k8s-enterprisedb-io-v1-cluster
+    - admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      deploymentName: postgresql-operator-controller-manager-1-9-2
+      failurePolicy: Fail
+      generateName: mclusterv1alpha1.kb.io
+      rules:
+        - apiGroups:
+            - postgresql.k8s.enterprisedb.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - clusters
+      sideEffects: None
+      type: MutatingAdmissionWebhook
+      webhookPath: /mutate-postgresql-k8s-enterprisedb-io-v1alpha1-cluster
+    - admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      deploymentName: postgresql-operator-controller-manager-1-9-2
+      failurePolicy: Fail
+      generateName: mbackup.kb.io
+      rules:
+        - apiGroups:
+            - postgresql.k8s.enterprisedb.io
+          apiVersions:
+            - v1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - backups
+      sideEffects: None
+      type: MutatingAdmissionWebhook
+      webhookPath: /mutate-postgresql-k8s-enterprisedb-io-v1-backup
+    - admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      deploymentName: postgresql-operator-controller-manager-1-9-2
+      failurePolicy: Fail
+      generateName: mbackupv1alpha1.kb.io
+      rules:
+        - apiGroups:
+            - postgresql.k8s.enterprisedb.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - backups
+      sideEffects: None
+      type: MutatingAdmissionWebhook
+      webhookPath: /mutate-postgresql-k8s-enterprisedb-io-v1alpha1-backup
+    - admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      deploymentName: postgresql-operator-controller-manager-1-9-2
+      failurePolicy: Fail
+      generateName: mscheduledbackup.kb.io
+      rules:
+        - apiGroups:
+            - postgresql.k8s.enterprisedb.io
+          apiVersions:
+            - v1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - scheduledbackups
+      sideEffects: None
+      type: MutatingAdmissionWebhook
+      webhookPath: /mutate-postgresql-k8s-enterprisedb-io-v1-scheduledbackup
+    - admissionReviewVersions:
+        - v1
+      containerPort: 9443
+      deploymentName: postgresql-operator-controller-manager-1-9-2
+      failurePolicy: Fail
+      generateName: mscheduledbackupv1alpha1.kb.io
+      rules:
+        - apiGroups:
+            - postgresql.k8s.enterprisedb.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - scheduledbackups
+      sideEffects: None
+      type: MutatingAdmissionWebhook
+      webhookPath: /mutate-postgresql-k8s-enterprisedb-io-v1alpha1-scheduledbackup

--- a/operators/cloud-native-postgresql/1.9.2/manifests/postgresql-operator-manager_v1_serviceaccount.yaml
+++ b/operators/cloud-native-postgresql/1.9.2/manifests/postgresql-operator-manager_v1_serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  creationTimestamp: null
+  name: postgresql-operator-manager

--- a/operators/cloud-native-postgresql/1.9.2/manifests/postgresql.k8s.enterprisedb.io_backups.yaml
+++ b/operators/cloud-native-postgresql/1.9.2/manifests/postgresql.k8s.enterprisedb.io_backups.yaml
@@ -1,0 +1,396 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: backups.postgresql.k8s.enterprisedb.io
+spec:
+  conversion:
+    strategy: None
+  group: postgresql.k8s.enterprisedb.io
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    singular: backup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.error
+      name: Error
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Backup is the Schema for the backups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the desired behavior of the backup. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              cluster:
+                description: The cluster to backup
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+          status:
+            description: 'Most recently observed status of the backup. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              azureCredentials:
+                description: The credentials to be used to upload data to Azure Blob Storage
+                properties:
+                  connectionString:
+                    description: The connection string to be used
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  storageAccount:
+                    description: The storage account where to upload data
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  storageKey:
+                    description: The storage account key to be used in conjunction with the storage account name
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  storageSasToken:
+                    description: A shared-access-signature to be used in conjunction with the storage account name
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                type: object
+              backupId:
+                description: The ID of the Barman backup
+                type: string
+              beginLSN:
+                description: The starting xlog
+                type: string
+              beginWal:
+                description: The starting WAL
+                type: string
+              commandError:
+                description: The backup command output in case of error
+                type: string
+              commandOutput:
+                description: Unused. Retained for compatibility with old versions.
+                type: string
+              destinationPath:
+                description: The path where to store the backup (i.e. s3://bucket/path/to/folder) this path, with different destination folders, will be used for WALs and for data
+                type: string
+              encryption:
+                description: Encryption method required to S3 API
+                type: string
+              endLSN:
+                description: The ending xlog
+                type: string
+              endWal:
+                description: The ending WAL
+                type: string
+              endpointURL:
+                description: Endpoint to be used to upload data to the cloud, overriding the automatic endpoint discovery
+                type: string
+              error:
+                description: The detected error
+                type: string
+              phase:
+                description: The last backup status
+                type: string
+              s3Credentials:
+                description: The credentials to be used to upload data to S3
+                properties:
+                  accessKeyId:
+                    description: The reference to the access key id
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  secretAccessKey:
+                    description: The reference to the secret access key
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                required:
+                - accessKeyId
+                - secretAccessKey
+                type: object
+              serverName:
+                description: The server name on S3, the cluster name is used if this parameter is omitted
+                type: string
+              startedAt:
+                description: When the backup was started
+                format: date-time
+                type: string
+              stoppedAt:
+                description: When the backup was terminated
+                format: date-time
+                type: string
+            required:
+            - destinationPath
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.error
+      name: Error
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Backup is the Schema for the backups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the desired behavior of the backup. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              cluster:
+                description: The cluster to backup
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+            type: object
+          status:
+            description: 'Most recently observed status of the backup. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              azureCredentials:
+                description: The credentials to be used to upload data to S3
+                properties:
+                  connectionString:
+                    description: The connection string to be used
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  storageAccount:
+                    description: The storage account where to upload data
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  storageKey:
+                    description: The storage account key to be used in conjunction with the storage account name
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  storageSasToken:
+                    description: A shared-access-signature to be used in conjunction with the storage account name
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                type: object
+              backupId:
+                description: The ID of the Barman backup
+                type: string
+              beginLSN:
+                description: The starting xlog
+                type: string
+              beginWal:
+                description: The starting WAL
+                type: string
+              commandError:
+                description: The backup command output in case of error
+                type: string
+              commandOutput:
+                description: Unused. Retained for compatibility with old versions.
+                type: string
+              destinationPath:
+                description: The path where to store the backup (i.e. s3://bucket/path/to/folder) this path, with different destination folders, will be used for WALs and for data
+                type: string
+              encryption:
+                description: Encryption method required to S3 API
+                type: string
+              endLSN:
+                description: The ending xlog
+                type: string
+              endWal:
+                description: The ending WAL
+                type: string
+              endpointURL:
+                description: Endpoint to be used to upload data to the cloud, overriding the automatic endpoint discovery
+                type: string
+              error:
+                description: The detected error
+                type: string
+              phase:
+                description: The last backup status
+                type: string
+              s3Credentials:
+                description: The credentials to be used to upload data to S3
+                properties:
+                  accessKeyId:
+                    description: The reference to the access key id
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  secretAccessKey:
+                    description: The reference to the secret access key
+                    properties:
+                      key:
+                        description: The key to select
+                        type: string
+                      name:
+                        description: Name of the referent.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                required:
+                - accessKeyId
+                - secretAccessKey
+                type: object
+              serverName:
+                description: The server name on S3, the cluster name is used if this parameter is omitted
+                type: string
+              startedAt:
+                description: When the backup was started
+                format: date-time
+                type: string
+              stoppedAt:
+                description: When the backup was terminated
+                format: date-time
+                type: string
+            required:
+            - destinationPath
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/cloud-native-postgresql/1.9.2/manifests/postgresql.k8s.enterprisedb.io_clusters.yaml
+++ b/operators/cloud-native-postgresql/1.9.2/manifests/postgresql.k8s.enterprisedb.io_clusters.yaml
@@ -1,0 +1,2841 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: clusters.postgresql.k8s.enterprisedb.io
+spec:
+  conversion:
+    strategy: None
+  group: postgresql.k8s.enterprisedb.io
+  names:
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    singular: cluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Number of instances
+      jsonPath: .status.instances
+      name: Instances
+      type: integer
+    - description: Number of ready instances
+      jsonPath: .status.readyInstances
+      name: Ready
+      type: integer
+    - description: Cluster current status
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Primary pod
+      jsonPath: .status.currentPrimary
+      name: Primary
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the PostgreSQL API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the desired behavior of the cluster. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              affinity:
+                description: Affinity/Anti-affinity rules for Pods
+                properties:
+                  additionalPodAffinity:
+                    description: AdditionalPodAffinity allows to specify pod affinity terms to be passed to all the cluster's pods.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources, in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  additionalPodAntiAffinity:
+                    description: AdditionalPodAntiAffinity allows to specify pod anti-affinity terms to be added to the ones generated by the operator if EnablePodAntiAffinity is set to true (default) or to be used exclusively if set to false.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources, in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  enablePodAntiAffinity:
+                    description: Activates anti-affinity for the pods. The operator will define pods anti-affinity unless this field is explicitly set to false
+                    type: boolean
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'NodeSelector is map of key-value pairs used to define the nodes on which the pods can run. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                    type: object
+                  podAntiAffinityType:
+                    description: 'PodAntiAffinityType allows the user to decide whether pod anti-affinity between cluster instance has to be considered a strong requirement during scheduling or not. Allowed values are: "preferred" (default if empty) or "required". Setting it to "required", could lead to instances remaining pending until new kubernetes nodes are added if all the existing nodes don''t match the required pod anti-affinity rule. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity'
+                    type: string
+                  tolerations:
+                    description: 'Tolerations is a list of Tolerations that should be set for all the pods, in order to allow them to run on tainted nodes. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/'
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologyKey:
+                    description: TopologyKey to use for anti-affinity configuration. See k8s documentation for more info on that
+                    type: string
+                type: object
+              backup:
+                description: The configuration to be used for backups
+                properties:
+                  barmanObjectStore:
+                    description: The configuration for the barman-cloud tool suite
+                    properties:
+                      azureCredentials:
+                        description: The credentials to use to upload data in Azure Blob Storage
+                        properties:
+                          connectionString:
+                            description: The connection string to be used
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          storageAccount:
+                            description: The storage account where to upload data
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          storageKey:
+                            description: The storage account key to be used in conjunction with the storage account name
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          storageSasToken:
+                            description: A shared-access-signature to be used in conjunction with the storage account name
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        type: object
+                      data:
+                        description: The configuration to be used to backup the data files When not defined, base backups files will be stored uncompressed and may be unencrypted in the object store, according to the bucket default policy.
+                        properties:
+                          compression:
+                            description: Compress a backup file (a tar file per tablespace) while streaming it to the object store. Available options are empty string (no compression, default), `gzip` or `bzip2`.
+                            enum:
+                            - gzip
+                            - bzip2
+                            type: string
+                          encryption:
+                            description: Whenever to force the encryption of files (if the bucket is not already configured for that). Allowed options are empty string (use the bucket policy, default), `AES256` and `aws:kms`
+                            enum:
+                            - AES256
+                            - aws:kms
+                            type: string
+                          immediateCheckpoint:
+                            description: Control whether the I/O workload for the backup initial checkpoint will be limited, according to the `checkpoint_completion_target` setting on the PostgreSQL server. If set to true, an immediate checkpoint will be used, meaning PostgreSQL will complete the checkpoint as soon as possible. `false` by default.
+                            type: boolean
+                          jobs:
+                            description: The number of parallel jobs to be used to upload the backup, defaults to 2
+                            format: int32
+                            minimum: 1
+                            type: integer
+                        type: object
+                      destinationPath:
+                        description: The path where to store the backup (i.e. s3://bucket/path/to/folder) this path, with different destination folders, will be used for WALs and for data
+                        minLength: 1
+                        type: string
+                      endpointCA:
+                        description: EndpointCA store the CA bundle of the barman endpoint. Useful when using self-signed certificates to avoid errors with certificate issuer and barman-cloud-wal-archive
+                        properties:
+                          key:
+                            description: The key to select
+                            type: string
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      endpointURL:
+                        description: Endpoint to be used to upload data to the cloud, overriding the automatic endpoint discovery
+                        type: string
+                      s3Credentials:
+                        description: The credentials to use to upload data to S3
+                        properties:
+                          accessKeyId:
+                            description: The reference to the access key id
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          secretAccessKey:
+                            description: The reference to the secret access key
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        required:
+                        - accessKeyId
+                        - secretAccessKey
+                        type: object
+                      serverName:
+                        description: The server name on S3, the cluster name is used if this parameter is omitted
+                        type: string
+                      wal:
+                        description: The configuration for the backup of the WAL stream. When not defined, WAL files will be stored uncompressed and may be unencrypted in the object store, according to the bucket default policy.
+                        properties:
+                          compression:
+                            description: Compress a WAL file before sending it to the object store. Available options are empty string (no compression, default), `gzip` or `bzip2`.
+                            enum:
+                            - gzip
+                            - bzip2
+                            type: string
+                          encryption:
+                            description: Whenever to force the encryption of files (if the bucket is not already configured for that). Allowed options are empty string (use the bucket policy, default), `AES256` and `aws:kms`
+                            enum:
+                            - AES256
+                            - aws:kms
+                            type: string
+                        type: object
+                    required:
+                    - destinationPath
+                    type: object
+                type: object
+              bootstrap:
+                description: Instructions to bootstrap this cluster
+                properties:
+                  initdb:
+                    description: Bootstrap the cluster via initdb
+                    properties:
+                      database:
+                        description: 'Name of the database used by the application. Default: `app`.'
+                        type: string
+                      options:
+                        description: The list of options that must be passed to initdb when creating the cluster
+                        items:
+                          type: string
+                        type: array
+                      owner:
+                        description: Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.
+                        type: string
+                      postInitSQL:
+                        description: List of SQL queries to be executed as a superuser immediately after the cluster has been created - to be used with extreme care (by default empty)
+                        items:
+                          type: string
+                        type: array
+                      redwood:
+                        description: If we need to enable/disable Redwood compatibility. Requires EPAS and for EPAS defaults to true
+                        type: boolean
+                      secret:
+                        description: Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch
+                        properties:
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  pg_basebackup:
+                    description: Bootstrap the cluster taking a physical backup of another compatible PostgreSQL instance
+                    properties:
+                      source:
+                        description: The name of the server of which we need to take a physical backup
+                        minLength: 1
+                        type: string
+                    required:
+                    - source
+                    type: object
+                  recovery:
+                    description: Bootstrap the cluster from a backup
+                    properties:
+                      backup:
+                        description: The backup we need to restore
+                        properties:
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      recoveryTarget:
+                        description: 'By default, the recovery process applies all the available WAL files in the archive (full recovery). However, you can also end the recovery as soon as a consistent state is reached or recover to a point-in-time (PITR) by specifying a `RecoveryTarget` object, as expected by PostgreSQL (i.e., timestamp, transaction Id, LSN, ...). More info: https://www.postgresql.org/docs/current/runtime-config-wal.html#RUNTIME-CONFIG-WAL-RECOVERY-TARGET'
+                        properties:
+                          exclusive:
+                            description: Set the target to be exclusive (defaults to true)
+                            type: boolean
+                          targetImmediate:
+                            description: End recovery as soon as a consistent state is reached
+                            type: boolean
+                          targetLSN:
+                            description: The target LSN (Log Sequence Number)
+                            type: string
+                          targetName:
+                            description: The target name (to be previously created with `pg_create_restore_point`)
+                            type: string
+                          targetTLI:
+                            description: The target timeline ("latest", "current" or a positive integer)
+                            type: string
+                          targetTime:
+                            description: The target time, in any unambiguous representation allowed by PostgreSQL
+                            type: string
+                          targetXID:
+                            description: The target transaction ID
+                            type: string
+                        type: object
+                      source:
+                        description: The external cluster whose backup we will restore. This is also used as the name of the folder under which the backup is stored, so it must be set to the name of the source cluster
+                        type: string
+                    type: object
+                type: object
+              certificates:
+                description: The configuration for the CA and related certificates
+                properties:
+                  clientCASecret:
+                    description: 'The secret containing the Client CA certificate. If not defined, a new secret will be created with a self-signed CA and will be used to generate all the client certificates.<br /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should be used to validate the client certificates, used as `ssl_ca_file` of all the instances.<br /> - `ca.key`: key used to generate client certificates, if ReplicationTLSSecret is provided, this can be omitted.<br />'
+                    type: string
+                  replicationTLSSecret:
+                    description: The secret of type kubernetes.io/tls containing the client certificate to authenticate as the `streaming_replica` user. If not defined, ClientCASecret must provide also `ca.key`, and a new secret will be created using the provided CA.
+                    type: string
+                  serverAltDNSNames:
+                    description: The list of the server alternative DNS names to be added to the generated server TLS certificates, when required.
+                    items:
+                      type: string
+                    type: array
+                  serverCASecret:
+                    description: 'The secret containing the Server CA certificate. If not defined, a new secret will be created with a self-signed CA and will be used to generate the TLS certificate ServerTLSSecret.<br /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should be used to validate the server certificate, used as `sslrootcert` in client connection strings.<br /> - `ca.key`: key used to generate Server SSL certs, if ServerTLSSecret is provided, this can be omitted.<br />'
+                    type: string
+                  serverTLSSecret:
+                    description: The secret of type kubernetes.io/tls containing the server TLS certificate and key that will be set as `ssl_cert_file` and `ssl_key_file` so that clients can connect to postgres securely. If not defined, ServerCASecret must provide also `ca.key` and a new secret will be created using the provided CA.
+                    type: string
+                type: object
+              description:
+                description: Description of this PostgreSQL cluster
+                type: string
+              enableSuperuserAccess:
+                description: When this option is enabled, the operator will use the `SuperuserSecret` to update the `postgres` user password (if the secret is not present, the operator will automatically create one). When this option is disabled, the operator will ignore the `SuperuserSecret` content, delete it when automatically created, and then blank the password of the `postgres` user by setting it to `NULL`. Enabled by default.
+                type: boolean
+              externalClusters:
+                description: The list of external clusters which are used in the configuration
+                items:
+                  description: ExternalCluster represents the connection parameters to an external cluster which is used in the other sections of the configuration
+                  properties:
+                    barmanObjectStore:
+                      description: The configuration for the barman-cloud tool suite
+                      properties:
+                        azureCredentials:
+                          description: The credentials to use to upload data in Azure Blob Storage
+                          properties:
+                            connectionString:
+                              description: The connection string to be used
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            storageAccount:
+                              description: The storage account where to upload data
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            storageKey:
+                              description: The storage account key to be used in conjunction with the storage account name
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            storageSasToken:
+                              description: A shared-access-signature to be used in conjunction with the storage account name
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          type: object
+                        data:
+                          description: The configuration to be used to backup the data files When not defined, base backups files will be stored uncompressed and may be unencrypted in the object store, according to the bucket default policy.
+                          properties:
+                            compression:
+                              description: Compress a backup file (a tar file per tablespace) while streaming it to the object store. Available options are empty string (no compression, default), `gzip` or `bzip2`.
+                              enum:
+                              - gzip
+                              - bzip2
+                              type: string
+                            encryption:
+                              description: Whenever to force the encryption of files (if the bucket is not already configured for that). Allowed options are empty string (use the bucket policy, default), `AES256` and `aws:kms`
+                              enum:
+                              - AES256
+                              - aws:kms
+                              type: string
+                            immediateCheckpoint:
+                              description: Control whether the I/O workload for the backup initial checkpoint will be limited, according to the `checkpoint_completion_target` setting on the PostgreSQL server. If set to true, an immediate checkpoint will be used, meaning PostgreSQL will complete the checkpoint as soon as possible. `false` by default.
+                              type: boolean
+                            jobs:
+                              description: The number of parallel jobs to be used to upload the backup, defaults to 2
+                              format: int32
+                              minimum: 1
+                              type: integer
+                          type: object
+                        destinationPath:
+                          description: The path where to store the backup (i.e. s3://bucket/path/to/folder) this path, with different destination folders, will be used for WALs and for data
+                          minLength: 1
+                          type: string
+                        endpointCA:
+                          description: EndpointCA store the CA bundle of the barman endpoint. Useful when using self-signed certificates to avoid errors with certificate issuer and barman-cloud-wal-archive
+                          properties:
+                            key:
+                              description: The key to select
+                              type: string
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        endpointURL:
+                          description: Endpoint to be used to upload data to the cloud, overriding the automatic endpoint discovery
+                          type: string
+                        s3Credentials:
+                          description: The credentials to use to upload data to S3
+                          properties:
+                            accessKeyId:
+                              description: The reference to the access key id
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            secretAccessKey:
+                              description: The reference to the secret access key
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - accessKeyId
+                          - secretAccessKey
+                          type: object
+                        serverName:
+                          description: The server name on S3, the cluster name is used if this parameter is omitted
+                          type: string
+                        wal:
+                          description: The configuration for the backup of the WAL stream. When not defined, WAL files will be stored uncompressed and may be unencrypted in the object store, according to the bucket default policy.
+                          properties:
+                            compression:
+                              description: Compress a WAL file before sending it to the object store. Available options are empty string (no compression, default), `gzip` or `bzip2`.
+                              enum:
+                              - gzip
+                              - bzip2
+                              type: string
+                            encryption:
+                              description: Whenever to force the encryption of files (if the bucket is not already configured for that). Allowed options are empty string (use the bucket policy, default), `AES256` and `aws:kms`
+                              enum:
+                              - AES256
+                              - aws:kms
+                              type: string
+                          type: object
+                      required:
+                      - destinationPath
+                      type: object
+                    connectionParameters:
+                      additionalProperties:
+                        type: string
+                      description: The list of connection parameters, such as dbname, host, username, etc
+                      type: object
+                    name:
+                      description: The server name, required
+                      type: string
+                    password:
+                      description: The reference to the password to be used to connect to the server
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    sslCert:
+                      description: The reference to an SSL certificate to be used to connect to this instance
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    sslKey:
+                      description: The reference to an SSL private key to be used to connect to this instance
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    sslRootCert:
+                      description: The reference to an SSL CA public key to be used to connect to this instance
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              imageName:
+                description: Name of the container image, supporting both tags (`<image>:<tag>`) and digests for deterministic and repeatable deployments (`<image>:<tag>@sha256:<digestValue>`)
+                type: string
+              imagePullPolicy:
+                description: 'Image pull policy. One of `Always`, `Never` or `IfNotPresent`. If not defined, it defaults to `IfNotPresent`. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                type: string
+              imagePullSecrets:
+                description: The list of pull secrets to be used to pull the images. If the license key contains a pull secret that secret will be automatically included.
+                items:
+                  description: LocalObjectReference contains enough information to let you locate a local object with a known type inside the same namespace
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              instances:
+                description: Number of instances required in the cluster
+                format: int32
+                minimum: 1
+                type: integer
+              licenseKey:
+                description: The license key of the cluster. When empty, the cluster operates in trial mode and after the expiry date (default 30 days) the operator will cease any reconciliation attempt. For details, please refer to the license agreement that comes with the operator.
+                type: string
+              licenseKeySecret:
+                description: The reference to the license key. When this is set it take precedence over LicenseKey.
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a valid secret key.
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+              logLevel:
+                description: 'The instances'' log level, one of the following values: error, info (default), debug, trace'
+                type: string
+              maxSyncReplicas:
+                description: The target value for the synchronous replication quorum, that can be decreased if the number of ready standbys is lower than this. Undefined or 0 disable synchronous replication.
+                format: int32
+                type: integer
+              minSyncReplicas:
+                description: Minimum number of instances required in synchronous replication with the primary. Undefined or 0 allow writes to complete when no standby is available.
+                format: int32
+                type: integer
+              monitoring:
+                description: The configuration of the monitoring infrastructure of this cluster
+                properties:
+                  customQueriesConfigMap:
+                    description: The list of config maps containing the custom queries
+                    items:
+                      description: ConfigMapKeySelector contains enough information to let you locate the key of a ConfigMap
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type: array
+                  customQueriesSecret:
+                    description: The list of secrets containing the custom queries
+                    items:
+                      description: SecretKeySelector contains enough information to let you locate the key of a Secret
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type: array
+                type: object
+              nodeMaintenanceWindow:
+                description: Define a maintenance window for the Kubernetes nodes
+                properties:
+                  inProgress:
+                    description: Is there a node maintenance activity in progress?
+                    type: boolean
+                  reusePVC:
+                    description: Reuse the existing PVC (wait for the node to come up again) or not (recreate it elsewhere)
+                    type: boolean
+                required:
+                - inProgress
+                type: object
+              postgresGID:
+                description: The GID of the `postgres` user inside the image, defaults to `26`
+                format: int64
+                type: integer
+              postgresUID:
+                description: The UID of the `postgres` user inside the image, defaults to `26`
+                format: int64
+                type: integer
+              postgresql:
+                description: Configuration of the PostgreSQL server
+                properties:
+                  epas:
+                    description: EDB Postgres Advanced Server specific configurations
+                    properties:
+                      audit:
+                        description: If true enables edb_audit logging
+                        type: boolean
+                    type: object
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    description: PostgreSQL configuration options (postgresql.conf)
+                    type: object
+                  pg_hba:
+                    description: PostgreSQL Host Based Authentication rules (lines to be appended to the pg_hba.conf file)
+                    items:
+                      type: string
+                    type: array
+                  promotionTimeout:
+                    description: Specifies the maximum number of seconds to wait when promoting an instance to primary
+                    format: int32
+                    type: integer
+                  shared_preload_libraries:
+                    description: Lists of shared preload libraries to add to the default ones
+                    items:
+                      type: string
+                    type: array
+                type: object
+              primaryUpdateStrategy:
+                description: 'Strategy to follow to upgrade the primary server during a rolling update procedure, after all replicas have been successfully updated: it can be automated (`unsupervised` - default) or manual (`supervised`)'
+                type: string
+              replica:
+                description: Replica cluster configuration
+                properties:
+                  enabled:
+                    description: If replica mode is enabled, this cluster will be a replica of an existing cluster. A cluster of such type can be created only using bootstrap via pg_basebackup
+                    type: boolean
+                  source:
+                    description: The name of the external cluster which is the replication origin
+                    minLength: 1
+                    type: string
+                required:
+                - source
+                type: object
+              resources:
+                description: Resources requirements of every generated Pod. Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              startDelay:
+                description: The time in seconds that is allowed for a PostgreSQL instance to successfully start up (default 30)
+                format: int32
+                type: integer
+              stopDelay:
+                description: The time in seconds that is allowed for a PostgreSQL instance node to gracefully shutdown (default 30)
+                format: int32
+                type: integer
+              storage:
+                description: Configuration of the storage of the instances
+                properties:
+                  pvcTemplate:
+                    description: Template to be used to generate the Persistent Volume Claim
+                    properties:
+                      accessModes:
+                        description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                        items:
+                          type: string
+                        type: array
+                      dataSource:
+                        description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      dataSourceRef:
+                        description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      selector:
+                        description: A label query over volumes to consider for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      storageClassName:
+                        description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                        type: string
+                      volumeMode:
+                        description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                        type: string
+                      volumeName:
+                        description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                        type: string
+                    type: object
+                  resizeInUseVolumes:
+                    description: Resize existent PVCs, defaults to true
+                    type: boolean
+                  size:
+                    description: Size of the storage. Required if not already specified in the PVC template. Changes to this field are automatically reapplied to the created PVCs. Size cannot be decreased.
+                    type: string
+                  storageClass:
+                    description: StorageClass to use for database data (`PGDATA`). Applied after evaluating the PVC template, if available. If not specified, generated PVCs will be satisfied by the default storage class
+                    type: string
+                required:
+                - size
+                type: object
+              superuserSecret:
+                description: The secret containing the superuser password. If not defined a new secret will be created with a randomly generated password
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - instances
+            type: object
+          status:
+            description: 'Most recently observed status of the cluster. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              certificates:
+                description: The configuration for the CA and related certificates, initialized with defaults.
+                properties:
+                  clientCASecret:
+                    description: 'The secret containing the Client CA certificate. If not defined, a new secret will be created with a self-signed CA and will be used to generate all the client certificates.<br /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should be used to validate the client certificates, used as `ssl_ca_file` of all the instances.<br /> - `ca.key`: key used to generate client certificates, if ReplicationTLSSecret is provided, this can be omitted.<br />'
+                    type: string
+                  expirations:
+                    additionalProperties:
+                      type: string
+                    description: Expiration dates for all certificates.
+                    type: object
+                  replicationTLSSecret:
+                    description: The secret of type kubernetes.io/tls containing the client certificate to authenticate as the `streaming_replica` user. If not defined, ClientCASecret must provide also `ca.key`, and a new secret will be created using the provided CA.
+                    type: string
+                  serverAltDNSNames:
+                    description: The list of the server alternative DNS names to be added to the generated server TLS certificates, when required.
+                    items:
+                      type: string
+                    type: array
+                  serverCASecret:
+                    description: 'The secret containing the Server CA certificate. If not defined, a new secret will be created with a self-signed CA and will be used to generate the TLS certificate ServerTLSSecret.<br /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should be used to validate the server certificate, used as `sslrootcert` in client connection strings.<br /> - `ca.key`: key used to generate Server SSL certs, if ServerTLSSecret is provided, this can be omitted.<br />'
+                    type: string
+                  serverTLSSecret:
+                    description: The secret of type kubernetes.io/tls containing the server TLS certificate and key that will be set as `ssl_cert_file` and `ssl_key_file` so that clients can connect to postgres securely. If not defined, ServerCASecret must provide also `ca.key` and a new secret will be created using the provided CA.
+                    type: string
+                type: object
+              cloudNativePostgresqlCommitHash:
+                description: The commit hash number of which this operator running
+                type: string
+              configMapResourceVersion:
+                description: The list of resource versions of the configmaps, managed by the operator. Every change here is done in the interest of the instance manager, which will refresh the configmap data
+                properties:
+                  metrics:
+                    additionalProperties:
+                      type: string
+                    description: A map with the versions of all the config maps used to pass metrics. Map keys are the config map names, map values are the versions
+                    type: object
+                type: object
+              currentPrimary:
+                description: Current primary instance
+                type: string
+              currentPrimaryTimestamp:
+                description: The timestamp when the last actual promotion to primary has occurred
+                type: string
+              danglingPVC:
+                description: List of all the PVCs created by this cluster and still available which are not attached to a Pod
+                items:
+                  type: string
+                type: array
+              firstRecoverabilityPoint:
+                description: The first recoverability point, stored as a date in RFC3339 format
+                type: string
+              healthyPVC:
+                description: List of all the PVCs not dangling nor initializing
+                items:
+                  type: string
+                type: array
+              initializingPVC:
+                description: List of all the PVCs that are being initialized by this cluster
+                items:
+                  type: string
+                type: array
+              instances:
+                description: Total number of instances in the cluster
+                format: int32
+                type: integer
+              instancesStatus:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: Instances status
+                type: object
+              jobCount:
+                description: How many Jobs have been created by this cluster
+                format: int32
+                type: integer
+              latestGeneratedNode:
+                description: ID of the latest generated node (used to avoid node name clashing)
+                format: int32
+                type: integer
+              licenseStatus:
+                description: Status of the license
+                properties:
+                  isImplicit:
+                    description: True in case of implicit trial license
+                    type: boolean
+                  isTrial:
+                    description: True if we are using a trial license
+                    type: boolean
+                  issuer:
+                    description: Who issued this license?
+                    type: string
+                  licenseExpiration:
+                    description: The expiration timestamp of the license key, after which the operator will cease any reconciliation attempt on the cluster.
+                    format: date-time
+                    type: string
+                  licenseStatus:
+                    description: Current status the license key of the cluster
+                    type: string
+                  repositoryAccess:
+                    description: True if the license embeds a pull secret that can be used to access the repositories
+                    type: boolean
+                  systemUID:
+                    description: When present the license is valid only for the specified Kubernetes cluster
+                    type: string
+                  valid:
+                    description: Whether the license key is valid or not
+                    type: boolean
+                required:
+                - repositoryAccess
+                - valid
+                type: object
+              phase:
+                description: Current phase of the cluster
+                type: string
+              phaseReason:
+                description: Reason for the current phase
+                type: string
+              pvcCount:
+                description: How many PVCs have been created by this cluster
+                format: int32
+                type: integer
+              readService:
+                description: Current list of read pods
+                type: string
+              readyInstances:
+                description: Total number of ready instances in the cluster
+                format: int32
+                type: integer
+              secretsResourceVersion:
+                description: The list of resource versions of the secrets managed by the operator. Every change here is done in the interest of the instance manager, which will refresh the secret data
+                properties:
+                  applicationSecretVersion:
+                    description: The resource version of the "app" user secret
+                    type: string
+                  barmanEndpointCA:
+                    description: The resource version of the Barman Endpoint CA if provided
+                    type: string
+                  caSecretVersion:
+                    description: Unused. Retained for compatibility with old versions.
+                    type: string
+                  clientCaSecretVersion:
+                    description: The resource version of the PostgreSQL client-side CA secret version
+                    type: string
+                  metrics:
+                    additionalProperties:
+                      type: string
+                    description: A map with the versions of all the secrets used to pass metrics. Map keys are the secret names, map values are the versions
+                    type: object
+                  replicationSecretVersion:
+                    description: The resource version of the "streaming_replica" user secret
+                    type: string
+                  serverCaSecretVersion:
+                    description: The resource version of the PostgreSQL server-side CA secret version
+                    type: string
+                  serverSecretVersion:
+                    description: The resource version of the PostgreSQL server-side secret version
+                    type: string
+                  superuserSecretVersion:
+                    description: The resource version of the "postgres" user secret
+                    type: string
+                type: object
+              targetPrimary:
+                description: Target primary instance, this is different from the previous one during a switchover or a failover
+                type: string
+              targetPrimaryTimestamp:
+                description: The timestamp when the last request for a new primary has occurred
+                type: string
+              writeService:
+                description: Current write pod
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.instances
+        statusReplicasPath: .status.instances
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Number of instances
+      jsonPath: .status.instances
+      name: Instances
+      type: integer
+    - description: Number of ready instances
+      jsonPath: .status.readyInstances
+      name: Ready
+      type: integer
+    - description: Cluster current status
+      jsonPath: .status.phase
+      name: Status
+      type: string
+    - description: Primary pod
+      jsonPath: .status.currentPrimary
+      name: Primary
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the PostgreSQL API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the desired behavior of the cluster. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              affinity:
+                description: Affinity/Anti-affinity rules for Pods
+                properties:
+                  additionalPodAffinity:
+                    description: AdditionalPodAffinity allows to specify pod affinity terms to be passed to all the cluster's pods.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources, in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  additionalPodAntiAffinity:
+                    description: AdditionalPodAntiAffinity allows to specify pod anti-affinity terms to be added to the ones generated by the operator if EnablePodAntiAffinity is set to true (default) or to be used exclusively if set to false.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources, in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaceSelector:
+                                  description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: A label query over a set of resources, in this case pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaceSelector:
+                              description: A label query over the set of namespaces that the term applies to. The term is applied to the union of the namespaces selected by this field and the ones listed in the namespaces field. null selector and null or empty namespaces list means "this pod's namespace". An empty selector ({}) matches all namespaces. This field is beta-level and is only honored when PodAffinityNamespaceSelector feature is enabled.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            namespaces:
+                              description: namespaces specifies a static list of namespace names that the term applies to. The term is applied to the union of the namespaces listed in this field and the ones selected by namespaceSelector. null or empty namespaces list and null namespaceSelector means "this pod's namespace"
+                              items:
+                                type: string
+                              type: array
+                            topologyKey:
+                              description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                    type: object
+                  enablePodAntiAffinity:
+                    description: Activates anti-affinity for the pods. The operator will define pods anti-affinity unless this field is explicitly set to false
+                    type: boolean
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: 'NodeSelector is map of key-value pairs used to define the nodes on which the pods can run. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                    type: object
+                  podAntiAffinityType:
+                    description: 'PodAntiAffinityType allows the user to decide whether pod anti-affinity between cluster instance has to be considered a strong requirement during scheduling or not. Allowed values are: "preferred" (default if empty) or "required". Setting it to "required", could lead to instances remaining pending until new kubernetes nodes are added if all the existing nodes don''t match the required pod anti-affinity rule. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity'
+                    type: string
+                  tolerations:
+                    description: 'Tolerations is a list of Tolerations that should be set to all the pods for this cluster. More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/'
+                    items:
+                      description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologyKey:
+                    description: TopologyKey to use for anti-affinity configuration. See k8s documentation for more info on that
+                    type: string
+                type: object
+              backup:
+                description: The configuration to be used for backups
+                properties:
+                  barmanObjectStore:
+                    description: The configuration for the barman-cloud tool suite
+                    properties:
+                      azureCredentials:
+                        description: The credentials to use to upload data to S3
+                        properties:
+                          connectionString:
+                            description: The connection string to be used
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          storageAccount:
+                            description: The storage account where to upload data
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          storageKey:
+                            description: The storage account key to be used in conjunction with the storage account name
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          storageSasToken:
+                            description: A shared-access-signature to be used in conjunction with the storage account name
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        type: object
+                      data:
+                        description: The configuration to be used to backup the data files When not defined, base backups files will be stored uncompressed and may be unencrypted in the object store, according to the bucket default policy.
+                        properties:
+                          compression:
+                            description: Compress a backup file (a tar file per tablespace) while streaming it to the object store. Available options are empty string (no compression, default), `gzip` or `bzip2`.
+                            type: string
+                          encryption:
+                            description: Whenever to force the encryption of files (if the bucket is not already configured for that). Allowed options are empty string (use the bucket policy, default), `AES256` and `aws:kms`
+                            type: string
+                          immediateCheckpoint:
+                            description: Control whether the I/O workload for the backup initial checkpoint will be limited, according to the `checkpoint_completion_target` setting on the PostgreSQL server. If set to true, an immediate checkpoint will be used, meaning PostgreSQL will complete the checkpoint as soon as possible. `false` by default.
+                            type: boolean
+                          jobs:
+                            description: The number of parallel jobs to be used to upload the backup, defaults to 2
+                            format: int32
+                            type: integer
+                        type: object
+                      destinationPath:
+                        description: The path where to store the backup (i.e. s3://bucket/path/to/folder) this path, with different destination folders, will be used for WALs and for data
+                        minLength: 1
+                        type: string
+                      endpointCA:
+                        description: EndpointCA store the CA bundle of the barman endpoint. Useful when using self-signed certificates to avoid errors with certificate issuer and barman-cloud-wal-archive
+                        properties:
+                          key:
+                            description: The key to select
+                            type: string
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      endpointURL:
+                        description: Endpoint to be used to upload data to the cloud, overriding the automatic endpoint discovery
+                        type: string
+                      s3Credentials:
+                        description: The credentials to use to upload data to S3
+                        properties:
+                          accessKeyId:
+                            description: The reference to the access key id
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                          secretAccessKey:
+                            description: The reference to the secret access key
+                            properties:
+                              key:
+                                description: The key to select
+                                type: string
+                              name:
+                                description: Name of the referent.
+                                type: string
+                            required:
+                            - key
+                            - name
+                            type: object
+                        required:
+                        - accessKeyId
+                        - secretAccessKey
+                        type: object
+                      serverName:
+                        description: The server name on S3, the cluster name is used if this parameter is omitted
+                        type: string
+                      wal:
+                        description: The configuration for the backup of the WAL stream. When not defined, WAL files will be stored uncompressed and may be unencrypted in the object store, according to the bucket default policy.
+                        properties:
+                          compression:
+                            description: Compress a WAL file before sending it to the object store. Available options are empty string (no compression, default), `gzip` or `bzip2`.
+                            type: string
+                          encryption:
+                            description: Whenever to force the encryption of files (if the bucket is not already configured for that). Allowed options are empty string (use the bucket policy, default), `AES256` and `aws:kms`
+                            type: string
+                        type: object
+                    required:
+                    - destinationPath
+                    type: object
+                type: object
+              bootstrap:
+                description: Instructions to bootstrap this cluster
+                properties:
+                  initdb:
+                    description: Bootstrap the cluster via initdb
+                    properties:
+                      database:
+                        description: 'Name of the database used by the application. Default: `app`.'
+                        type: string
+                      options:
+                        description: The list of options that must be passed to initdb when creating the cluster
+                        items:
+                          type: string
+                        type: array
+                      owner:
+                        description: Name of the owner of the database in the instance to be used by applications. Defaults to the value of the `database` key.
+                        type: string
+                      postInitSQL:
+                        description: List of SQL queries to be executed as a superuser immediately after the cluster has been created - to be used with extreme care (by default empty)
+                        items:
+                          type: string
+                        type: array
+                      redwood:
+                        description: If we need to enable/disable Redwood compatibility. Requires EPAS and for EPAS defaults to true
+                        type: boolean
+                      secret:
+                        description: Name of the secret containing the initial credentials for the owner of the user database. If empty a new secret will be created from scratch
+                        properties:
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                  pg_basebackup:
+                    description: Bootstrap the cluster taking a physical backup of another compatible PostgreSQL instance
+                    properties:
+                      source:
+                        description: The name of the server of which we need to take a physical backup
+                        minLength: 1
+                        type: string
+                    required:
+                    - source
+                    type: object
+                  recovery:
+                    description: Bootstrap the cluster from a backup
+                    properties:
+                      backup:
+                        description: The backup we need to restore
+                        properties:
+                          name:
+                            description: Name of the referent.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      recoveryTarget:
+                        description: 'By default, the recovery will end as soon as a consistent state is reached: in this case, that means at the end of a backup. This option allows to fine tune the recovery process'
+                        properties:
+                          exclusive:
+                            description: Set the target to be exclusive (defaults to true)
+                            type: boolean
+                          targetImmediate:
+                            description: End recovery as soon as a consistent state is reached
+                            type: boolean
+                          targetLSN:
+                            description: The target LSN (Log Sequence Number)
+                            type: string
+                          targetName:
+                            description: The target name (to be previously created with `pg_create_restore_point`)
+                            type: string
+                          targetTLI:
+                            description: The target timeline ("latest", "current" or a positive integer)
+                            type: string
+                          targetTime:
+                            description: The target time, in any unambiguous representation allowed by PostgreSQL
+                            type: string
+                          targetXID:
+                            description: The target transaction ID
+                            type: string
+                        type: object
+                      source:
+                        description: The external cluster whose backup we will restore
+                        type: string
+                    type: object
+                type: object
+              certificates:
+                description: The configuration for the CA and related certificates
+                properties:
+                  clientCASecret:
+                    description: 'The secret containing the Client CA certificate. If not defined, a new secret will be created with a self-signed CA and will be used to generate all the client certificates.<br /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should be used to validate the client certificates, used as `ssl_ca_file` of all the instances.<br /> - `ca.key`: key used to generate client certificates, if ReplicationTLSSecret is provided, this can be omitted.<br />'
+                    type: string
+                  replicationTLSSecret:
+                    description: The secret of type kubernetes.io/tls containing the client certificate to authenticate as the `streaming_replica` user If not defined, ClientCASecret must provide also `ca.key` and a new secret will be created using the provided CA.
+                    type: string
+                  serverAltDNSNames:
+                    description: The list of the server alternative DNS names to be added to the generated server TLS certificates, when required.
+                    items:
+                      type: string
+                    type: array
+                  serverCASecret:
+                    description: 'The secret containing the Server CA certificate. If not defined, a new secret will be created with a self-signed CA and will be used to generate the TLS certificate ServerTLSSecret.<br /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should be used to validate the server certificate, used as `sslrootcert` in client connection strings.<br /> - `ca.key`: key used to generate Server SSL certs, if ServerTLSSecret is provided, this can be omitted.<br />'
+                    type: string
+                  serverTLSSecret:
+                    description: The secret of type kubernetes.io/tls containing the server TLS certificate and key that will be set as `ssl_cert_file` and `ssl_key_file` so that clients can connect to postgres securely. If not defined, ServerCASecret must provide also `ca.key` and a new secret will be created using the provided CA.
+                    type: string
+                type: object
+              description:
+                description: Description of this PostgreSQL cluster
+                type: string
+              enableSuperuserAccess:
+                description: When this option is enabled, the operator will use the `SuperuserSecret` to update the `postgres` user password (if the secret is not present, the operator will automatically create one). When this option is disabled, the operator will ignore the `SuperuserSecret` content, delete it when automatically created, and then blank the password of the `postgres` user by setting it to `NULL`. Enabled by default.
+                type: boolean
+              externalClusters:
+                description: The list of external clusters which are used in the other sections of the configuration
+                items:
+                  description: ExternalCluster represent the connection parameters to an external cluster which is used in the other sections of the configuration
+                  properties:
+                    barmanObjectStore:
+                      description: The configuration for the barman-cloud tool suite
+                      properties:
+                        azureCredentials:
+                          description: The credentials to use to upload data to S3
+                          properties:
+                            connectionString:
+                              description: The connection string to be used
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            storageAccount:
+                              description: The storage account where to upload data
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            storageKey:
+                              description: The storage account key to be used in conjunction with the storage account name
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            storageSasToken:
+                              description: A shared-access-signature to be used in conjunction with the storage account name
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          type: object
+                        data:
+                          description: The configuration to be used to backup the data files When not defined, base backups files will be stored uncompressed and may be unencrypted in the object store, according to the bucket default policy.
+                          properties:
+                            compression:
+                              description: Compress a backup file (a tar file per tablespace) while streaming it to the object store. Available options are empty string (no compression, default), `gzip` or `bzip2`.
+                              type: string
+                            encryption:
+                              description: Whenever to force the encryption of files (if the bucket is not already configured for that). Allowed options are empty string (use the bucket policy, default), `AES256` and `aws:kms`
+                              type: string
+                            immediateCheckpoint:
+                              description: Control whether the I/O workload for the backup initial checkpoint will be limited, according to the `checkpoint_completion_target` setting on the PostgreSQL server. If set to true, an immediate checkpoint will be used, meaning PostgreSQL will complete the checkpoint as soon as possible. `false` by default.
+                              type: boolean
+                            jobs:
+                              description: The number of parallel jobs to be used to upload the backup, defaults to 2
+                              format: int32
+                              type: integer
+                          type: object
+                        destinationPath:
+                          description: The path where to store the backup (i.e. s3://bucket/path/to/folder) this path, with different destination folders, will be used for WALs and for data
+                          minLength: 1
+                          type: string
+                        endpointCA:
+                          description: EndpointCA store the CA bundle of the barman endpoint. Useful when using self-signed certificates to avoid errors with certificate issuer and barman-cloud-wal-archive
+                          properties:
+                            key:
+                              description: The key to select
+                              type: string
+                            name:
+                              description: Name of the referent.
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                        endpointURL:
+                          description: Endpoint to be used to upload data to the cloud, overriding the automatic endpoint discovery
+                          type: string
+                        s3Credentials:
+                          description: The credentials to use to upload data to S3
+                          properties:
+                            accessKeyId:
+                              description: The reference to the access key id
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            secretAccessKey:
+                              description: The reference to the secret access key
+                              properties:
+                                key:
+                                  description: The key to select
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - accessKeyId
+                          - secretAccessKey
+                          type: object
+                        serverName:
+                          description: The server name on S3, the cluster name is used if this parameter is omitted
+                          type: string
+                        wal:
+                          description: The configuration for the backup of the WAL stream. When not defined, WAL files will be stored uncompressed and may be unencrypted in the object store, according to the bucket default policy.
+                          properties:
+                            compression:
+                              description: Compress a WAL file before sending it to the object store. Available options are empty string (no compression, default), `gzip` or `bzip2`.
+                              type: string
+                            encryption:
+                              description: Whenever to force the encryption of files (if the bucket is not already configured for that). Allowed options are empty string (use the bucket policy, default), `AES256` and `aws:kms`
+                              type: string
+                          type: object
+                      required:
+                      - destinationPath
+                      type: object
+                    connectionParameters:
+                      additionalProperties:
+                        type: string
+                      description: The list of connection parameters, such as dbname, host, username, etc
+                      type: object
+                    name:
+                      description: The server name, required
+                      type: string
+                    password:
+                      description: The reference to the password to be used to connect to the server
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    sslCert:
+                      description: The reference to an SSL certificate to be used to connect to this instance
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    sslKey:
+                      description: The reference to an SSL private key to be used to connect to this instance
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                    sslRootCert:
+                      description: The reference to an SSL CA public key to be used to connect to this instance
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              imageName:
+                description: Name of the container image
+                type: string
+              imagePullPolicy:
+                description: 'Image pull policy. One of `Always`, `Never` or `IfNotPresent`. If not defined, it defaults to `IfNotPresent`. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                type: string
+              imagePullSecrets:
+                description: The list of pull secrets to be used to pull the images. If the license key contains a pull secret, that secret will be automatically included.
+                items:
+                  description: LocalObjectReference contains enough information to let you locate a local object with a known type inside the same namespace
+                  properties:
+                    name:
+                      description: Name of the referent.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              instances:
+                description: Number of instances required in the cluster
+                format: int32
+                minimum: 1
+                type: integer
+              licenseKey:
+                description: The license key of the cluster. When empty, the cluster operates in trial mode and after the expiry date (default 30 days) the operator will cease any reconciliation attempt. For details, please refer to the license agreement that comes with the operator.
+                type: string
+              licenseKeySecret:
+                description: The reference to the license key. When this is set it take precedence over LicenseKey.
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a valid secret key.
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+              logLevel:
+                description: 'The instances'' log level, one of the following values: error, info (default), debug, trace'
+                type: string
+              maxSyncReplicas:
+                description: The target value for the synchronous replication quorum, that can be decreased if the number of ready standbys is lower than this. Undefined or 0 disable synchronous replication.
+                format: int32
+                type: integer
+              minSyncReplicas:
+                description: Minimum number of instances required in synchronous replication with the primary. Undefined or 0 allow writes to complete when no standby is available.
+                format: int32
+                type: integer
+              monitoring:
+                description: The configuration of the monitoring infrastructure of this cluster
+                properties:
+                  customQueriesConfigMap:
+                    description: The list of config maps containing the custom queries
+                    items:
+                      description: ConfigMapKeySelector contains enough information to let you locate key of a ConfigMap
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type: array
+                  customQueriesSecret:
+                    description: The list of secrets containing the custom queries
+                    items:
+                      description: SecretKeySelector contains enough information to let you locate key of a Secret
+                      properties:
+                        key:
+                          description: The key to select
+                          type: string
+                        name:
+                          description: Name of the referent.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    type: array
+                type: object
+              nodeMaintenanceWindow:
+                description: Define a maintenance window for the Kubernetes nodes
+                properties:
+                  inProgress:
+                    description: Is there a node maintenance activity in progress?
+                    type: boolean
+                  reusePVC:
+                    description: Reuse the existing PVC (wait for the node to come up again) or not (recreate it elsewhere)
+                    type: boolean
+                required:
+                - inProgress
+                type: object
+              postgresGID:
+                description: The GID of the `postgres` user inside the image, defaults to `26`
+                format: int64
+                type: integer
+              postgresUID:
+                description: The UID of the `postgres` user inside the image, defaults to `26`
+                format: int64
+                type: integer
+              postgresql:
+                description: Configuration of the PostgreSQL server
+                properties:
+                  epas:
+                    description: EDB Postgres Advanced Server specific configurations
+                    properties:
+                      audit:
+                        description: If true enables edb_audit logging
+                        type: boolean
+                    type: object
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    description: PostgreSQL configuration options (postgresql.conf)
+                    type: object
+                  pg_hba:
+                    description: PostgreSQL Host Based Authentication rules (lines to be appended to the pg_hba.conf file)
+                    items:
+                      type: string
+                    type: array
+                  promotionTimeout:
+                    description: Specifies the maximum number of seconds to wait when promoting an instance to primary
+                    format: int32
+                    type: integer
+                  shared_preload_libraries:
+                    description: Lists of shared preload libraries to add to the default ones
+                    items:
+                      type: string
+                    type: array
+                type: object
+              primaryUpdateStrategy:
+                description: 'Strategy to follow to upgrade the primary server during a rolling update procedure, after all replicas have been successfully updated: it can be automated (`unsupervised` - default) or manual (`supervised`)'
+                type: string
+              replica:
+                description: Replica cluster configuration
+                properties:
+                  enabled:
+                    description: If replica mode is enabled, this cluster will be a replica of an existing cluster. A cluster of such type can be created only using bootstrap via pg_basebackup
+                    type: boolean
+                  source:
+                    description: The name of the external cluster which is the replication origin
+                    minLength: 1
+                    type: string
+                required:
+                - source
+                type: object
+              resources:
+                description: Resources requirements of every generated Pod. Please refer to https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ for more information.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                    type: object
+                type: object
+              startDelay:
+                description: The time in seconds that is allowed for a PostgreSQL instance to successfully start up (default 30)
+                format: int32
+                type: integer
+              stopDelay:
+                description: The time in seconds that is allowed for a PostgreSQL instance node to gracefully shutdown (default 30)
+                format: int32
+                type: integer
+              storage:
+                description: Configuration of the storage of the instances
+                properties:
+                  pvcTemplate:
+                    description: Template to be used to generate the Persistent Volume Claim
+                    properties:
+                      accessModes:
+                        description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                        items:
+                          type: string
+                        type: array
+                      dataSource:
+                        description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the AnyVolumeDataSource feature gate is enabled, this field will always have the same contents as the DataSourceRef field.'
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      dataSourceRef:
+                        description: 'Specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any local object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the DataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, both fields (DataSource and DataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. There are two important differences between DataSource and DataSourceRef: * While DataSource only allows two specific types of objects, DataSourceRef   allows any non-core object, as well as PersistentVolumeClaim objects. * While DataSource ignores disallowed values (dropping them), DataSourceRef   preserves all values, and generates an error if a disallowed value is   specified. (Alpha) Using this field requires the AnyVolumeDataSource feature gate to be enabled.'
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      resources:
+                        description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            type: object
+                        type: object
+                      selector:
+                        description: A label query over volumes to consider for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      storageClassName:
+                        description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                        type: string
+                      volumeMode:
+                        description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                        type: string
+                      volumeName:
+                        description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                        type: string
+                    type: object
+                  resizeInUseVolumes:
+                    description: Resize existent PVCs, defaults to true
+                    type: boolean
+                  size:
+                    description: Size of the storage. Required if not already specified in the PVC template. Changes to this field are automatically reapplied to the created PVCs. Size cannot be decreased.
+                    type: string
+                  storageClass:
+                    description: StorageClass to use for database data (`PGDATA`). Applied after evaluating the PVC template, if available. If not specified, generated PVCs will be satisfied by the default storage class
+                    type: string
+                required:
+                - size
+                type: object
+              superuserSecret:
+                description: The secret containing the superuser password. If not defined, a new secret will be created with a randomly generated password
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - instances
+            type: object
+          status:
+            description: 'Most recently observed status of the cluster. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              certificates:
+                description: The configuration for the CA and related certificates, initialized with defaults.
+                properties:
+                  clientCASecret:
+                    description: 'The secret containing the Client CA certificate. If not defined, a new secret will be created with a self-signed CA and will be used to generate all the client certificates.<br /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should be used to validate the client certificates, used as `ssl_ca_file` of all the instances.<br /> - `ca.key`: key used to generate client certificates, if ReplicationTLSSecret is provided, this can be omitted.<br />'
+                    type: string
+                  expirations:
+                    additionalProperties:
+                      type: string
+                    description: Expiration dates for all certificates.
+                    type: object
+                  replicationTLSSecret:
+                    description: The secret of type kubernetes.io/tls containing the client certificate to authenticate as the `streaming_replica` user If not defined, ClientCASecret must provide also `ca.key` and a new secret will be created using the provided CA.
+                    type: string
+                  serverAltDNSNames:
+                    description: The list of the server alternative DNS names to be added to the generated server TLS certificates, when required.
+                    items:
+                      type: string
+                    type: array
+                  serverCASecret:
+                    description: 'The secret containing the Server CA certificate. If not defined, a new secret will be created with a self-signed CA and will be used to generate the TLS certificate ServerTLSSecret.<br /> <br /> Contains:<br /> <br /> - `ca.crt`: CA that should be used to validate the server certificate, used as `sslrootcert` in client connection strings.<br /> - `ca.key`: key used to generate Server SSL certs, if ServerTLSSecret is provided, this can be omitted.<br />'
+                    type: string
+                  serverTLSSecret:
+                    description: The secret of type kubernetes.io/tls containing the server TLS certificate and key that will be set as `ssl_cert_file` and `ssl_key_file` so that clients can connect to postgres securely. If not defined, ServerCASecret must provide also `ca.key` and a new secret will be created using the provided CA.
+                    type: string
+                type: object
+              cloudNativePostgresqlCommitHash:
+                description: The commit hash number of which this operator running
+                type: string
+              configMapResourceVersion:
+                description: The list of resource versions of the configmaps managed by the operator. Every change here is done in the interest of the instance manager, which will refresh the configmap data
+                properties:
+                  metrics:
+                    additionalProperties:
+                      type: string
+                    description: The versions of all the configmaps used to pass metrics
+                    type: object
+                type: object
+              currentPrimary:
+                description: Current primary instance
+                type: string
+              currentPrimaryTimestamp:
+                description: The timestamp of the current primary
+                type: string
+              danglingPVC:
+                description: List of all the PVCs created by this cluster and still available which are not attached to a Pod
+                items:
+                  type: string
+                type: array
+              healthyPVC:
+                description: List of all the PVCs not dangling nor initializing
+                items:
+                  type: string
+                type: array
+              initializingPVC:
+                description: List of all the PVCs that are being initialized by this cluster
+                items:
+                  type: string
+                type: array
+              instances:
+                description: Total number of instances in the cluster
+                format: int32
+                type: integer
+              instancesStatus:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: Instances status
+                type: object
+              jobCount:
+                description: How many Jobs have been created by this cluster
+                format: int32
+                type: integer
+              latestGeneratedNode:
+                description: ID of the latest generated node (used to avoid node name clashing)
+                format: int32
+                type: integer
+              licenseStatus:
+                description: Status of the license
+                properties:
+                  isImplicit:
+                    description: True in case of implicit trial license
+                    type: boolean
+                  isTrial:
+                    description: True if we are using a trial license
+                    type: boolean
+                  issuer:
+                    description: Who issued this license?
+                    type: string
+                  licenseExpiration:
+                    description: The expiration timestamp of the license key, after which the operator will cease any reconciliation attempt on the cluster.
+                    format: date-time
+                    type: string
+                  licenseStatus:
+                    description: Current status the license key of the cluster
+                    type: string
+                  repositoryAccess:
+                    description: True if the license embeds a pull secret that can be used to access the repositories
+                    type: boolean
+                  systemUID:
+                    description: When present the license is valid only for the specified Kubernetes cluster
+                    type: string
+                  valid:
+                    description: Whether the license key is valid or not
+                    type: boolean
+                required:
+                - repositoryAccess
+                - valid
+                type: object
+              phase:
+                description: Current phase of the cluster
+                type: string
+              phaseReason:
+                description: Reason for the current phase
+                type: string
+              pvcCount:
+                description: How many PVCs have been created by this cluster
+                format: int32
+                type: integer
+              readService:
+                description: Current list of read pods
+                type: string
+              readyInstances:
+                description: Total number of ready instances in the cluster
+                format: int32
+                type: integer
+              secretsResourceVersion:
+                description: The list of resource versions of the secrets managed by the operator. Every change here is done in the interest of the instance manager, which will refresh the secret data
+                properties:
+                  applicationSecretVersion:
+                    description: The resource version of the "app" user secret
+                    type: string
+                  barmanEndpointCA:
+                    description: The resource version of the Barman Endpoint CA if provided
+                    type: string
+                  caSecretVersion:
+                    description: Unused. Retained for compatibility with old versions.
+                    type: string
+                  clientCaSecretVersion:
+                    description: The resource version of the PostgreSQL client-side CA secret version
+                    type: string
+                  metrics:
+                    additionalProperties:
+                      type: string
+                    description: The versions of all the secrets used to pass metrics
+                    type: object
+                  replicationSecretVersion:
+                    description: The resource version of the "streaming_replica" user secret
+                    type: string
+                  serverCaSecretVersion:
+                    description: The resource version of the PostgreSQL server-side CA secret version
+                    type: string
+                  serverSecretVersion:
+                    description: The resource version of the PostgreSQL server-side secret version
+                    type: string
+                  superuserSecretVersion:
+                    description: The resource version of the "postgres" user secret
+                    type: string
+                type: object
+              targetPrimary:
+                description: Target primary instance, this is different from the previous one during a switchover or a failover
+                type: string
+              targetPrimaryTimestamp:
+                description: The timestamp of the target primary
+                type: string
+              writeService:
+                description: Current write pod
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      scale:
+        specReplicasPath: .spec.instances
+        statusReplicasPath: .status.instances
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/cloud-native-postgresql/1.9.2/manifests/postgresql.k8s.enterprisedb.io_scheduledbackups.yaml
+++ b/operators/cloud-native-postgresql/1.9.2/manifests/postgresql.k8s.enterprisedb.io_scheduledbackups.yaml
@@ -1,0 +1,160 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.7.0
+  creationTimestamp: null
+  name: scheduledbackups.postgresql.k8s.enterprisedb.io
+spec:
+  conversion:
+    strategy: None
+  group: postgresql.k8s.enterprisedb.io
+  names:
+    kind: ScheduledBackup
+    listKind: ScheduledBackupList
+    plural: scheduledbackups
+    singular: scheduledbackup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .status.lastScheduleTime
+      name: Last Backup
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: ScheduledBackup is the Schema for the scheduledbackups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the desired behavior of the ScheduledBackup. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              cluster:
+                description: The cluster to backup
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              immediate:
+                description: If the first backup has to be immediately start after creation or not
+                type: boolean
+              schedule:
+                description: The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+                type: string
+              suspend:
+                description: If this backup is suspended or not
+                type: boolean
+            required:
+            - schedule
+            type: object
+          status:
+            description: 'Most recently observed status of the ScheduledBackup. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              lastCheckTime:
+                description: The latest time the schedule
+                format: date-time
+                type: string
+              lastScheduleTime:
+                description: Information when was the last time that backup was successfully scheduled.
+                format: date-time
+                type: string
+              nextScheduleTime:
+                description: Next time we will run a backup
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .status.lastScheduleTime
+      name: Last Backup
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ScheduledBackup is the Schema for the scheduledbackups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the desired behavior of the ScheduledBackup. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              cluster:
+                description: The cluster to backup
+                properties:
+                  name:
+                    description: Name of the referent.
+                    type: string
+                required:
+                - name
+                type: object
+              immediate:
+                description: If the first backup has to be immediately start after creation or not
+                type: boolean
+              schedule:
+                description: The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
+                type: string
+              suspend:
+                description: If this backup is suspended or not
+                type: boolean
+            required:
+            - schedule
+            type: object
+          status:
+            description: 'Most recently observed status of the ScheduledBackup. This data may not be up to date. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              lastCheckTime:
+                description: The latest time the schedule
+                format: date-time
+                type: string
+              lastScheduleTime:
+                description: Information when was the last time that backup was successfully scheduled.
+                format: date-time
+                type: string
+              nextScheduleTime:
+                description: Next time we will run a backup
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/operators/cloud-native-postgresql/1.9.2/metadata/annotations.yaml
+++ b/operators/cloud-native-postgresql/1.9.2/metadata/annotations.yaml
@@ -1,0 +1,12 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: cloud-native-postgresql
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.1.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1


### PR DESCRIPTION
### Updates to existing Operators

* [X] Did you create a `ci.yaml` file according to the [update instructions](https://github.com/operator-framework/community-operators/blob/master/docs/operator-ci-yaml.md)?
* [X] Is your new CSV pointing to the previous version with the `replaces` property if you chose `replaces-mode` via the `updateGraph` property in `ci.yaml`?
* [X] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#channels) defined in the `package.yaml` or `annotations.yaml` ?
* [X] Have you tested an update to your Operator when deployed via OLM?
* [X] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-prerequisites.md#sign-your-work)?

### Your submission should not

* [X] Modify more than one operator
* [X] Modify an Operator you don't own
* [X] Rename an operator - please remove and add with a different name instead
* [X] Modify any files outside the above mentioned folders
* [X] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [X] Description about the managed Application and where to find more information
2. [X] Features and capabilities of your Operator and how to use it
3. [X] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [X] Human readable name and 1-liner description about your Operator
* [X] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#categories)<sup>1</sup>
* [X] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [X] Links to the maintainer, source code and documentation
* [X] Example templates for all Custom Resource Definitions intended to be used
* [X] A quadratic logo