### PR TITLE
operator [CI] external-secrets-operator

### DIFF
--- a/operators/external-secrets-operator/ci.yaml
+++ b/operators/external-secrets-operator/ci.yaml
@@ -5,3 +5,7 @@ reviewers:
   - moolen
   - knelasevero
   - gusfcarvalho
+  - sebagomez
+  - IdanAdar
+  - shuheiktgw
+  - skarlso


### PR DESCRIPTION
This PR updates the maintainers list of External Secrets Operator

WRT: https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/3541