### PR TITLE
operator [CI] rabbitmq-messaging-topology-operator

### DIFF
--- a/operators/rabbitmq-messaging-topology-operator/ci.yaml
+++ b/operators/rabbitmq-messaging-topology-operator/ci.yaml
@@ -5,4 +5,4 @@ addReviewers: true
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
-  - DanielePalaia
+  - Zerpet


### PR DESCRIPTION
Updating `ci.yaml` for rabbitmq-messaging-topology-operator, since Daniele is leaving the project.