### PR TITLE
operator [R] keycloak-operator (12.0.1 12.0.3 13.0.0 13.0.1 14.0.0 15.0.0 15.0.1 15.0.2 15.1.0 15.1.1 16.0.0 16.1.0 17.0.0 17.0.1 18.0.0 18.0.1 18.0.2 19.0.0 19.0.1 19.0.2 19.0.3 20.0.0 20.0.0-alpha.1 20.0.0-alpha.2 20.0.0-alpha.3 20.0.0-alpha.4 20.0.0-alpha.5 20.0.0-alpha.6 20.0.0-alpha.7 20.0.1 20.0.2 20.0.3 21.0.0 21.0.1 21.0.2 21.1.0 21.1.1 21.1.2 22.0.0 22.0.1 22.0.2 22.0.3 22.0.4)

### DIFF
--- a/operators/keycloak-operator/12.0.1/manifests/keycloak-operator.v12.0.1.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/12.0.1/manifests/keycloak-operator.v12.0.1.clusterserviceversion.yaml
@@ -347,7 +347,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/12.0.3/manifests/keycloak-operator.v12.0.3.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/12.0.3/manifests/keycloak-operator.v12.0.3.clusterserviceversion.yaml
@@ -347,7 +347,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/13.0.0/manifests/keycloak-operator.v13.0.0.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/13.0.0/manifests/keycloak-operator.v13.0.0.clusterserviceversion.yaml
@@ -347,7 +347,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/13.0.1/manifests/keycloak-operator.v13.0.1.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/13.0.1/manifests/keycloak-operator.v13.0.1.clusterserviceversion.yaml
@@ -353,7 +353,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/14.0.0/manifests/keycloak-operator.v14.0.0.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/14.0.0/manifests/keycloak-operator.v14.0.0.clusterserviceversion.yaml
@@ -346,7 +346,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/15.0.0/manifests/keycloak-operator.v15.0.0.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/15.0.0/manifests/keycloak-operator.v15.0.0.clusterserviceversion.yaml
@@ -346,7 +346,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/15.0.1/manifests/keycloak-operator.v15.0.1.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/15.0.1/manifests/keycloak-operator.v15.0.1.clusterserviceversion.yaml
@@ -346,7 +346,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/15.0.2/manifests/keycloak-operator.v15.0.2.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/15.0.2/manifests/keycloak-operator.v15.0.2.clusterserviceversion.yaml
@@ -349,7 +349,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/15.1.0/manifests/keycloak-operator.v15.1.0.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/15.1.0/manifests/keycloak-operator.v15.1.0.clusterserviceversion.yaml
@@ -349,7 +349,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/15.1.1/manifests/keycloak-operator.v15.1.1.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/15.1.1/manifests/keycloak-operator.v15.1.1.clusterserviceversion.yaml
@@ -349,7 +349,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/16.0.0/manifests/keycloak-operator.v16.0.0.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/16.0.0/manifests/keycloak-operator.v16.0.0.clusterserviceversion.yaml
@@ -346,7 +346,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/16.1.0/manifests/keycloak-operator.v16.1.0.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/16.1.0/manifests/keycloak-operator.v16.1.0.clusterserviceversion.yaml
@@ -346,7 +346,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/17.0.0/manifests/keycloak-operator.v17.0.0.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/17.0.0/manifests/keycloak-operator.v17.0.0.clusterserviceversion.yaml
@@ -346,7 +346,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/17.0.1/manifests/keycloak-operator.v17.0.1.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/17.0.1/manifests/keycloak-operator.v17.0.1.clusterserviceversion.yaml
@@ -346,7 +346,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/18.0.0/manifests/keycloak-operator.v18.0.0.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/18.0.0/manifests/keycloak-operator.v18.0.0.clusterserviceversion.yaml
@@ -346,7 +346,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/18.0.1/manifests/keycloak-operator.v18.0.1.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/18.0.1/manifests/keycloak-operator.v18.0.1.clusterserviceversion.yaml
@@ -346,7 +346,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/18.0.2/manifests/keycloak-operator.v18.0.2.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/18.0.2/manifests/keycloak-operator.v18.0.2.clusterserviceversion.yaml
@@ -346,7 +346,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/19.0.0/manifests/keycloak-operator.v19.0.0.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/19.0.0/manifests/keycloak-operator.v19.0.0.clusterserviceversion.yaml
@@ -347,7 +347,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/19.0.1/manifests/keycloak-operator.v19.0.1.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/19.0.1/manifests/keycloak-operator.v19.0.1.clusterserviceversion.yaml
@@ -347,7 +347,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/19.0.2/manifests/keycloak-operator.v19.0.2.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/19.0.2/manifests/keycloak-operator.v19.0.2.clusterserviceversion.yaml
@@ -347,7 +347,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/19.0.3/manifests/keycloak-operator.v19.0.3.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/19.0.3/manifests/keycloak-operator.v19.0.3.clusterserviceversion.yaml
@@ -347,7 +347,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/20.0.0-alpha.1/manifests/keycloak-operator.v20.0.0-alpha.1.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/20.0.0-alpha.1/manifests/keycloak-operator.v20.0.0-alpha.1.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/20.0.0-alpha.2/manifests/keycloak-operator.v20.0.0-alpha.2.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/20.0.0-alpha.2/manifests/keycloak-operator.v20.0.0-alpha.2.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/20.0.0-alpha.3/manifests/keycloak-operator.v20.0.0-alpha.3.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/20.0.0-alpha.3/manifests/keycloak-operator.v20.0.0-alpha.3.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/20.0.0-alpha.4/manifests/keycloak-operator.v20.0.0-alpha.4.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/20.0.0-alpha.4/manifests/keycloak-operator.v20.0.0-alpha.4.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/20.0.0-alpha.5/manifests/keycloak-operator.v20.0.0-alpha.5.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/20.0.0-alpha.5/manifests/keycloak-operator.v20.0.0-alpha.5.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/20.0.0-alpha.6/manifests/keycloak-operator.v20.0.0-alpha.6.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/20.0.0-alpha.6/manifests/keycloak-operator.v20.0.0-alpha.6.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/20.0.0-alpha.7/manifests/keycloak-operator.v20.0.0-alpha.7.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/20.0.0-alpha.7/manifests/keycloak-operator.v20.0.0-alpha.7.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/20.0.0/manifests/keycloak-operator.v20.0.0.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/20.0.0/manifests/keycloak-operator.v20.0.0.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/20.0.1/manifests/keycloak-operator.v20.0.1.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/20.0.1/manifests/keycloak-operator.v20.0.1.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/20.0.2/manifests/keycloak-operator.v20.0.2.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/20.0.2/manifests/keycloak-operator.v20.0.2.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/20.0.3/manifests/keycloak-operator.v20.0.3.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/20.0.3/manifests/keycloak-operator.v20.0.3.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/21.0.0/manifests/keycloak-operator.v21.0.0.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/21.0.0/manifests/keycloak-operator.v21.0.0.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/21.0.1/manifests/keycloak-operator.v21.0.1.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/21.0.1/manifests/keycloak-operator.v21.0.1.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/21.0.2/manifests/keycloak-operator.v21.0.2.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/21.0.2/manifests/keycloak-operator.v21.0.2.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/21.1.0/manifests/keycloak-operator.v21.1.0.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/21.1.0/manifests/keycloak-operator.v21.1.0.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/21.1.1/manifests/keycloak-operator.v21.1.1.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/21.1.1/manifests/keycloak-operator.v21.1.1.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/21.1.2/manifests/keycloak-operator.v21.1.2.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/21.1.2/manifests/keycloak-operator.v21.1.2.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/22.0.0/manifests/keycloak-operator.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/22.0.0/manifests/keycloak-operator.clusterserviceversion.yaml
@@ -202,7 +202,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/22.0.1/manifests/keycloak-operator.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/22.0.1/manifests/keycloak-operator.clusterserviceversion.yaml
@@ -202,7 +202,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/22.0.2/manifests/keycloak-operator.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/22.0.2/manifests/keycloak-operator.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/22.0.3/manifests/keycloak-operator.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/22.0.3/manifests/keycloak-operator.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse

--- a/operators/keycloak-operator/22.0.4/manifests/keycloak-operator.clusterserviceversion.yaml
+++ b/operators/keycloak-operator/22.0.4/manifests/keycloak-operator.clusterserviceversion.yaml
@@ -208,7 +208,7 @@ spec:
     - Access
   links:
     - name: Documentation
-      url: https://www.keycloak.org/docs/latest/server_installation/index.html#_operator
+      url: https://www.keycloak.org/guides#operator
     - name: Keycloak
       url: https://www.keycloak.org/
     - name: Keycloak Discourse


### PR DESCRIPTION
Before this patch, clicking on the documentation link resulted in a 404 Not Found on Github pages.

With this change, the documentation link points to the "Operator" anchor in the Keycloak docs index. Note that the operator docs don't seem to be versioned on the Keycloak website.

This patch is the result of:

```sh
find . -name '*keycloak-operator*.yaml' -exec sed -i 's|\(\s\+url: \)https://www.keycloak.org/docs/latest/server_installation/index.html#_operator\s*$|\1https://www.keycloak.org/guides#operator|' {} \;
```