### PR TITLE
Remove jpkrohling from jaeger

### DIFF
--- a/operators/jaeger/ci.yaml
+++ b/operators/jaeger/ci.yaml
@@ -2,7 +2,6 @@
 # Use `replaces-mode` or `semver-mode`. Once you switch to `semver-mode`, there is no easy way back.
 updateGraph: replaces-mode
 reviewers:
-  - jpkrohling
   - rkukura
   - pavolloffay
   - rubenvp8510


### PR DESCRIPTION
This PR removes me from the list of owners for the Jaeger operator.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

