### PR TITLE
3641: made stale issues never close

### DIFF
--- a/.github/workflows/stale_issues.yaml
+++ b/.github/workflows/stale_issues.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/stale@v3
         with:
           days-before-issue-stale: 30
-          days-before-issue-close: 30
+          days-before-issue-close: -1
           stale-issue-label: "lifecycle/stale"
           stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 30 days since being marked as stale."


### PR DESCRIPTION
To address #3641 this PR modifies the stale issue workflow to never close issues. This configuration might not be ideal for maintainers but I didn't want to impose any changes without more feedback.

I believe the stale bot is a very important part of maintaining this repository. One alternative configuration I might suggest is only allowing the stale bot to close issues or mark them as stale after they have been triaged by a maintainer. This could be achieved using the only-labels or exempt-labels options in the workflow. 

For only-labels a maintainer would have to add a `needs-information` type label. If a user doesn't respond in 30 days when this label is active then the issue would be stale. This pattern is similar to one I've seen in Mozilla Firefox issue tracker. This setup favors issue creators but might put more workload on maintainers. 

For exempt-labels new issues would get a label like `needs-triage`. This could be achieved with an auto labeler workflow. Then once a maintainer responds the label could be removed. This setup would favor maintainers but might potentially cause legitimate issues waiting for maintainer action to be closed.

Options I haven't investigated include some sort of auto-assigner which tries to assign a maintainer to an issue based on the relevant component. 