### PR TITLE
operators [O] prometheus (0.47.0)

### DIFF
--- a/operators/prometheus/0.47.0/prometheusoperator.0.47.0.clusterserviceversion.yaml
+++ b/operators/prometheus/0.47.0/prometheusoperator.0.47.0.clusterserviceversion.yaml
@@ -324,12 +324,17 @@ spec:
             spec:
               containers:
               - args:
-                - --prometheus-instance-namespaces=$(NAMESPACES)
-                - --alertmanager-instance-namespaces=$(NAMESPACES)
-                - --thanos-ruler-instance-namespaces=$(NAMESPACES)
+                - --namespaces=$(TARGET_NAMESPACES)
+                - --prometheus-instance-namespaces=$(OPERATOR_NAMESPACE)
+                - --alertmanager-instance-namespaces=$(OPERATOR_NAMESPACE)
+                - --thanos-ruler-instance-namespaces=$(OPERATOR_NAMESPACE)
                 - --prometheus-config-reloader=quay.io/prometheus-operator/prometheus-config-reloader:v0.47.0
                 env:
-                - name: NAMESPACES
+                - name: OPERATOR_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.operatorNamespace']
+                - name: TARGET_NAMESPACES
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']


### PR DESCRIPTION
thanks to #1045 for mentioning
the operator tries to monitor all namespaces even in single namespace installation.

when the installation will be namespace scoped, the operator should work as previously.
when the operator is installed cluster scoped, he will manage all the `serviceMonitors`, `prometheusRules`... in all namespaces, and the `prometheus`, `alertmanager` instances only in his namespace.

i didnt checked the cluster scoped option yet, but the namespace scoped work as always worked before.
