### PR TITLE
operator temporal-operator (0.21.0)

### DIFF
--- a/operators/temporal-operator/0.21.0/bundle/manifests/temporal-operator-webhook-service_v1_service.yaml
+++ b/operators/temporal-operator/0.21.0/bundle/manifests/temporal-operator-webhook-service_v1_service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: temporal-operator
+    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: temporal-operator
+  name: temporal-operator-webhook-service
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/temporal-operator/0.21.0/bundle/manifests/temporal-operator.clusterserviceversion.yaml
+++ b/operators/temporal-operator/0.21.0/bundle/manifests/temporal-operator.clusterserviceversion.yaml
@@ -1,0 +1,522 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "temporal.io/v1beta1",
+          "kind": "TemporalCluster",
+          "metadata": {
+            "name": "prod",
+            "namespace": "demo"
+          },
+          "spec": {
+            "jobTtlSecondsAfterFinished": 300,
+            "numHistoryShards": 1,
+            "persistence": {
+              "defaultStore": {
+                "passwordSecretRef": {
+                  "key": "PASSWORD",
+                  "name": "postgres-password"
+                },
+                "sql": {
+                  "connectAddr": "postgres.demo.svc.cluster.local:5432",
+                  "connectProtocol": "tcp",
+                  "databaseName": "temporal",
+                  "pluginName": "postgres",
+                  "user": "temporal"
+                }
+              },
+              "visibilityStore": {
+                "passwordSecretRef": {
+                  "key": "PASSWORD",
+                  "name": "postgres-password"
+                },
+                "sql": {
+                  "connectAddr": "postgres.demo.svc.cluster.local:5432",
+                  "connectProtocol": "tcp",
+                  "databaseName": "temporal_visibility",
+                  "pluginName": "postgres",
+                  "user": "temporal"
+                }
+              }
+            },
+            "ui": {
+              "enabled": true
+            },
+            "version": "1.24.3"
+          }
+        },
+        {
+          "apiVersion": "temporal.io/v1beta1",
+          "kind": "TemporalClusterClient",
+          "metadata": {
+            "name": "my-worker",
+            "namespace": "demo"
+          },
+          "spec": {
+            "clusterRef": {
+              "name": "prod"
+            }
+          }
+        },
+        {
+          "apiVersion": "temporal.io/v1beta1",
+          "kind": "TemporalNamespace",
+          "metadata": {
+            "name": "accounting"
+          },
+          "spec": {
+            "clusterRef": {
+              "name": "prod"
+            },
+            "description": "Accounting team namespace",
+            "retentionPeriod": "168h"
+          }
+        },
+        {
+          "apiVersion": "temporal.io/v1beta1",
+          "kind": "TemporalSchedule",
+          "metadata": {
+            "name": "demo",
+            "namespace": "demo"
+          },
+          "spec": {
+            "allowDeletion": true,
+            "namespaceRef": {
+              "name": "demo"
+            },
+            "schedule": {
+              "action": {
+                "workflow": {
+                  "id": "Demo",
+                  "taskQueue": "SomeWorkflowQueue",
+                  "type": "SomeWorkflow"
+                }
+              },
+              "spec": {
+                "intervals": [
+                  {
+                    "every": "10m"
+                  }
+                ]
+              },
+              "state": {
+                "paused": false
+              }
+            }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Application Runtime, Developer Tools, AI/Machine Learning
+    containerImage: ghcr.io/alexandrevilain/temporal-operator
+    createdAt: "2025-04-03T09:32:19Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.37.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+  name: temporal-operator.v0.21.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: A TemporalClusterClient creates a new mTLS client in the targeted
+        temporal cluster.
+      displayName: Temporal Cluster Client
+      kind: TemporalClusterClient
+      name: temporalclusterclients.temporal.io
+      version: v1beta1
+    - description: TemporalCluster defines a temporal cluster deployment.
+      displayName: Temporal Cluster
+      kind: TemporalCluster
+      name: temporalclusters.temporal.io
+      version: v1beta1
+    - description: A TemporalNamespace creates a namespace in the targeted temporal
+        cluster.
+      displayName: Temporal Namespace
+      kind: TemporalNamespace
+      name: temporalnamespaces.temporal.io
+      version: v1beta1
+    - kind: TemporalSchedule
+      name: temporalschedules.temporal.io
+      version: v1beta1
+  description: |
+    ## Temporal
+    Temporal is a durable workflow execution environment for applications. The Temporal operator will deploy all required Temporal server services and dependencies. You will need to deploy database, elasticsearch (optional) and prometheus/grafana (optional) separately. Temporal supports native MySQL, PostgreSQL or Cassandra databases.
+
+    ## Quick Setup
+    Follow these steps to deploy a Temporal cluster instance with a test PostgreSQL database.
+
+    ### Create Demo Namespace
+    <pre>
+    $ kubectl apply -f https://raw.githubusercontent.com/alexandrevilain/temporal-operator/main/examples/cluster-postgres/00-namespace.yaml
+    </pre>
+
+    ### Deploy PostgreSQL database
+    <pre>
+    $ kubectl apply -f https://raw.githubusercontent.com/alexandrevilain/temporal-operator/main/examples/cluster-postgres/01-postgresql.yaml
+    </pre>
+
+    ### Create TemporalCluster CustomResource
+    <pre>
+    $ vi temporalcluster.yaml
+    apiVersion: temporal.io/v1beta1
+    kind: TemporalCluster
+    metadata:
+      name: prod
+    spec:
+      jobTtlSecondsAfterFinished: 300
+      numHistoryShards: 512
+      persistence:
+        defaultStore:
+          passwordSecretRef:
+            key: PASSWORD
+            name: postgres-password
+          sql:
+            connectAddr: 'postgres.demo.svc.cluster.local:5432'
+            connectProtocol: tcp
+            databaseName: temporal
+            pluginName: postgres
+            user: temporal
+        visibilityStore:
+          passwordSecretRef:
+            key: PASSWORD
+            name: postgres-password
+          sql:
+            connectAddr: 'postgres.demo.svc.cluster.local:5432'
+            connectProtocol: tcp
+            databaseName: temporal_visibility
+            pluginName: postgres
+            user: temporal
+      ui:
+        enabled: true
+      version: 1.24.3
+    </pre>
+
+    ### Apply TemporalCluster CustomResource
+    <pre>
+    $ kubectl apply -f temporal.yaml -n demo
+    </pre>
+  displayName: Temporal Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAMgAAADICAIAAAAiOjnJAAAbZklEQVR4nOydeVRU5/3/7wzDFlRUkH0TBILD5rBDBQZEI1s1tEnDIjmApz1t3AJGTBfNObVp2vSoTRMCRaOJ0h4VqwKGsDhADKvsoKK4YEC2ASSHbWZg5nfKfJv4M3M/s917Z+6d+/r388zzvGXePvfOs3w+TISGBgdoY9HgAm0sGlygjUWDC7SxaHCBNhYNLtDGosEFlqYFaDVGRkZbtmwJCQlxc3Nbu3YtgiCTk5P37t1raGioqqpaWFjQtEAasrF9+/aamprvQHg83iuvvKJppVoKQ9MCtI7Q0NDCwkI7OzsF2w8ODmZlZdXX1+Osi2TQxvoBFotVWFj46quvqvDZ4uLi3bt3Ly4u4qCLlNDG+j9sbGxu3LhhY2Ojcg9Pnz7lcrnDw8OY6iIrtLH+C5vN5vF4RkZGavazsLDA5XJ7e3sx0kViaGMhXl5etbW1LBY2P5AXFxfDw8N7enow6Y286LqxHB0db926ZWhoiGGfAoHAz8/vyZMnGPZJOnTaWCYmJr29vdIFKmyZmJhgs9lzc3OY90wWdHrlvaysTEFX8fn8r5bh8/mKtDczMysrK1NbIA0J+d3vfgevf0opLy93dXV9/oOurq7l5eWKfPa3v/2t5v59GkZHH4VsNruhoQFuI5FIfvWrX/3rX/+SGU1OTs7Ly2Mw5PwBQ0JCdPNHoo4a6+7du/CSlUgkio6O7ujoANps2rSpqqpKX18faDM0NOTh4aGGUrKii+9Yhw8fhl0lFou5XC7sKgRB2tvbo6KixGIx0MbW1jY3N1dVpSRG52YsMzOzBw8eMJnQ/6jXX3/9yy+/VLDD2NjYf//730ADsVjs4uIyMTGhpFJyo6dpAUTz2Wefubm5AQ0++uij/Px8xTu8f//+ypUrAwMD0RowGAxXV9fi4mIllZIb3Zqx3N3dW1pagAb379/38/NToefW1tYXfjy+gL+//71791TomaTo1jvWP/7xDyAqkUh27typWs+vvvqqRCJReWjqoUPGYrPZQUFBQIPjx4+rvA8zMDBw4sQJoEFwcPDGjRtV65yM6NCjsKysbPPmzWjR6elpR0dH+CceDJPJHBgYMDU1RWtQV1cXHx+vcv/kQldmLDs7O8BVCIK8/fbb6rhK+usvOzsbaBAeHq74wVSyoyvG+sMf/gBEBwcHL168qP4oFy5cGBwcBBr8/ve/V38UUqATj0JDQ8OxsTFg++UXv/jF9evXMRkrLi4ObRdIOqtZWloKBAJMxtJmdGLG2r17N+Cq4eFhrFwlfZMDTiczmcysrCysxtJmdMJY+/btA6JHjx7Fdrj33nsPiO7fvx/b4bQT6j8Kvb29b968iRadm5uzsrLCfNDR0VFjY2O0aFhYWHd3N+aDahXUn7H27NkDRD/++GM8BoW7hSVRA4rPWAwGY2JiArgoYW9vPz09jfm4pqam3377LVp0cXERj/PQWgXFZ6xt27YBrqqrq8PDVdLlVuD5y2Kxtm3bhse42gPFjZWZmQlET548id/Q8A4PLIwCUPlRyGAwpqam0I5eCQSCdevW4SpgfHwc7WKZWCxes2YNvG9Naqg8Y8XExAAH+uDTeZhw4cIFtBCTydyyZQveAjQIlY2VnJwMRAsLC/EW8M9//hOIwvLIDpUfhXw+38DAQGZodnbW2tqaAA3Dw8MmJiYyQwQ8izUIZWcsNpuN5ir4IYUtwN62oaEhhU9oUdZYSUlJQPT8+fPEyIAHgkWSGso+Ctvb211cXGSGCF6fnJycRFtL6+/v53A4hCkhEmrOWPr6+miuQhCkqqqKSDHV1dVooQ0bNsD3XckLNY0VGRkJRAm+iQUPFxERQaAW4qCmseLi4oBoaWkpgVrkDAdLJS/UNBaQJXt4eHh2dpZIMTMzMyMjI2hRqib0pqCxWCwWkJpBI2mrgEFtbW2xylKpVVDQWD/5yU+AqOJJGTAEHjQsLIxALQRBQWNxuVwgWltbS6CW/6OmpgaIwoJJCgWNBfwkHBkZEQqFxMr5L0KhcHR0FC0K/4YlKRQ0lo+PD1oIWFLCG2BoX19fYrUQAdWMZWNjAxyV4fF4xMr5gRs3bqCFmEwmMTviREI1Y4WGhgJR+F0HV+B3O1g2GaGasYBfWEtLS2NjY8TK+YHR0VEgNwT1fhhSzVhAoqLOzk5itSghAM6vREaoZizghJPGSwoCAthsNrFacIdSxjI1NQXe3JuamoiVo4QAJpO5atUqYuXgC6WMtWnTJiDa3NxMoBalBVDsYBaljAV/NxovUfn06VMgCv+vIB2UMhbw3WhJkTfg3j1tLO3Fy8sLLdTe3k6sFtkAMgDxZIRSxlq/fj1aSONrDVIAGc7OzsRqwRfqGMvY2BhI29fV1UWsHNkAMhgMhvpFqbUH6hwxe/nll4GozCLNLBZr7dq1pv9jxTImJiZGRkbGxsaGhob6y7BYLOYy0pwLYrF4cXFRtIxAIJifn19YWJidnZ1ZZvp/TE5OLi4uKiLj+X+C3MpQZIE6xoKrt2VnZ1tbW1tZWVlaWlpYWGBbBBpGIBCMjY2Njo4ODw8DZ5Sl/wTKGIsK9wrt7Ow8PDx++ctfbt26VdNa1KKioiI/P//OnTtwTm9SQDJj6enpeXh4cDgcX19fb29vNpuNlhmB7MzOzvb09HR3d7cvc/v2bTXrGxCMthvL2Ng4ODg4NDQ0KCjI399/xYoVmlakMWZmZlpaWpqbm+vr6xsbG+fn5zWtCEIbjeXl5cXlciMjI8PCwoDcwzrO/Pz8zZs3a2pqeDwe/JtAI2iLsfz8/OLi4rZt2+bp6Sm3gjfNC0gkkp6envLy8rKysra2Nk3LQTRsLBsbm6SkpB07dvj7+9NmwgqJRNLS0nLlypXLly/Du5O4ooGvMyAgIDk5+Wc/+xlQgY0GE6anpy9dulRUVATXlcUD4owVHBycmZm5c+dOIB+aliCRSIRCoUAgEIlEQqFwaWlJui4qPTjFZDL19PQMDAz09fUNDQ0NDAy0f7oVCoX/+c9/Tp061djYSMyIuP9FnJyc3nrrrdTU1JdeegnvsdAQi8Wjo6NPnz4dHh4eXWZ8fHxiYoLP509NTT1bBquEDi+99NKaNWtWr169Zs0aMzMzc3PzdevWWS5jbW1tY2NjaWkJ19DHlbm5uS+++OLjjz9+/PgxrgPhZSwmk5mSkpKdna3xvdXJyUknJyfNavgxK1euXL9+vfP/cHFx2bBhg4WFBWGT38OHD//2t7+dP38ep+Ux7P8Z5ubmubm5GRkZuOa6mJ2d7ezs7Ojo6O7u7unpeffdd7dv3y6zZXd3N4nuwBgYGLz88suenp5eXl6+vr4+Pj64Lt2JRKLTp0//+c9/npiYwLZnLI21fv36999/PzY2FsM+v+fJkyf19fVNTU3Nzc29vb0v/D+rqqoKDAyU+cHy8vLXXnsND0nEwGQyN27cGBgYGBQUFBoa6ujoiMcoZWVlhw8fxvD5iI2xHBwcTp48GR0djUlvUubm5urq6ng8Xm1t7e3bt+HGvb299vb2MkNnzpzZu3cvhsI0joeHR0REBJfLDQ8Px3ZHq6qqav/+/ZictlXXWKtWrTp+/PjPf/5z9aVIH3AVFRXXr1+vqKiYmppS/INASvcPPvjg2LFjmMjTQtasWRMTExMbG7t161asHpoXL148cODAd999p04nahlr3759R48e1dPTU6cT6YJecXHxlStXVL7vAPwVDhw4cOrUKTUEkgYrK6sdO3YkJSUFBgaq+SNgaWnpyJEjf//731XuQcXh3dzcLl26pM6vrcXFxbKysnPnzlVWVqr/wwQwVlpa2tWrV9Xsn1xIC/WkpKTEx8erk5X58ePHSUlJ9+/fV0WDCp85ePBgS0uLaq4Si8XXrl1LSEhYu3ZtWlraV199pb6r4BO9fD5fzf5Jh1gsrqioSE9PNzMzi4+Pv3r1qmp/ZCcnp1u3buXk5KjwWeVmLGNj42vXrqmWaKCrq+vEiROXL1/GfOHE1tb2zp07aNGAgIC+vj5sRyQdTCZz586d+/fvB5KHATQ1NSUmJip1UEcJY9nb29fW1pqbmyulSSQSffbZZx9++CF8KlcdvLy8vvnmG7Tohg0bNJhkRtuwsrLKzs7OyMhQ9hHJ5/MjIiKAe5EvoOij0NPTs62tTSlXTU1N5eTkWFhY5OTk4OcqacoGIPrs2TP8hiYdIyMjBw8elH4pk5OTin/Q3Ny8tbVV8eQlChnL09Ozrq5O8QsI4+PjWVlZjo6OBQUFS0tLCn5KZWBjaSTpqJaztLRUUFDg5OSUmZk5Pj6u4KeMjIy+/vprBb0l31h2dnY8Hk/B/ZnZ2dm9e/e6uLgQVrdNrrFoAC5evOji4rJnzx4F9+BZLBaPx7O1tZXbUo6xDAwMeDyegnPVp59+6uDgcObMGUUaY4guH4THhLNnz9rb2+fl5SnS2MjIiMfjyX1Fk2Oss2fPWlpayh3s8ePHHA7nnXfeEYlEiojDFsBY5LrZokEWFxcPHTrE4XAePXokt7GVldXZs2fhNpCxoqOjFSkhVFBQ4O3t3d/fL7clTgD7ZVp+lUXb6O/v9/Hxyc/Pl9syPj4+KioKaAAZq6CgAO5dLBYnJyertoCGIcBNHtpYKnDw4MHk5GS5kz1sD1Rjvfbaa3ApbJFIFBkZSXCJNpkAK++0sVSjtLQ0IiICfrGxsLAADh+gGis3NxfoVCwWR0VFaUmiAcBY9FqDynR2dnK5XHjeAkwi21hmZmYbNmwAeszMzNSSjFPSQr1oIdpY6tDV1ZWRkQE0cHV1RauuLdtY8fHxQHfV1dUEV7+FAYylkV+pVOLy5ctwCW00q8g2FnxI/De/+Y2S8vAFWLz9cYYqGmV56623gCiaVWQby93dHa2j/v5+Dd6vlQlwm4pex1Kfp0+fAkey0Kwi+ysBNpsbGhpUkocjgLEkEgmxWqgJ8KWjWUX2VwIcbCXXWwttLEwA3ijQrCLbWMBFBi1MRw487zR455hKAF86mlVk/92B/ZlNmzatXLlSJXl4AUxLtLHUZ+XKlYCx0Kwi++8O1zPStttUwESt5g0iGgRB/vSnPwFRNKvINlZZWRnQ15tvvunn56ekPBwBXvvUuaNCgyCIv79/eno60ADNKrKNNTAwAB8sLC0ttbCwUFIkXgDG0v6USdqMpaUlvBc8NjaGdm0a9RXk+PHjQI8mJiZNTU3wLjVhCAQCtBBtLJWxsLBobGyEk08BJkE1Vl5eHnw0wMzMrKOjA64HQQyATjo3rmpISxmYmZkBbebn5z/99FO0KKqxlpaWDh06BA+/cuXKxsbGlJQUxdTixcLCAlqINpYKpKamNjQ0yD3w/c477wA3ZaBf42fOnJFb24jJZObl5RUXF2swkT9wEYA2llKYmJhcvnz5k08+kbtM09nZCZ9OlvP5xMREYD74npiYmEePHr3xxhtyW+LBzMwMWoheblCclJSUR48ebdmyRW7L+fn5n/70p3AbOcaanJyMi4tTZGPEyMgoPz//1q1bxC/NA8aiUQQOh9Pa2pqXl6dIXTuJRBIfHy/3sqv8hemWlpbU1FQFJbq5udXW1paXlxP5Uq9mJiddxsPDo6KioqamxtXVVcGPpKSkKJLcW6Edj5KSkrS0NMU3dENDQ5ubm4H0jdgyPT0NROmnoUyCgoKqq6ubmpqCg4MV/IhEIklNTVXwloOiW2lXr16Ni4tT6txcYGBgVVVVT09PSkoKrnt2cHaG1atX4zc06WAymampqb29vZWVlQEBAYp/UCQSxcXFXbt2TcH2yqUxcnBwqKqqsrKyUupTUllFRUUnT57E4/qhg4MDUKWIw+Fo8M6j9uDq6rpv377k5GQVslmPjIxs2bJFqdykyk0kT548YbPZJSUlyirT19dPT09va2u7e/dudnY2vPKmLHAqaWXzLlEMMzOznJycvr6+1tbWXbt2qeCqkpISNputbMZbFVNFJiQkFBYWqrNK9PDhw88//7yoqAiTDEfA+/sbb7wB76lTEmtr6+Tk5F27dgGV/eUyPz+flZWlwjyiVnJbY2PjTz75JCkpSeUepPD5/OJl1CnzAhhr7969xOcp0RQhISFJy6j/TCguLv71r3+t8o1fddNxe3p6nj59GpPFBWn65NLS0i+//FLZ5I6Tk5Nok/yxY8c++OAD9eVpLe7u7rGxsXFxcQEBAZhUTLl7925GRoaaxTWxKSDwyiuvnDhxwsbGBpPepKeNW1tbq6ureTxec3Oz3OxtfX191tbWMkOFhYVvv/02VsK0AT09vcDAQC6XGx0d7efnh+Ev7qGhoQMHDpSXl6vfFZYlTxISEt5//30HBwcM+5TC5/O/+eabhoaGxsbGrq6uH6961NTUcDgcmZ8tLS1NTk7GXBKRsFgsHx8facmTsLAwbH/6SBkYGHj33XdVe52SCfZFmsLCwt577z1cl0bn5uY6Ojra29s7Ozu7urr6+vrOnTuHlnGpvb09IiICPzGYw2Kx3N3dpUWapOBaka+5ufnIkSNAdmDVwKuImY2NTU5Ozq5duzR+1G5sbAzOQ6Ep9PT0HBwcvi8r5+Li4urq6ujoSMxWgVAo/Pzzzz/88EOcrh/jWx2PwWAkJibu2bOHmL0dmUgkEm1LUjowMLBmzRpNjd7c3PzRRx9du3YN10uXBJVdXLFiRVpaWkZGBnB5Hz9WrVpF/KAAGtk17+vrO3Xq1Llz54g5DEJ0MWNTU9PXX389OTkZ7V0bD7SqhoC5ufnDhw8JG66tre38+fMXLlyAt+oxR2NVslks1tatW5OSkmJjY/E+fRoTEwPflCSSgICA6upqXIeYnZ29fv16cXFxRUWFpvLt4FhdF2ZxcfH6MtL9B+kSX3h4OB4v+87OztpjLJyKZAuFwrq6urKysuvXr6tcnQ9DNGas5xkeHj61jDTVc0xMDJfLjYyMxGr/WOMFz5/HxcUFq67Gx8dra2t5PF5lZSWuRWVUQCuM9TwjIyNfLCN9XHI4nLBlAgMDVT5ZpVXLDeoYa2pqqqWl5Ztl2tratDmtnMbesVSAwWBs3LiRw+FsWobNZityRhtBkI6OjvDwcPwFKgSwSfACCwsLvb297cu0tbXdvn2bRFmZyGSsH8NgMJydnT2W2bFjh5eXl8xmMzMzGO5jqsng4CDa8kd3d/eVK1fuLPPw4UMS2ejHkNtYz/Pmm28CNYy1ZykLWMTas2eP3FIiZIE66aPu3r0LRLXkHCla8mopQJ1Y0kEdY8HfiqenJ4FaUIFlwP83yAV1jAWvLKO9fhGMt7c3EKXSBUnqGEuaOBot5OvrS6wW2QC1voeGhojVgi+UMhaQwkRLjAXkH5Cbf4VcUMpYQNEoLVkjBW6ya0nFK6yglLHa29vRQgwGQ4NHoKSsXr0auOzQ1tZGrBx8oZSx4O9Gg4cNFREA/K8gI5Qy1ujoKLBarXj2C5wICgpCC0kkEu05MYYJlDKW9II1WigkJIRYLUoIePDgAbFacIdqxgLOXfn7+xOr5UWA7C7ac1wMK6hmrPr6erSQgYGBBm9VrFq1ytDQEC0KyCYpVDMWfD9u8+bNBGpRYmjMr/VpHKoZC35ZiYqKIlDL/weXywWiRF6vIAaqGUt6zwktpEFjRUdHo4WotPf8PRQ0Vk1NDVrI2dlZI4XmGAwGcCIZEExedMtYmlrNggeljUUOeDweEN2+fTuBWhQalDYWOZibmwNKD8fHxxMr57+gZcKRpoybm5sjVg4RUNBYCIJUVlaihVxcXAiujqmvrw8cagCkkhpqGgvOZrt161YCtSBwdRqqJt6lprEqKiqAqPoJeZUCHo6qMxZ1rn+9wP379y0tLWWG5ufn0UJ4MDIygpaSb2RkxM3NjTAlRELNGUtaowUtZGxs7OHhQYwMd3d3INEjIJLsUNZYxcXFQJSwqrDwQLBIUkPZR6G0eBPaOjufzycmBc2DBw/QSrKLxWIKF5Ci7IwFr5Sam5urUwtEQRwdHYFC/zdu3MBbgAahsrGKioqAaFZWFt4C4CFgeWSHyo9CAwMDPp+PFp2enra3t8dVwJMnT4CHnbm5uVAoxFWABqHyjCUUCoEjv6amprgeVvbz8wNc1djYSGFXUdxYCIKcPn0aiO7fvx+/offt2wdEYWEUgMqPQuk+HZ/PR7smKpFILCwsBAIB5uMaGBiMj48D45qbm4tEIszH1R4oPmOJRKKqqiq0KIPBwOkVPjMzE7j0XFlZSW1XUX/Gkh42Bxa4cVrQApavEARJTEyk5Bms56H4jCVdzQKKfJibm8fExGA7YnR0NOCqmZkZyrtKJ4yFIEhBQQEQ/eMf/4jtcMeOHQOi+fn52A6nnVD/UShN8wIXYY+Kirp16xYmY3E4HHhCcnBwePbsGSZjaTM6MWM9e/YMeIVHEOTEiRNYjXXy5EkgWlVVpQuu0hVjIQhy9OhRIOrt7Y3JJemwsDAgGSSCIEeOHFF/FFKgE49CKU1NTcAxrG+//ZbNZqs5RE9PD1AS+86dO0AmI4qhKzMWgiC5ublA1N7efvfu3er0n5mZCRdaP3TokDr9kwsdmrGkWfOAG8kikcjZ2Vm1gpGrVq169OgRcP+nv7+fyNqfGkeHZiwEQfbu3QtE9fX1VT7KUlRUBN8qg4emHrplrK+//hpO9bl582YVNnkyMjLg6mLt7e03b95UtltSo1uPQmlebjgHrkQiCQsL6+npUbBDNptdX18P7AxKF7f6+/uVVEpudGvGkr7rnDt3DmjAYDAqKysVvB9mYWFRWVkJu+qLL77QNVfp4oyFIIihoeHjx4/hCueTk5NBQUGjo6NAGwsLi6amJjMzM6DNzMyMk5MTtc/0yUTnZiwEQQQCQXp6Otxm7dq1HR0dQIUSX1/fjo4O2FUIgqSnp+ugq3TUWNI7+HLv9JmYmNTW1v71r399oUCwkZHRX/7yl7q6uhUrVsA9XLp0iao36OWii49CKXp6ej09Pba2tnJbSiSSmpqalpYWaUrtyMhI+KVKytDQkKen59LSEkZ6SYbuGgtBEDs7u87OTjyyGgmFQh8fH4pVilMKHX0UShkcHExISMC8prdEIklISNBlV+m6saSZ+9PS0rDtMzU1taGhAds+SYeepgVonr6+vt7e3p07dyry5gQjkUhSU1NLSkowkkZidPod63mCg4NLSkqAqiRyEQgE8fHx1KuKoxq0sX5g3bp1paWlqqXOunPnTnx8/Pj4OA66SImuv2M9z/j4eFBQUG5urlJLmkKh8NChQ0FBQbSraORgaGh4+PDhoaGh70CGhoZyc3PVeXpSGPpRCOHj45OYmBgSEuLq6irdvZmYmLh3715DQ0NJSUlnZ6emBdLQ6Bj0OxYNLtDGosEF2lg0uEAbiwYXaGPR4AJtLBpc+H8BAAD//0CespDBZHwPAAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - get
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates
+          - issuers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - networking.istio.io
+          resources:
+          - destinationrules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - security.istio.io
+          resources:
+          - peerauthentications
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - temporal.io
+          resources:
+          - temporalclusterclients
+          - temporalclusters
+          - temporalnamespaces
+          - temporalschedules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - temporal.io
+          resources:
+          - temporalclusterclients/finalizers
+          - temporalclusters/finalizers
+          - temporalnamespaces/finalizers
+          - temporalschedules/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - temporal.io
+          resources:
+          - temporalclusterclients/status
+          - temporalclusters/status
+          - temporalnamespaces/status
+          - temporalschedules/status
+          verbs:
+          - get
+          - patch
+          - update
+        serviceAccountName: temporal-operator-controller-manager
+      deployments:
+      - label:
+          control-plane: controller-manager
+        name: temporal-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --leader-elect
+                command:
+                - /manager
+                image: ghcr.io/alexandrevilain/temporal-operator:v0.21.0
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: temporal-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+              volumes:
+              - name: cert
+                secret:
+                  defaultMode: 420
+                  secretName: webhook-server-cert
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: temporal-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - durable
+  - execution
+  - workflow
+  - sdk
+  - application
+  - distributed
+  links:
+  - name: Temporal Operator
+    url: https://github.com/alexandrevilain/temporal-operator
+  maintainers:
+  - email: alexandre.vilain@me.com
+    name: alexandrevilain
+  - email: keith.tenzer@temporal.io
+    name: ktenzer
+  maturity: alpha
+  minKubeVersion: 1.22.0
+  provider:
+    name: Temporal Community
+    url: https://temporal.io/
+  replaces: temporal-operator.helm-chart-0.6.0
+  version: 0.21.0
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: temporal-operator-controller-manager
+    failurePolicy: Fail
+    generateName: mtemporalc.kb.io
+    rules:
+    - apiGroups:
+      - temporal.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - temporalclusters
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-temporal-io-v1beta1-temporalcluster
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: temporal-operator-controller-manager
+    failurePolicy: Fail
+    generateName: vtemporalc.kb.io
+    rules:
+    - apiGroups:
+      - temporal.io
+      apiVersions:
+      - v1beta1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - temporalclusters
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-temporal-io-v1beta1-temporalcluster

--- a/operators/temporal-operator/0.21.0/bundle/manifests/temporal.io_temporalclusterclients.yaml
+++ b/operators/temporal-operator/0.21.0/bundle/manifests/temporal.io_temporalclusterclients.yaml
@@ -1,0 +1,94 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  creationTimestamp: null
+  name: temporalclusterclients.temporal.io
+spec:
+  group: temporal.io
+  names:
+    kind: TemporalClusterClient
+    listKind: TemporalClusterClientList
+    plural: temporalclusterclients
+    singular: temporalclusterclient
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: A TemporalClusterClient creates a new mTLS client in the targeted
+          temporal cluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TemporalClusterClientSpec defines the desired state of ClusterClient.
+            properties:
+              clusterRef:
+                description: Reference to the temporal cluster the client will get
+                  access to.
+                properties:
+                  name:
+                    description: The name of the temporal object to reference.
+                    type: string
+                  namespace:
+                    description: |-
+                      The namespace of the temporal object to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+            required:
+            - clusterRef
+            type: object
+          status:
+            description: TemporalClusterClientStatus defines the observed state of
+              ClusterClient.
+            properties:
+              secretRef:
+                description: Reference to the Kubernetes Secret containing the certificate
+                  for the client.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              serverName:
+                description: ServerName is the hostname returned by the certificate.
+                type: string
+            required:
+            - serverName
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/temporal-operator/0.21.0/bundle/manifests/temporal.io_temporalclusters.yaml
+++ b/operators/temporal-operator/0.21.0/bundle/manifests/temporal.io_temporalclusters.yaml
@@ -1,0 +1,4528 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  creationTimestamp: null
+  name: temporalclusters.temporal.io
+spec:
+  group: temporal.io
+  names:
+    kind: TemporalCluster
+    listKind: TemporalClusterList
+    plural: temporalclusters
+    singular: temporalcluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type == 'Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type == 'ReconcileSuccess')].status
+      name: ReconcileSuccess
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: TemporalCluster defines a temporal cluster deployment.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Specification of the desired behavior of the Temporal cluster.
+            properties:
+              admintools:
+                description: AdminTools allows configuration of the optional admin
+                  tool pod deployed alongside the cluster.
+                properties:
+                  enabled:
+                    description: Enabled defines if the operator should deploy the
+                      admin tools alongside the cluster.
+                    type: boolean
+                  image:
+                    description: Image defines the temporal admin tools docker image
+                      the instance should run.
+                    type: string
+                  overrides:
+                    description: Overrides adds some overrides to the resources deployed
+                      for the ui.
+                    properties:
+                      deployment:
+                        description: Override configuration for the temporal service
+                          Deployment.
+                        properties:
+                          jsonPatch:
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            description: |-
+                              ObjectMetaOverride provides the ability to override an object metadata.
+                              It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Annotations is an unstructured key value map stored with a resource that may be
+                                  set by external tools to store and retrieve arbitrary metadata.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Map of string keys and values that can be used to organize and categorize
+                                  (scope and select) objects.
+                                type: object
+                            type: object
+                          spec:
+                            description: Specification of the desired behavior of
+                              the Deployment.
+                            properties:
+                              template:
+                                description: Template describes the pods that will
+                                  be created.
+                                properties:
+                                  metadata:
+                                    description: |-
+                                      ObjectMetaOverride provides the ability to override an object metadata.
+                                      It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          Annotations is an unstructured key value map stored with a resource that may be
+                                          set by external tools to store and retrieve arbitrary metadata.
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          Map of string keys and values that can be used to organize and categorize
+                                          (scope and select) objects.
+                                        type: object
+                                    type: object
+                                  spec:
+                                    description: Specification of the desired behavior
+                                      of the pod.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  resources:
+                    description: |-
+                      Compute Resources required by the ui.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  version:
+                    description: Version defines the temporal admin tools version
+                      the instance should run.
+                    type: string
+                type: object
+              archival:
+                description: Archival allows Workflow Execution Event Histories and
+                  Visibility data backups for the temporal cluster.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enabled defines if the archival is enabled for the
+                      cluster.
+                    type: boolean
+                  history:
+                    description: History is the default config for the history archival.
+                    properties:
+                      enableRead:
+                        default: false
+                        description: EnableRead allows temporal to read from the archived
+                          Event History.
+                        type: boolean
+                      enabled:
+                        default: false
+                        description: |-
+                          Enabled defines if the archival is enabled by default for all namespaces
+                          or for a particular namespace (depends if it's for a TemporalCluster or a TemporalNamespace).
+                        type: boolean
+                      path:
+                        description: Path is ...
+                        type: string
+                      paused:
+                        default: false
+                        description: Paused defines if the archival is paused.
+                        type: boolean
+                    required:
+                    - enableRead
+                    - path
+                    - paused
+                    type: object
+                  provider:
+                    description: |-
+                      Provider defines the archival provider for the cluster.
+                      The same provider is used for both history and visibility,
+                      but some config can be changed using spec.archival.[history|visibility].config.
+                    properties:
+                      filestore:
+                        description: FilestoreArchiver is the file store archival
+                          provider configuration.
+                        properties:
+                          dirPermissions:
+                            default: "0766"
+                            description: |-
+                              DirPermissions sets the directory permissions of the archive directory.
+                              It's recommend to leave it empty and use the default value of "0766" to avoid read/write issues.
+                            type: string
+                          filePermissions:
+                            default: "0666"
+                            description: |-
+                              FilePermissions sets the file permissions of the archived files.
+                              It's recommend to leave it empty and use the default value of "0666" to avoid read/write issues.
+                            type: string
+                        required:
+                        - dirPermissions
+                        - filePermissions
+                        type: object
+                      gcs:
+                        description: GCSArchiver is the GCS archival provider configuration.
+                        properties:
+                          credentialsRef:
+                            description: SecretAccessKeyRef is the secret key selector
+                              containing Google Cloud Storage credentials file.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                        - credentialsRef
+                        type: object
+                      s3:
+                        description: S3Archiver is the S3 archival provider configuration.
+                        properties:
+                          credentials:
+                            description: Use credentials if you want to use aws credentials
+                              from secret.
+                            properties:
+                              accessKeyIdRef:
+                                description: AccessKeyIDRef is the secret key selector
+                                  containing AWS access key ID.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: SecretAccessKeyRef is the secret key
+                                  selector containing AWS secret access key.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - accessKeyIdRef
+                            - secretKeyRef
+                            type: object
+                          endpoint:
+                            description: Use Endpoint if you want to use s3-compatible
+                              object storage.
+                            type: string
+                          region:
+                            description: Region is the aws s3 region.
+                            type: string
+                          roleName:
+                            description: |-
+                              Use RoleName if you want the temporal service account
+                              to assume an AWS Identity and Access Management (IAM) role.
+                            type: string
+                          s3ForcePathStyle:
+                            description: Use s3ForcePathStyle if you want to use s3
+                              path style.
+                            type: boolean
+                        required:
+                        - region
+                        type: object
+                    type: object
+                  visibility:
+                    description: Visibility is the default config for visibility archival.
+                    properties:
+                      enableRead:
+                        default: false
+                        description: EnableRead allows temporal to read from the archived
+                          Event History.
+                        type: boolean
+                      enabled:
+                        default: false
+                        description: |-
+                          Enabled defines if the archival is enabled by default for all namespaces
+                          or for a particular namespace (depends if it's for a TemporalCluster or a TemporalNamespace).
+                        type: boolean
+                      path:
+                        description: Path is ...
+                        type: string
+                      paused:
+                        default: false
+                        description: Paused defines if the archival is paused.
+                        type: boolean
+                    required:
+                    - enableRead
+                    - path
+                    - paused
+                    type: object
+                type: object
+              authorization:
+                description: Authorization allows authorization configuration for
+                  the temporal cluster.
+                properties:
+                  authorizer:
+                    description: |-
+                      Authorizer defines the authorization mechanism to be used. It can be left as an empty string to
+                      use a no-operation authorizer (noopAuthorizer), or set to "default" to use the temporal's default
+                      authorizer (defaultAuthorizer).
+                    type: string
+                  claimMapper:
+                    description: |-
+                      ClaimMapper specifies the claim mapping mechanism used for handling JWT claims. Similar to the Authorizer,
+                      it can be left as an empty string to use a no-operation claim mapper (noopClaimMapper), or set to "default"
+                      to use the default JWT claim mapper (defaultJWTClaimMapper).
+                    type: string
+                  jwtKeyProvider:
+                    description: JWTKeyProvider specifies the signing key provider
+                      used for validating JWT tokens.
+                    properties:
+                      keySourceURIs:
+                        description: |-
+                          KeySourceURIs is a list of URIs where the JWT signing keys can be obtained. These URIs are used by the
+                          authorization system to fetch the public keys necessary for validating JWT tokens.
+                        items:
+                          type: string
+                        type: array
+                      refreshInterval:
+                        description: |-
+                          RefreshInterval defines the time interval at which temporal should refresh the JWT signing keys from
+                          the specified URIs.
+                        type: string
+                    type: object
+                  permissionsClaimName:
+                    description: PermissionsClaimName is the name of the claim within
+                      the JWT token that contains the user's permissions.
+                    type: string
+                type: object
+              dynamicConfig:
+                description: DynamicConfig allows advanced configuration for the temporal
+                  cluster.
+                properties:
+                  pollInterval:
+                    description: |-
+                      PollInterval defines how often the config should be updated by checking provided values.
+                      Defaults to 10s.
+                    type: string
+                  values:
+                    additionalProperties:
+                      items:
+                        description: ConstrainedValue is an alias for temporal's dynamicconfig.ConstrainedValue.
+                        properties:
+                          constraints:
+                            description: Constraints describe under what conditions
+                              a ConstrainedValue should be used.
+                            properties:
+                              namespace:
+                                type: string
+                              namespaceId:
+                                type: string
+                              shardId:
+                                format: int32
+                                type: integer
+                              taskQueueName:
+                                type: string
+                              taskQueueType:
+                                type: string
+                              taskType:
+                                type: string
+                            type: object
+                          value:
+                            description: |-
+                              Value is the value for the configuration key.
+                              The type of the Value field depends on the key.
+                              Acceptable types will be one of: int, float64, bool, string, map[string]any, time.Duration
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - value
+                        type: object
+                      type: array
+                    description: Values contains all dynamic config keys and their
+                      constrained values.
+                    type: object
+                required:
+                - values
+                type: object
+              image:
+                description: Image defines the temporal server docker image the cluster
+                  should use for each services.
+                type: string
+              imagePullSecrets:
+                description: |-
+                  An optional list of references to secrets in the same namespace
+                  to use for pulling temporal images from registries.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              jobInitContainers:
+                description: JobInitContainers adds a list of init containers to the
+                  setup's jobs.
+                items:
+                  description: A single application container that you want to run
+                    within a pod.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
+              jobResources:
+                description: JobResources allows set resources for setup/update jobs.
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              jobTtlSecondsAfterFinished:
+                default: 300
+                description: |-
+                  JobTTLSecondsAfterFinished is amount of time to keep job pods after jobs are completed.
+                  Defaults to 300 seconds.
+                format: int32
+                minimum: 1
+                type: integer
+              log:
+                description: Log defines temporal cluster's logger configuration.
+                properties:
+                  development:
+                    default: false
+                    description: |-
+                      Development determines whether the logger is run in Development (== Test) or in
+                      Production mode.  Default is Production.  Production-stage disables panics from
+                      DPanic logging.
+                    type: boolean
+                  format:
+                    default: json
+                    description: |-
+                      Format determines the format of each log file printed to the output.
+                      Use "console" if you want stack traces to appear on multiple lines.
+                    enum:
+                    - json
+                    - console
+                    type: string
+                  level:
+                    default: info
+                    description: Level is the desired log level; see colocated zap_logger.go::parseZapLevel()
+                    enum:
+                    - debug
+                    - info
+                    - warn
+                    - error
+                    - dpanic
+                    - panic
+                    - fatal
+                    type: string
+                  outputFile:
+                    description: OutputFile is the path to the log output file.
+                    type: string
+                  stdout:
+                    default: true
+                    description: Stdout is true if the output needs to goto standard
+                      out; default is stderr.
+                    type: boolean
+                type: object
+              mTLS:
+                description: MTLS allows configuration of the network traffic encryption
+                  for the cluster.
+                properties:
+                  certificatesDuration:
+                    description: |-
+                      CertificatesDuration allows configuration of maximum certificates lifetime.
+                      Useless if mTLS provider is not cert-manager.
+                    properties:
+                      clientCertificates:
+                        description: |-
+                          ClientCertificates is the 'duration' (i.e. lifetime) of the client certificates.
+                          It defaults to 1 year.
+                        type: string
+                      frontendCertificate:
+                        description: |-
+                          FrontendCertificate is the 'duration' (i.e. lifetime) of the frontend certificate.
+                          It defaults to 1 year.
+                        type: string
+                      intermediateCAsCertificates:
+                        description: |-
+                          IntermediateCACertificates is the 'duration' (i.e. lifetime) of the intermediate CAs Certificates.
+                          It defaults to 5 years.
+                        type: string
+                      internodeCertificate:
+                        description: |-
+                          InternodeCertificate is the 'duration' (i.e. lifetime) of the internode certificate.
+                          It defaults to 1 year.
+                        type: string
+                      rootCACertificate:
+                        description: |-
+                          RootCACertificate is the 'duration' (i.e. lifetime) of the Root CA Certificate.
+                          It defaults to 10 years.
+                        type: string
+                    type: object
+                  frontend:
+                    description: |-
+                      Frontend allows configuration of the frontend's public endpoint traffic encryption.
+                      Useless if mTLS provider is not cert-manager.
+                    properties:
+                      enabled:
+                        description: Enabled defines if the operator should enable
+                          mTLS for cluster's public endpoints.
+                        type: boolean
+                      extraDnsNames:
+                        description: |-
+                          ExtraDNSNames is a list of additional DNS names associated with the TemporalCluster.
+                          These DNS names can be used for accessing the TemporalCluster from external services.
+                          The DNS names specified here will be added to the TLS certificate for secure communication.
+                        items:
+                          type: string
+                        nullable: true
+                        type: array
+                    type: object
+                  internode:
+                    description: |-
+                      Internode allows configuration of the internode traffic encryption.
+                      Useless if mTLS provider is not cert-manager.
+                    properties:
+                      enabled:
+                        description: Enabled defines if the operator should enable
+                          mTLS for network between cluster nodes.
+                        type: boolean
+                    type: object
+                  permissiveMetrics:
+                    description: |-
+                      PermissiveMetrics allows insecure HTTP requests to the metrics endpoint.
+                      This is handy if the metrics collector does not support mTLS.
+                      Useless if mTLS provider is not istio
+                    type: boolean
+                  provider:
+                    default: cert-manager
+                    description: Provider defines the tool used to manage mTLS certificates.
+                    enum:
+                    - cert-manager
+                    - linkerd
+                    - istio
+                    type: string
+                  refreshInterval:
+                    description: |-
+                      RefreshInterval defines interval between refreshes of certificates in the cluster components.
+                      Defaults to 1 hour.
+                      Useless if mTLS provider is not cert-manager.
+                    type: string
+                  renewBefore:
+                    description: |-
+                      RenewBefore is defines how long before the currently issued certificate's expiry
+                      cert-manager should renew the certificate. The default is 2/3 of the
+                      issued certificate's duration. Minimum accepted value is 5 minutes.
+                      Useless if mTLS provider is not cert-manager.
+                    type: string
+                type: object
+              metrics:
+                description: Metrics allows configuration of scraping endpoints for
+                  stats. prometheus or m3.
+                properties:
+                  enabled:
+                    description: Enabled defines if the operator should enable metrics
+                      exposition on temporal components.
+                    type: boolean
+                  excludeTags:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: |-
+                      ExcludeTags is a map from tag name string to tag values string list.
+                      Each value present in keys will have relevant tag value replaced with "_tag_excluded_"
+                      Each value in values list will white-list tag values to be reported as usual.
+                    type: object
+                  perUnitHistogramBoundaries:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: |-
+                      PerUnitHistogramBoundaries defines the default histogram bucket boundaries.
+                      Configuration of histogram boundaries for given metric unit.
+
+                      Supported values:
+                      - "dimensionless"
+                      - "milliseconds"
+                      - "bytes"
+                    type: object
+                  prefix:
+                    description: Prefix sets the prefix to all outgoing metrics
+                    type: string
+                  prometheus:
+                    description: Prometheus reporter configuration.
+                    properties:
+                      listenAddress:
+                        description: Deprecated. Address for prometheus to serve metrics
+                          from.
+                        type: string
+                      listenPort:
+                        description: ListenPort for prometheus to serve metrics from.
+                        format: int32
+                        type: integer
+                      scrapeConfig:
+                        description: ScrapeConfig is the prometheus scrape configuration.
+                        properties:
+                          annotations:
+                            description: Annotations defines if the operator should
+                              add prometheus scrape annotations to the services pods.
+                            type: boolean
+                          serviceMonitor:
+                            description: PrometheusScrapeConfigServiceMonitor is the
+                              configuration for prometheus operator ServiceMonitor.
+                            properties:
+                              enabled:
+                                description: Enabled defines if the operator should
+                                  create a ServiceMonitor for each services.
+                                type: boolean
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: Labels adds extra labels to the ServiceMonitor.
+                                type: object
+                              metricRelabelings:
+                                description: MetricRelabelConfigs to apply to samples
+                                  before ingestion.
+                                items:
+                                  description: |-
+                                    RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                                    scraped samples and remote write samples.
+
+                                    More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                                  properties:
+                                    action:
+                                      default: replace
+                                      description: |-
+                                        Action to perform based on the regex matching.
+
+                                        `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                                        `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                                        Default: "Replace"
+                                      enum:
+                                      - replace
+                                      - Replace
+                                      - keep
+                                      - Keep
+                                      - drop
+                                      - Drop
+                                      - hashmod
+                                      - HashMod
+                                      - labelmap
+                                      - LabelMap
+                                      - labeldrop
+                                      - LabelDrop
+                                      - labelkeep
+                                      - LabelKeep
+                                      - lowercase
+                                      - Lowercase
+                                      - uppercase
+                                      - Uppercase
+                                      - keepequal
+                                      - KeepEqual
+                                      - dropequal
+                                      - DropEqual
+                                      type: string
+                                    modulus:
+                                      description: |-
+                                        Modulus to take of the hash of the source label values.
+
+                                        Only applicable when the action is `HashMod`.
+                                      format: int64
+                                      type: integer
+                                    regex:
+                                      description: Regular expression against which
+                                        the extracted value is matched.
+                                      type: string
+                                    replacement:
+                                      description: |-
+                                        Replacement value against which a Replace action is performed if the
+                                        regular expression matches.
+
+                                        Regex capture groups are available.
+                                      type: string
+                                    separator:
+                                      description: Separator is the string between
+                                        concatenated SourceLabels.
+                                      type: string
+                                    sourceLabels:
+                                      description: |-
+                                        The source labels select values from existing labels. Their content is
+                                        concatenated using the configured Separator and matched against the
+                                        configured regular expression.
+                                      items:
+                                        description: |-
+                                          LabelName is a valid Prometheus label name which may only contain ASCII
+                                          letters, numbers, as well as underscores.
+                                        pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                        type: string
+                                      type: array
+                                    targetLabel:
+                                      description: |-
+                                        Label to which the resulting string is written in a replacement.
+
+                                        It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                                        `KeepEqual` and `DropEqual` actions.
+
+                                        Regex capture groups are available.
+                                      type: string
+                                  type: object
+                                type: array
+                              override:
+                                description: |-
+                                  Override allows customization of the created ServiceMonitor.
+                                  All fields can be overwritten except "endpoints", "selector" and "namespaceSelector".
+                                properties:
+                                  attachMetadata:
+                                    description: |-
+                                      `attachMetadata` defines additional metadata which is added to the
+                                      discovered targets.
+
+                                      It requires Prometheus >= v2.37.0.
+                                    properties:
+                                      node:
+                                        description: |-
+                                          When set to true, Prometheus attaches node metadata to the discovered
+                                          targets.
+
+                                          The Prometheus service account must have the `list` and `watch`
+                                          permissions on the `Nodes` objects.
+                                        type: boolean
+                                    type: object
+                                  bodySizeLimit:
+                                    description: |-
+                                      When defined, bodySizeLimit specifies a job level limit on the size
+                                      of uncompressed response body that will be accepted by Prometheus.
+
+                                      It requires Prometheus >= v2.28.0.
+                                    pattern: (^0|([0-9]*[.])?[0-9]+((K|M|G|T|E|P)i?)?B)$
+                                    type: string
+                                  endpoints:
+                                    description: |-
+                                      List of endpoints part of this ServiceMonitor.
+                                      Defines how to scrape metrics from Kubernetes [Endpoints](https://kubernetes.io/docs/concepts/services-networking/service/#endpoints) objects.
+                                      In most cases, an Endpoints object is backed by a Kubernetes [Service](https://kubernetes.io/docs/concepts/services-networking/service/) object with the same name and labels.
+                                    items:
+                                      description: |-
+                                        Endpoint defines an endpoint serving Prometheus metrics to be scraped by
+                                        Prometheus.
+                                      properties:
+                                        authorization:
+                                          description: |-
+                                            `authorization` configures the Authorization header credentials to use when
+                                            scraping the target.
+
+                                            Cannot be set at the same time as `basicAuth`, or `oauth2`.
+                                          properties:
+                                            credentials:
+                                              description: Selects a key of a Secret
+                                                in the namespace that contains the
+                                                credentials for authentication.
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            type:
+                                              description: |-
+                                                Defines the authentication type. The value is case-insensitive.
+
+                                                "Basic" is not a supported value.
+
+                                                Default: "Bearer"
+                                              type: string
+                                          type: object
+                                        basicAuth:
+                                          description: |-
+                                            `basicAuth` configures the Basic Authentication credentials to use when
+                                            scraping the target.
+
+                                            Cannot be set at the same time as `authorization`, or `oauth2`.
+                                          properties:
+                                            password:
+                                              description: |-
+                                                `password` specifies a key of a Secret containing the password for
+                                                authentication.
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            username:
+                                              description: |-
+                                                `username` specifies a key of a Secret containing the username for
+                                                authentication.
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                        bearerTokenFile:
+                                          description: |-
+                                            File to read bearer token for scraping the target.
+
+                                            Deprecated: use `authorization` instead.
+                                          type: string
+                                        bearerTokenSecret:
+                                          description: |-
+                                            `bearerTokenSecret` specifies a key of a Secret containing the bearer
+                                            token for scraping targets. The secret needs to be in the same namespace
+                                            as the ServiceMonitor object and readable by the Prometheus Operator.
+
+                                            Deprecated: use `authorization` instead.
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        enableHttp2:
+                                          description: '`enableHttp2` can be used
+                                            to disable HTTP2 when scraping the target.'
+                                          type: boolean
+                                        filterRunning:
+                                          description: |-
+                                            When true, the pods which are not running (e.g. either in Failed or
+                                            Succeeded state) are dropped during the target discovery.
+
+                                            If unset, the filtering is enabled.
+
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+                                          type: boolean
+                                        followRedirects:
+                                          description: |-
+                                            `followRedirects` defines whether the scrape requests should follow HTTP
+                                            3xx redirects.
+                                          type: boolean
+                                        honorLabels:
+                                          description: |-
+                                            When true, `honorLabels` preserves the metric's labels when they collide
+                                            with the target's labels.
+                                          type: boolean
+                                        honorTimestamps:
+                                          description: |-
+                                            `honorTimestamps` controls whether Prometheus preserves the timestamps
+                                            when exposed by the target.
+                                          type: boolean
+                                        interval:
+                                          description: |-
+                                            Interval at which Prometheus scrapes the metrics from the target.
+
+                                            If empty, Prometheus uses the global scrape interval.
+                                          pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                                          type: string
+                                        metricRelabelings:
+                                          description: |-
+                                            `metricRelabelings` configures the relabeling rules to apply to the
+                                            samples before ingestion.
+                                          items:
+                                            description: |-
+                                              RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                                              scraped samples and remote write samples.
+
+                                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                                            properties:
+                                              action:
+                                                default: replace
+                                                description: |-
+                                                  Action to perform based on the regex matching.
+
+                                                  `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                                                  `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                                                  Default: "Replace"
+                                                enum:
+                                                - replace
+                                                - Replace
+                                                - keep
+                                                - Keep
+                                                - drop
+                                                - Drop
+                                                - hashmod
+                                                - HashMod
+                                                - labelmap
+                                                - LabelMap
+                                                - labeldrop
+                                                - LabelDrop
+                                                - labelkeep
+                                                - LabelKeep
+                                                - lowercase
+                                                - Lowercase
+                                                - uppercase
+                                                - Uppercase
+                                                - keepequal
+                                                - KeepEqual
+                                                - dropequal
+                                                - DropEqual
+                                                type: string
+                                              modulus:
+                                                description: |-
+                                                  Modulus to take of the hash of the source label values.
+
+                                                  Only applicable when the action is `HashMod`.
+                                                format: int64
+                                                type: integer
+                                              regex:
+                                                description: Regular expression against
+                                                  which the extracted value is matched.
+                                                type: string
+                                              replacement:
+                                                description: |-
+                                                  Replacement value against which a Replace action is performed if the
+                                                  regular expression matches.
+
+                                                  Regex capture groups are available.
+                                                type: string
+                                              separator:
+                                                description: Separator is the string
+                                                  between concatenated SourceLabels.
+                                                type: string
+                                              sourceLabels:
+                                                description: |-
+                                                  The source labels select values from existing labels. Their content is
+                                                  concatenated using the configured Separator and matched against the
+                                                  configured regular expression.
+                                                items:
+                                                  description: |-
+                                                    LabelName is a valid Prometheus label name which may only contain ASCII
+                                                    letters, numbers, as well as underscores.
+                                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                                  type: string
+                                                type: array
+                                              targetLabel:
+                                                description: |-
+                                                  Label to which the resulting string is written in a replacement.
+
+                                                  It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                                                  `KeepEqual` and `DropEqual` actions.
+
+                                                  Regex capture groups are available.
+                                                type: string
+                                            type: object
+                                          type: array
+                                        oauth2:
+                                          description: |-
+                                            `oauth2` configures the OAuth2 settings to use when scraping the target.
+
+                                            It requires Prometheus >= 2.27.0.
+
+                                            Cannot be set at the same time as `authorization`, or `basicAuth`.
+                                          properties:
+                                            clientId:
+                                              description: |-
+                                                `clientId` specifies a key of a Secret or ConfigMap containing the
+                                                OAuth2 client's ID.
+                                              properties:
+                                                configMap:
+                                                  description: ConfigMap containing
+                                                    data to use for the targets.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the ConfigMap or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secret:
+                                                  description: Secret containing data
+                                                    to use for the targets.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            clientSecret:
+                                              description: |-
+                                                `clientSecret` specifies a key of a Secret containing the OAuth2
+                                                client's secret.
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            endpointParams:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                `endpointParams` configures the HTTP parameters to append to the token
+                                                URL.
+                                              type: object
+                                            noProxy:
+                                              description: |-
+                                                `noProxy` is a comma-separated string that can contain IPs, CIDR notation, domain names
+                                                that should be excluded from proxying. IP and domain names can
+                                                contain port numbers.
+
+                                                It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                              type: string
+                                            proxyConnectHeader:
+                                              additionalProperties:
+                                                items:
+                                                  description: SecretKeySelector selects
+                                                    a key of a Secret.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                type: array
+                                              description: |-
+                                                ProxyConnectHeader optionally specifies headers to send to
+                                                proxies during CONNECT requests.
+
+                                                It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            proxyFromEnvironment:
+                                              description: |-
+                                                Whether to use the proxy configuration defined by environment variables (HTTP_PROXY, HTTPS_PROXY, and NO_PROXY).
+
+                                                It requires Prometheus >= v2.43.0 or Alertmanager >= 0.25.0.
+                                              type: boolean
+                                            proxyUrl:
+                                              description: '`proxyURL` defines the
+                                                HTTP proxy server to use.'
+                                              pattern: ^http(s)?://.+$
+                                              type: string
+                                            scopes:
+                                              description: '`scopes` defines the OAuth2
+                                                scopes used for the token request.'
+                                              items:
+                                                type: string
+                                              type: array
+                                            tlsConfig:
+                                              description: |-
+                                                TLS configuration to use when connecting to the OAuth2 server.
+                                                It requires Prometheus >= v2.43.0.
+                                              properties:
+                                                ca:
+                                                  description: Certificate authority
+                                                    used when verifying server certificates.
+                                                  properties:
+                                                    configMap:
+                                                      description: ConfigMap containing
+                                                        data to use for the targets.
+                                                      properties:
+                                                        key:
+                                                          description: The key to
+                                                            select.
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          description: |-
+                                                            Name of the referent.
+                                                            This field is effectively required, but due to backwards compatibility is
+                                                            allowed to be empty. Instances of this type with an empty value here are
+                                                            almost certainly wrong.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the ConfigMap or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    secret:
+                                                      description: Secret containing
+                                                        data to use for the targets.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          description: |-
+                                                            Name of the referent.
+                                                            This field is effectively required, but due to backwards compatibility is
+                                                            allowed to be empty. Instances of this type with an empty value here are
+                                                            almost certainly wrong.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                cert:
+                                                  description: Client certificate
+                                                    to present when doing client-authentication.
+                                                  properties:
+                                                    configMap:
+                                                      description: ConfigMap containing
+                                                        data to use for the targets.
+                                                      properties:
+                                                        key:
+                                                          description: The key to
+                                                            select.
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          description: |-
+                                                            Name of the referent.
+                                                            This field is effectively required, but due to backwards compatibility is
+                                                            allowed to be empty. Instances of this type with an empty value here are
+                                                            almost certainly wrong.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the ConfigMap or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    secret:
+                                                      description: Secret containing
+                                                        data to use for the targets.
+                                                      properties:
+                                                        key:
+                                                          description: The key of
+                                                            the secret to select from.  Must
+                                                            be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          default: ""
+                                                          description: |-
+                                                            Name of the referent.
+                                                            This field is effectively required, but due to backwards compatibility is
+                                                            allowed to be empty. Instances of this type with an empty value here are
+                                                            almost certainly wrong.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether
+                                                            the Secret or its key
+                                                            must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                insecureSkipVerify:
+                                                  description: Disable target certificate
+                                                    validation.
+                                                  type: boolean
+                                                keySecret:
+                                                  description: Secret containing the
+                                                    client key file for the targets.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                maxVersion:
+                                                  description: |-
+                                                    Maximum acceptable TLS version.
+
+                                                    It requires Prometheus >= v2.41.0.
+                                                  enum:
+                                                  - TLS10
+                                                  - TLS11
+                                                  - TLS12
+                                                  - TLS13
+                                                  type: string
+                                                minVersion:
+                                                  description: |-
+                                                    Minimum acceptable TLS version.
+
+                                                    It requires Prometheus >= v2.35.0.
+                                                  enum:
+                                                  - TLS10
+                                                  - TLS11
+                                                  - TLS12
+                                                  - TLS13
+                                                  type: string
+                                                serverName:
+                                                  description: Used to verify the
+                                                    hostname for the targets.
+                                                  type: string
+                                              type: object
+                                            tokenUrl:
+                                              description: '`tokenURL` configures
+                                                the URL to fetch the token from.'
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                          - clientId
+                                          - clientSecret
+                                          - tokenUrl
+                                          type: object
+                                        params:
+                                          additionalProperties:
+                                            items:
+                                              type: string
+                                            type: array
+                                          description: params define optional HTTP
+                                            URL parameters.
+                                          type: object
+                                        path:
+                                          description: |-
+                                            HTTP path from which to scrape for metrics.
+
+                                            If empty, Prometheus uses the default value (e.g. `/metrics`).
+                                          type: string
+                                        port:
+                                          description: |-
+                                            Name of the Service port which this endpoint refers to.
+
+                                            It takes precedence over `targetPort`.
+                                          type: string
+                                        proxyUrl:
+                                          description: |-
+                                            `proxyURL` configures the HTTP Proxy URL (e.g.
+                                            "http://proxyserver:2195") to go through when scraping the target.
+                                          type: string
+                                        relabelings:
+                                          description: |-
+                                            `relabelings` configures the relabeling rules to apply the target's
+                                            metadata labels.
+
+                                            The Operator automatically adds relabelings for a few standard Kubernetes fields.
+
+                                            The original scrape job's name is available via the `__tmp_prometheus_job_name` label.
+
+                                            More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                                          items:
+                                            description: |-
+                                              RelabelConfig allows dynamic rewriting of the label set for targets, alerts,
+                                              scraped samples and remote write samples.
+
+                                              More info: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+                                            properties:
+                                              action:
+                                                default: replace
+                                                description: |-
+                                                  Action to perform based on the regex matching.
+
+                                                  `Uppercase` and `Lowercase` actions require Prometheus >= v2.36.0.
+                                                  `DropEqual` and `KeepEqual` actions require Prometheus >= v2.41.0.
+
+                                                  Default: "Replace"
+                                                enum:
+                                                - replace
+                                                - Replace
+                                                - keep
+                                                - Keep
+                                                - drop
+                                                - Drop
+                                                - hashmod
+                                                - HashMod
+                                                - labelmap
+                                                - LabelMap
+                                                - labeldrop
+                                                - LabelDrop
+                                                - labelkeep
+                                                - LabelKeep
+                                                - lowercase
+                                                - Lowercase
+                                                - uppercase
+                                                - Uppercase
+                                                - keepequal
+                                                - KeepEqual
+                                                - dropequal
+                                                - DropEqual
+                                                type: string
+                                              modulus:
+                                                description: |-
+                                                  Modulus to take of the hash of the source label values.
+
+                                                  Only applicable when the action is `HashMod`.
+                                                format: int64
+                                                type: integer
+                                              regex:
+                                                description: Regular expression against
+                                                  which the extracted value is matched.
+                                                type: string
+                                              replacement:
+                                                description: |-
+                                                  Replacement value against which a Replace action is performed if the
+                                                  regular expression matches.
+
+                                                  Regex capture groups are available.
+                                                type: string
+                                              separator:
+                                                description: Separator is the string
+                                                  between concatenated SourceLabels.
+                                                type: string
+                                              sourceLabels:
+                                                description: |-
+                                                  The source labels select values from existing labels. Their content is
+                                                  concatenated using the configured Separator and matched against the
+                                                  configured regular expression.
+                                                items:
+                                                  description: |-
+                                                    LabelName is a valid Prometheus label name which may only contain ASCII
+                                                    letters, numbers, as well as underscores.
+                                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                                  type: string
+                                                type: array
+                                              targetLabel:
+                                                description: |-
+                                                  Label to which the resulting string is written in a replacement.
+
+                                                  It is mandatory for `Replace`, `HashMod`, `Lowercase`, `Uppercase`,
+                                                  `KeepEqual` and `DropEqual` actions.
+
+                                                  Regex capture groups are available.
+                                                type: string
+                                            type: object
+                                          type: array
+                                        scheme:
+                                          description: |-
+                                            HTTP scheme to use for scraping.
+
+                                            `http` and `https` are the expected values unless you rewrite the
+                                            `__scheme__` label via relabeling.
+
+                                            If empty, Prometheus uses the default value `http`.
+                                          enum:
+                                          - http
+                                          - https
+                                          type: string
+                                        scrapeTimeout:
+                                          description: |-
+                                            Timeout after which Prometheus considers the scrape to be failed.
+
+                                            If empty, Prometheus uses the global scrape timeout unless it is less
+                                            than the target's scrape interval value in which the latter is used.
+                                          pattern: ^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$
+                                          type: string
+                                        targetPort:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the target port of the `Pod` object behind the
+                                            Service. The port must be specified with the container's port property.
+                                          x-kubernetes-int-or-string: true
+                                        tlsConfig:
+                                          description: TLS configuration to use when
+                                            scraping the target.
+                                          properties:
+                                            ca:
+                                              description: Certificate authority used
+                                                when verifying server certificates.
+                                              properties:
+                                                configMap:
+                                                  description: ConfigMap containing
+                                                    data to use for the targets.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the ConfigMap or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secret:
+                                                  description: Secret containing data
+                                                    to use for the targets.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            caFile:
+                                              description: Path to the CA cert in
+                                                the Prometheus container to use for
+                                                the targets.
+                                              type: string
+                                            cert:
+                                              description: Client certificate to present
+                                                when doing client-authentication.
+                                              properties:
+                                                configMap:
+                                                  description: ConfigMap containing
+                                                    data to use for the targets.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the ConfigMap or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secret:
+                                                  description: Secret containing data
+                                                    to use for the targets.
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            certFile:
+                                              description: Path to the client cert
+                                                file in the Prometheus container for
+                                                the targets.
+                                              type: string
+                                            insecureSkipVerify:
+                                              description: Disable target certificate
+                                                validation.
+                                              type: boolean
+                                            keyFile:
+                                              description: Path to the client key
+                                                file in the Prometheus container for
+                                                the targets.
+                                              type: string
+                                            keySecret:
+                                              description: Secret containing the client
+                                                key file for the targets.
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            maxVersion:
+                                              description: |-
+                                                Maximum acceptable TLS version.
+
+                                                It requires Prometheus >= v2.41.0.
+                                              enum:
+                                              - TLS10
+                                              - TLS11
+                                              - TLS12
+                                              - TLS13
+                                              type: string
+                                            minVersion:
+                                              description: |-
+                                                Minimum acceptable TLS version.
+
+                                                It requires Prometheus >= v2.35.0.
+                                              enum:
+                                              - TLS10
+                                              - TLS11
+                                              - TLS12
+                                              - TLS13
+                                              type: string
+                                            serverName:
+                                              description: Used to verify the hostname
+                                                for the targets.
+                                              type: string
+                                          type: object
+                                        trackTimestampsStaleness:
+                                          description: |-
+                                            `trackTimestampsStaleness` defines whether Prometheus tracks staleness of
+                                            the metrics that have an explicit timestamp present in scraped data.
+                                            Has no effect if `honorTimestamps` is false.
+
+                                            It requires Prometheus >= v2.48.0.
+                                          type: boolean
+                                      type: object
+                                    type: array
+                                  jobLabel:
+                                    description: |-
+                                      `jobLabel` selects the label from the associated Kubernetes `Service`
+                                      object which will be used as the `job` label for all metrics.
+
+                                      For example if `jobLabel` is set to `foo` and the Kubernetes `Service`
+                                      object is labeled with `foo: bar`, then Prometheus adds the `job="bar"`
+                                      label to all ingested metrics.
+
+                                      If the value of this field is empty or if the label doesn't exist for
+                                      the given Service, the `job` label of the metrics defaults to the name
+                                      of the associated Kubernetes `Service`.
+                                    type: string
+                                  keepDroppedTargets:
+                                    description: |-
+                                      Per-scrape limit on the number of targets dropped by relabeling
+                                      that will be kept in memory. 0 means no limit.
+
+                                      It requires Prometheus >= v2.47.0.
+                                    format: int64
+                                    type: integer
+                                  labelLimit:
+                                    description: |-
+                                      Per-scrape limit on number of labels that will be accepted for a sample.
+
+                                      It requires Prometheus >= v2.27.0.
+                                    format: int64
+                                    type: integer
+                                  labelNameLengthLimit:
+                                    description: |-
+                                      Per-scrape limit on length of labels name that will be accepted for a sample.
+
+                                      It requires Prometheus >= v2.27.0.
+                                    format: int64
+                                    type: integer
+                                  labelValueLengthLimit:
+                                    description: |-
+                                      Per-scrape limit on length of labels value that will be accepted for a sample.
+
+                                      It requires Prometheus >= v2.27.0.
+                                    format: int64
+                                    type: integer
+                                  namespaceSelector:
+                                    description: |-
+                                      `namespaceSelector` defines in which namespace(s) Prometheus should discover the services.
+                                      By default, the services are discovered in the same namespace as the `ServiceMonitor` object but it is possible to select pods across different/all namespaces.
+                                    properties:
+                                      any:
+                                        description: |-
+                                          Boolean describing whether all namespaces are selected in contrast to a
+                                          list restricting them.
+                                        type: boolean
+                                      matchNames:
+                                        description: List of namespace names to select
+                                          from.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  nativeHistogramBucketLimit:
+                                    description: |-
+                                      If there are more than this many buckets in a native histogram,
+                                      buckets will be merged to stay within the limit.
+                                      It requires Prometheus >= v2.45.0.
+                                    format: int64
+                                    type: integer
+                                  nativeHistogramMinBucketFactor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      If the growth factor of one bucket to the next is smaller than this,
+                                      buckets will be merged to increase the factor sufficiently.
+                                      It requires Prometheus >= v2.50.0.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  podTargetLabels:
+                                    description: |-
+                                      `podTargetLabels` defines the labels which are transferred from the
+                                      associated Kubernetes `Pod` object onto the ingested metrics.
+                                    items:
+                                      type: string
+                                    type: array
+                                  sampleLimit:
+                                    description: |-
+                                      `sampleLimit` defines a per-scrape limit on the number of scraped samples
+                                      that will be accepted.
+                                    format: int64
+                                    type: integer
+                                  scrapeClass:
+                                    description: The scrape class to apply.
+                                    minLength: 1
+                                    type: string
+                                  scrapeClassicHistograms:
+                                    description: |-
+                                      Whether to scrape a classic histogram that is also exposed as a native histogram.
+                                      It requires Prometheus >= v2.45.0.
+                                    type: boolean
+                                  scrapeProtocols:
+                                    description: |-
+                                      `scrapeProtocols` defines the protocols to negotiate during a scrape. It tells clients the
+                                      protocols supported by Prometheus in order of preference (from most to least preferred).
+
+                                      If unset, Prometheus uses its default value.
+
+                                      It requires Prometheus >= v2.49.0.
+                                    items:
+                                      description: |-
+                                        ScrapeProtocol represents a protocol used by Prometheus for scraping metrics.
+                                        Supported values are:
+                                        * `OpenMetricsText0.0.1`
+                                        * `OpenMetricsText1.0.0`
+                                        * `PrometheusProto`
+                                        * `PrometheusText0.0.4`
+                                      enum:
+                                      - PrometheusProto
+                                      - OpenMetricsText0.0.1
+                                      - OpenMetricsText1.0.0
+                                      - PrometheusText0.0.4
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: set
+                                  selector:
+                                    description: Label selector to select the Kubernetes
+                                      `Endpoints` objects to scrape metrics from.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  targetLabels:
+                                    description: |-
+                                      `targetLabels` defines the labels which are transferred from the
+                                      associated Kubernetes `Service` object onto the ingested metrics.
+                                    items:
+                                      type: string
+                                    type: array
+                                  targetLimit:
+                                    description: |-
+                                      `targetLimit` defines a limit on the number of scraped targets that will
+                                      be accepted.
+                                    format: int64
+                                    type: integer
+                                required:
+                                - endpoints
+                                - selector
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                required:
+                - enabled
+                type: object
+              numHistoryShards:
+                description: |-
+                  NumHistoryShards is the desired number of history shards.
+                  This field is immutable.
+                format: int32
+                minimum: 1
+                type: integer
+              persistence:
+                description: Persistence defines temporal persistence configuration.
+                properties:
+                  advancedVisibilityStore:
+                    description: AdvancedVisibilityStore holds the advanced visibility
+                      datastore specs.
+                    properties:
+                      cassandra:
+                        description: |-
+                          Cassandra holds all connection parameters for Cassandra datastore.
+                          Note that cassandra is now deprecated for visibility store.
+                        properties:
+                          connectTimeout:
+                            description: ConnectTimeout is a timeout for initial dial
+                              to cassandra server.
+                            type: string
+                          consistency:
+                            description: Consistency configuration.
+                            properties:
+                              consistency:
+                                description: |-
+                                  Consistency sets the default consistency level.
+                                  Values identical to gocql Consistency values. (defaults to LOCAL_QUORUM if not set).
+                                enum:
+                                - ANY
+                                - ONE
+                                - TWO
+                                - THREE
+                                - QUORUM
+                                - ALL
+                                - LOCAL_QUORUM
+                                - EACH_QUORUM
+                                - LOCAL_ONE
+                                type: integer
+                              serialConsistency:
+                                description: |-
+                                  SerialConsistency sets the consistency for the serial prtion of queries. Values identical to gocql SerialConsistency values.
+                                  (defaults to LOCAL_SERIAL if not set)
+                                enum:
+                                - SERIAL
+                                - LOCAL_SERIAL
+                                type: integer
+                            type: object
+                          datacenter:
+                            description: Datacenter is the data center filter arg
+                              for cassandra.
+                            type: string
+                          disableInitialHostLookup:
+                            description: DisableInitialHostLookup instructs the gocql
+                              client to connect only using the supplied hosts.
+                            type: boolean
+                          hosts:
+                            description: Hosts is a list of cassandra endpoints.
+                            items:
+                              type: string
+                            type: array
+                          keyspace:
+                            description: Keyspace is the cassandra keyspace.
+                            type: string
+                          maxConns:
+                            description: MaxConns is the max number of connections
+                              to this datastore for a single keyspace.
+                            type: integer
+                          port:
+                            description: Port is the cassandra port used for connection
+                              by gocql client.
+                            type: integer
+                          user:
+                            description: User is the cassandra user used for authentication
+                              by gocql client.
+                            type: string
+                        required:
+                        - hosts
+                        - keyspace
+                        - port
+                        - user
+                        type: object
+                      elasticsearch:
+                        description: Elasticsearch holds all connection parameters
+                          for Elasticsearch datastores.
+                        properties:
+                          closeIdleConnectionsInterval:
+                            description: CloseIdleConnectionsInterval is the max duration
+                              a connection stay open while idle.
+                            type: string
+                          enableHealthcheck:
+                            description: EnableHealthcheck enables or disables healthcheck
+                              on the temporal cluster's es client.
+                            type: boolean
+                          enableSniff:
+                            description: EnableSniff enables or disables sniffer on
+                              the temporal cluster's es client.
+                            type: boolean
+                          indices:
+                            description: Indices holds visibility index names.
+                            properties:
+                              secondaryVisibility:
+                                description: SecondaryVisibility defines secondary
+                                  visibility's index name.
+                                type: string
+                              visibility:
+                                default: temporal_visibility_v1
+                                description: Visibility defines visibility's index
+                                  name.
+                                type: string
+                            required:
+                            - visibility
+                            type: object
+                          logLevel:
+                            description: LogLevel defines the temporal cluster's es
+                              client logger level.
+                            type: string
+                          url:
+                            description: URL is the connection url to connect to the
+                              instance.
+                            pattern: ^https?:\/\/.+$
+                            type: string
+                          username:
+                            description: Username is the username to be used for the
+                              connection.
+                            type: string
+                          version:
+                            default: v7
+                            description: Version defines the elasticsearch version.
+                            pattern: ^v(6|7|8)$
+                            type: string
+                        required:
+                        - indices
+                        - url
+                        - username
+                        - version
+                        type: object
+                      name:
+                        description: |-
+                          Name is the name of the datastore.
+                          It should be unique and will be referenced within the persistence spec.
+                          Defaults to "default" for default sore, "visibility" for visibility store,
+                          "secondaryVisibility" for secondary visibility store and
+                          "advancedVisibility" for advanced visibility store.
+                        type: string
+                      passwordSecretRef:
+                        description: PasswordSecret is the reference to the secret
+                          holding the password.
+                        properties:
+                          key:
+                            description: Key in the Secret.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      skipCreate:
+                        description: SkipCreate instructs the operator to skip creating
+                          the database for SQL datastores or to skip creating keyspace
+                          for Cassandra. Use this option if your database or keyspace
+                          has already been provisioned by an administrator.
+                        type: boolean
+                      sql:
+                        description: SQL holds all connection parameters for SQL datastores.
+                        properties:
+                          connectAddr:
+                            description: ConnectAddr is the remote addr of the database.
+                            type: string
+                          connectAttributes:
+                            additionalProperties:
+                              type: string
+                            description: ConnectAttributes is a set of key-value attributes
+                              to be sent as part of connect data_source_name url
+                            type: object
+                          connectProtocol:
+                            description: ConnectProtocol is the protocol that goes
+                              with the ConnectAddr.
+                            type: string
+                          databaseName:
+                            description: DatabaseName is the name of SQL database
+                              to connect to.
+                            type: string
+                          gcpServiceAccount:
+                            description: GCPServiceAccount is the service account
+                              to use to authenticate with GCP CloudSQL.
+                            type: string
+                          maxConnLifetime:
+                            description: MaxConnLifetime is the maximum time a connection
+                              can be alive
+                            type: string
+                          maxConns:
+                            description: MaxConns the max number of connections to
+                              this datastore.
+                            type: integer
+                          maxIdleConns:
+                            description: MaxIdleConns is the max number of idle connections
+                              to this datastore.
+                            type: integer
+                          pluginName:
+                            description: PluginName is the name of SQL plugin.
+                            enum:
+                            - postgres
+                            - postgres12
+                            - mysql
+                            - mysql8
+                            type: string
+                          taskScanPartitions:
+                            description: TaskScanPartitions is the number of partitions
+                              to sequentially scan during ListTaskQueue operations.
+                            type: integer
+                          user:
+                            description: User is the username to be used for the connection.
+                            type: string
+                        required:
+                        - connectAddr
+                        - databaseName
+                        - pluginName
+                        - user
+                        type: object
+                      tls:
+                        description: TLS is an optional option to connect to the datastore
+                          using TLS.
+                        properties:
+                          caFileRef:
+                            description: CaFileRef is a reference to a secret containing
+                              the ca file.
+                            properties:
+                              key:
+                                description: Key in the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          certFileRef:
+                            description: CertFileRef is a reference to a secret containing
+                              the cert file.
+                            properties:
+                              key:
+                                description: Key in the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          enableHostVerification:
+                            description: EnableHostVerification defines if the hostname
+                              should be verified when connecting to the datastore.
+                            type: boolean
+                          enabled:
+                            description: Enabled defines if the cluster should use
+                              a TLS connection to connect to the datastore.
+                            type: boolean
+                          keyFileRef:
+                            description: KeyFileRef is a reference to a secret containing
+                              the key file.
+                            properties:
+                              key:
+                                description: Key in the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          serverName:
+                            description: ServerName the datastore should present.
+                            type: string
+                        required:
+                        - enableHostVerification
+                        - enabled
+                        type: object
+                    type: object
+                  defaultStore:
+                    description: DefaultStore holds the default datastore specs.
+                    properties:
+                      cassandra:
+                        description: |-
+                          Cassandra holds all connection parameters for Cassandra datastore.
+                          Note that cassandra is now deprecated for visibility store.
+                        properties:
+                          connectTimeout:
+                            description: ConnectTimeout is a timeout for initial dial
+                              to cassandra server.
+                            type: string
+                          consistency:
+                            description: Consistency configuration.
+                            properties:
+                              consistency:
+                                description: |-
+                                  Consistency sets the default consistency level.
+                                  Values identical to gocql Consistency values. (defaults to LOCAL_QUORUM if not set).
+                                enum:
+                                - ANY
+                                - ONE
+                                - TWO
+                                - THREE
+                                - QUORUM
+                                - ALL
+                                - LOCAL_QUORUM
+                                - EACH_QUORUM
+                                - LOCAL_ONE
+                                type: integer
+                              serialConsistency:
+                                description: |-
+                                  SerialConsistency sets the consistency for the serial prtion of queries. Values identical to gocql SerialConsistency values.
+                                  (defaults to LOCAL_SERIAL if not set)
+                                enum:
+                                - SERIAL
+                                - LOCAL_SERIAL
+                                type: integer
+                            type: object
+                          datacenter:
+                            description: Datacenter is the data center filter arg
+                              for cassandra.
+                            type: string
+                          disableInitialHostLookup:
+                            description: DisableInitialHostLookup instructs the gocql
+                              client to connect only using the supplied hosts.
+                            type: boolean
+                          hosts:
+                            description: Hosts is a list of cassandra endpoints.
+                            items:
+                              type: string
+                            type: array
+                          keyspace:
+                            description: Keyspace is the cassandra keyspace.
+                            type: string
+                          maxConns:
+                            description: MaxConns is the max number of connections
+                              to this datastore for a single keyspace.
+                            type: integer
+                          port:
+                            description: Port is the cassandra port used for connection
+                              by gocql client.
+                            type: integer
+                          user:
+                            description: User is the cassandra user used for authentication
+                              by gocql client.
+                            type: string
+                        required:
+                        - hosts
+                        - keyspace
+                        - port
+                        - user
+                        type: object
+                      elasticsearch:
+                        description: Elasticsearch holds all connection parameters
+                          for Elasticsearch datastores.
+                        properties:
+                          closeIdleConnectionsInterval:
+                            description: CloseIdleConnectionsInterval is the max duration
+                              a connection stay open while idle.
+                            type: string
+                          enableHealthcheck:
+                            description: EnableHealthcheck enables or disables healthcheck
+                              on the temporal cluster's es client.
+                            type: boolean
+                          enableSniff:
+                            description: EnableSniff enables or disables sniffer on
+                              the temporal cluster's es client.
+                            type: boolean
+                          indices:
+                            description: Indices holds visibility index names.
+                            properties:
+                              secondaryVisibility:
+                                description: SecondaryVisibility defines secondary
+                                  visibility's index name.
+                                type: string
+                              visibility:
+                                default: temporal_visibility_v1
+                                description: Visibility defines visibility's index
+                                  name.
+                                type: string
+                            required:
+                            - visibility
+                            type: object
+                          logLevel:
+                            description: LogLevel defines the temporal cluster's es
+                              client logger level.
+                            type: string
+                          url:
+                            description: URL is the connection url to connect to the
+                              instance.
+                            pattern: ^https?:\/\/.+$
+                            type: string
+                          username:
+                            description: Username is the username to be used for the
+                              connection.
+                            type: string
+                          version:
+                            default: v7
+                            description: Version defines the elasticsearch version.
+                            pattern: ^v(6|7|8)$
+                            type: string
+                        required:
+                        - indices
+                        - url
+                        - username
+                        - version
+                        type: object
+                      name:
+                        description: |-
+                          Name is the name of the datastore.
+                          It should be unique and will be referenced within the persistence spec.
+                          Defaults to "default" for default sore, "visibility" for visibility store,
+                          "secondaryVisibility" for secondary visibility store and
+                          "advancedVisibility" for advanced visibility store.
+                        type: string
+                      passwordSecretRef:
+                        description: PasswordSecret is the reference to the secret
+                          holding the password.
+                        properties:
+                          key:
+                            description: Key in the Secret.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      skipCreate:
+                        description: SkipCreate instructs the operator to skip creating
+                          the database for SQL datastores or to skip creating keyspace
+                          for Cassandra. Use this option if your database or keyspace
+                          has already been provisioned by an administrator.
+                        type: boolean
+                      sql:
+                        description: SQL holds all connection parameters for SQL datastores.
+                        properties:
+                          connectAddr:
+                            description: ConnectAddr is the remote addr of the database.
+                            type: string
+                          connectAttributes:
+                            additionalProperties:
+                              type: string
+                            description: ConnectAttributes is a set of key-value attributes
+                              to be sent as part of connect data_source_name url
+                            type: object
+                          connectProtocol:
+                            description: ConnectProtocol is the protocol that goes
+                              with the ConnectAddr.
+                            type: string
+                          databaseName:
+                            description: DatabaseName is the name of SQL database
+                              to connect to.
+                            type: string
+                          gcpServiceAccount:
+                            description: GCPServiceAccount is the service account
+                              to use to authenticate with GCP CloudSQL.
+                            type: string
+                          maxConnLifetime:
+                            description: MaxConnLifetime is the maximum time a connection
+                              can be alive
+                            type: string
+                          maxConns:
+                            description: MaxConns the max number of connections to
+                              this datastore.
+                            type: integer
+                          maxIdleConns:
+                            description: MaxIdleConns is the max number of idle connections
+                              to this datastore.
+                            type: integer
+                          pluginName:
+                            description: PluginName is the name of SQL plugin.
+                            enum:
+                            - postgres
+                            - postgres12
+                            - mysql
+                            - mysql8
+                            type: string
+                          taskScanPartitions:
+                            description: TaskScanPartitions is the number of partitions
+                              to sequentially scan during ListTaskQueue operations.
+                            type: integer
+                          user:
+                            description: User is the username to be used for the connection.
+                            type: string
+                        required:
+                        - connectAddr
+                        - databaseName
+                        - pluginName
+                        - user
+                        type: object
+                      tls:
+                        description: TLS is an optional option to connect to the datastore
+                          using TLS.
+                        properties:
+                          caFileRef:
+                            description: CaFileRef is a reference to a secret containing
+                              the ca file.
+                            properties:
+                              key:
+                                description: Key in the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          certFileRef:
+                            description: CertFileRef is a reference to a secret containing
+                              the cert file.
+                            properties:
+                              key:
+                                description: Key in the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          enableHostVerification:
+                            description: EnableHostVerification defines if the hostname
+                              should be verified when connecting to the datastore.
+                            type: boolean
+                          enabled:
+                            description: Enabled defines if the cluster should use
+                              a TLS connection to connect to the datastore.
+                            type: boolean
+                          keyFileRef:
+                            description: KeyFileRef is a reference to a secret containing
+                              the key file.
+                            properties:
+                              key:
+                                description: Key in the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          serverName:
+                            description: ServerName the datastore should present.
+                            type: string
+                        required:
+                        - enableHostVerification
+                        - enabled
+                        type: object
+                    type: object
+                  secondaryVisibilityStore:
+                    description: |-
+                      SecondaryVisibilityStore holds the secondary visibility datastore specs.
+                      Feature only available for clusters >= 1.21.0.
+                    properties:
+                      cassandra:
+                        description: |-
+                          Cassandra holds all connection parameters for Cassandra datastore.
+                          Note that cassandra is now deprecated for visibility store.
+                        properties:
+                          connectTimeout:
+                            description: ConnectTimeout is a timeout for initial dial
+                              to cassandra server.
+                            type: string
+                          consistency:
+                            description: Consistency configuration.
+                            properties:
+                              consistency:
+                                description: |-
+                                  Consistency sets the default consistency level.
+                                  Values identical to gocql Consistency values. (defaults to LOCAL_QUORUM if not set).
+                                enum:
+                                - ANY
+                                - ONE
+                                - TWO
+                                - THREE
+                                - QUORUM
+                                - ALL
+                                - LOCAL_QUORUM
+                                - EACH_QUORUM
+                                - LOCAL_ONE
+                                type: integer
+                              serialConsistency:
+                                description: |-
+                                  SerialConsistency sets the consistency for the serial prtion of queries. Values identical to gocql SerialConsistency values.
+                                  (defaults to LOCAL_SERIAL if not set)
+                                enum:
+                                - SERIAL
+                                - LOCAL_SERIAL
+                                type: integer
+                            type: object
+                          datacenter:
+                            description: Datacenter is the data center filter arg
+                              for cassandra.
+                            type: string
+                          disableInitialHostLookup:
+                            description: DisableInitialHostLookup instructs the gocql
+                              client to connect only using the supplied hosts.
+                            type: boolean
+                          hosts:
+                            description: Hosts is a list of cassandra endpoints.
+                            items:
+                              type: string
+                            type: array
+                          keyspace:
+                            description: Keyspace is the cassandra keyspace.
+                            type: string
+                          maxConns:
+                            description: MaxConns is the max number of connections
+                              to this datastore for a single keyspace.
+                            type: integer
+                          port:
+                            description: Port is the cassandra port used for connection
+                              by gocql client.
+                            type: integer
+                          user:
+                            description: User is the cassandra user used for authentication
+                              by gocql client.
+                            type: string
+                        required:
+                        - hosts
+                        - keyspace
+                        - port
+                        - user
+                        type: object
+                      elasticsearch:
+                        description: Elasticsearch holds all connection parameters
+                          for Elasticsearch datastores.
+                        properties:
+                          closeIdleConnectionsInterval:
+                            description: CloseIdleConnectionsInterval is the max duration
+                              a connection stay open while idle.
+                            type: string
+                          enableHealthcheck:
+                            description: EnableHealthcheck enables or disables healthcheck
+                              on the temporal cluster's es client.
+                            type: boolean
+                          enableSniff:
+                            description: EnableSniff enables or disables sniffer on
+                              the temporal cluster's es client.
+                            type: boolean
+                          indices:
+                            description: Indices holds visibility index names.
+                            properties:
+                              secondaryVisibility:
+                                description: SecondaryVisibility defines secondary
+                                  visibility's index name.
+                                type: string
+                              visibility:
+                                default: temporal_visibility_v1
+                                description: Visibility defines visibility's index
+                                  name.
+                                type: string
+                            required:
+                            - visibility
+                            type: object
+                          logLevel:
+                            description: LogLevel defines the temporal cluster's es
+                              client logger level.
+                            type: string
+                          url:
+                            description: URL is the connection url to connect to the
+                              instance.
+                            pattern: ^https?:\/\/.+$
+                            type: string
+                          username:
+                            description: Username is the username to be used for the
+                              connection.
+                            type: string
+                          version:
+                            default: v7
+                            description: Version defines the elasticsearch version.
+                            pattern: ^v(6|7|8)$
+                            type: string
+                        required:
+                        - indices
+                        - url
+                        - username
+                        - version
+                        type: object
+                      name:
+                        description: |-
+                          Name is the name of the datastore.
+                          It should be unique and will be referenced within the persistence spec.
+                          Defaults to "default" for default sore, "visibility" for visibility store,
+                          "secondaryVisibility" for secondary visibility store and
+                          "advancedVisibility" for advanced visibility store.
+                        type: string
+                      passwordSecretRef:
+                        description: PasswordSecret is the reference to the secret
+                          holding the password.
+                        properties:
+                          key:
+                            description: Key in the Secret.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      skipCreate:
+                        description: SkipCreate instructs the operator to skip creating
+                          the database for SQL datastores or to skip creating keyspace
+                          for Cassandra. Use this option if your database or keyspace
+                          has already been provisioned by an administrator.
+                        type: boolean
+                      sql:
+                        description: SQL holds all connection parameters for SQL datastores.
+                        properties:
+                          connectAddr:
+                            description: ConnectAddr is the remote addr of the database.
+                            type: string
+                          connectAttributes:
+                            additionalProperties:
+                              type: string
+                            description: ConnectAttributes is a set of key-value attributes
+                              to be sent as part of connect data_source_name url
+                            type: object
+                          connectProtocol:
+                            description: ConnectProtocol is the protocol that goes
+                              with the ConnectAddr.
+                            type: string
+                          databaseName:
+                            description: DatabaseName is the name of SQL database
+                              to connect to.
+                            type: string
+                          gcpServiceAccount:
+                            description: GCPServiceAccount is the service account
+                              to use to authenticate with GCP CloudSQL.
+                            type: string
+                          maxConnLifetime:
+                            description: MaxConnLifetime is the maximum time a connection
+                              can be alive
+                            type: string
+                          maxConns:
+                            description: MaxConns the max number of connections to
+                              this datastore.
+                            type: integer
+                          maxIdleConns:
+                            description: MaxIdleConns is the max number of idle connections
+                              to this datastore.
+                            type: integer
+                          pluginName:
+                            description: PluginName is the name of SQL plugin.
+                            enum:
+                            - postgres
+                            - postgres12
+                            - mysql
+                            - mysql8
+                            type: string
+                          taskScanPartitions:
+                            description: TaskScanPartitions is the number of partitions
+                              to sequentially scan during ListTaskQueue operations.
+                            type: integer
+                          user:
+                            description: User is the username to be used for the connection.
+                            type: string
+                        required:
+                        - connectAddr
+                        - databaseName
+                        - pluginName
+                        - user
+                        type: object
+                      tls:
+                        description: TLS is an optional option to connect to the datastore
+                          using TLS.
+                        properties:
+                          caFileRef:
+                            description: CaFileRef is a reference to a secret containing
+                              the ca file.
+                            properties:
+                              key:
+                                description: Key in the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          certFileRef:
+                            description: CertFileRef is a reference to a secret containing
+                              the cert file.
+                            properties:
+                              key:
+                                description: Key in the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          enableHostVerification:
+                            description: EnableHostVerification defines if the hostname
+                              should be verified when connecting to the datastore.
+                            type: boolean
+                          enabled:
+                            description: Enabled defines if the cluster should use
+                              a TLS connection to connect to the datastore.
+                            type: boolean
+                          keyFileRef:
+                            description: KeyFileRef is a reference to a secret containing
+                              the key file.
+                            properties:
+                              key:
+                                description: Key in the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          serverName:
+                            description: ServerName the datastore should present.
+                            type: string
+                        required:
+                        - enableHostVerification
+                        - enabled
+                        type: object
+                    type: object
+                  visibilityStore:
+                    description: VisibilityStore holds the visibility datastore specs.
+                    properties:
+                      cassandra:
+                        description: |-
+                          Cassandra holds all connection parameters for Cassandra datastore.
+                          Note that cassandra is now deprecated for visibility store.
+                        properties:
+                          connectTimeout:
+                            description: ConnectTimeout is a timeout for initial dial
+                              to cassandra server.
+                            type: string
+                          consistency:
+                            description: Consistency configuration.
+                            properties:
+                              consistency:
+                                description: |-
+                                  Consistency sets the default consistency level.
+                                  Values identical to gocql Consistency values. (defaults to LOCAL_QUORUM if not set).
+                                enum:
+                                - ANY
+                                - ONE
+                                - TWO
+                                - THREE
+                                - QUORUM
+                                - ALL
+                                - LOCAL_QUORUM
+                                - EACH_QUORUM
+                                - LOCAL_ONE
+                                type: integer
+                              serialConsistency:
+                                description: |-
+                                  SerialConsistency sets the consistency for the serial prtion of queries. Values identical to gocql SerialConsistency values.
+                                  (defaults to LOCAL_SERIAL if not set)
+                                enum:
+                                - SERIAL
+                                - LOCAL_SERIAL
+                                type: integer
+                            type: object
+                          datacenter:
+                            description: Datacenter is the data center filter arg
+                              for cassandra.
+                            type: string
+                          disableInitialHostLookup:
+                            description: DisableInitialHostLookup instructs the gocql
+                              client to connect only using the supplied hosts.
+                            type: boolean
+                          hosts:
+                            description: Hosts is a list of cassandra endpoints.
+                            items:
+                              type: string
+                            type: array
+                          keyspace:
+                            description: Keyspace is the cassandra keyspace.
+                            type: string
+                          maxConns:
+                            description: MaxConns is the max number of connections
+                              to this datastore for a single keyspace.
+                            type: integer
+                          port:
+                            description: Port is the cassandra port used for connection
+                              by gocql client.
+                            type: integer
+                          user:
+                            description: User is the cassandra user used for authentication
+                              by gocql client.
+                            type: string
+                        required:
+                        - hosts
+                        - keyspace
+                        - port
+                        - user
+                        type: object
+                      elasticsearch:
+                        description: Elasticsearch holds all connection parameters
+                          for Elasticsearch datastores.
+                        properties:
+                          closeIdleConnectionsInterval:
+                            description: CloseIdleConnectionsInterval is the max duration
+                              a connection stay open while idle.
+                            type: string
+                          enableHealthcheck:
+                            description: EnableHealthcheck enables or disables healthcheck
+                              on the temporal cluster's es client.
+                            type: boolean
+                          enableSniff:
+                            description: EnableSniff enables or disables sniffer on
+                              the temporal cluster's es client.
+                            type: boolean
+                          indices:
+                            description: Indices holds visibility index names.
+                            properties:
+                              secondaryVisibility:
+                                description: SecondaryVisibility defines secondary
+                                  visibility's index name.
+                                type: string
+                              visibility:
+                                default: temporal_visibility_v1
+                                description: Visibility defines visibility's index
+                                  name.
+                                type: string
+                            required:
+                            - visibility
+                            type: object
+                          logLevel:
+                            description: LogLevel defines the temporal cluster's es
+                              client logger level.
+                            type: string
+                          url:
+                            description: URL is the connection url to connect to the
+                              instance.
+                            pattern: ^https?:\/\/.+$
+                            type: string
+                          username:
+                            description: Username is the username to be used for the
+                              connection.
+                            type: string
+                          version:
+                            default: v7
+                            description: Version defines the elasticsearch version.
+                            pattern: ^v(6|7|8)$
+                            type: string
+                        required:
+                        - indices
+                        - url
+                        - username
+                        - version
+                        type: object
+                      name:
+                        description: |-
+                          Name is the name of the datastore.
+                          It should be unique and will be referenced within the persistence spec.
+                          Defaults to "default" for default sore, "visibility" for visibility store,
+                          "secondaryVisibility" for secondary visibility store and
+                          "advancedVisibility" for advanced visibility store.
+                        type: string
+                      passwordSecretRef:
+                        description: PasswordSecret is the reference to the secret
+                          holding the password.
+                        properties:
+                          key:
+                            description: Key in the Secret.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      skipCreate:
+                        description: SkipCreate instructs the operator to skip creating
+                          the database for SQL datastores or to skip creating keyspace
+                          for Cassandra. Use this option if your database or keyspace
+                          has already been provisioned by an administrator.
+                        type: boolean
+                      sql:
+                        description: SQL holds all connection parameters for SQL datastores.
+                        properties:
+                          connectAddr:
+                            description: ConnectAddr is the remote addr of the database.
+                            type: string
+                          connectAttributes:
+                            additionalProperties:
+                              type: string
+                            description: ConnectAttributes is a set of key-value attributes
+                              to be sent as part of connect data_source_name url
+                            type: object
+                          connectProtocol:
+                            description: ConnectProtocol is the protocol that goes
+                              with the ConnectAddr.
+                            type: string
+                          databaseName:
+                            description: DatabaseName is the name of SQL database
+                              to connect to.
+                            type: string
+                          gcpServiceAccount:
+                            description: GCPServiceAccount is the service account
+                              to use to authenticate with GCP CloudSQL.
+                            type: string
+                          maxConnLifetime:
+                            description: MaxConnLifetime is the maximum time a connection
+                              can be alive
+                            type: string
+                          maxConns:
+                            description: MaxConns the max number of connections to
+                              this datastore.
+                            type: integer
+                          maxIdleConns:
+                            description: MaxIdleConns is the max number of idle connections
+                              to this datastore.
+                            type: integer
+                          pluginName:
+                            description: PluginName is the name of SQL plugin.
+                            enum:
+                            - postgres
+                            - postgres12
+                            - mysql
+                            - mysql8
+                            type: string
+                          taskScanPartitions:
+                            description: TaskScanPartitions is the number of partitions
+                              to sequentially scan during ListTaskQueue operations.
+                            type: integer
+                          user:
+                            description: User is the username to be used for the connection.
+                            type: string
+                        required:
+                        - connectAddr
+                        - databaseName
+                        - pluginName
+                        - user
+                        type: object
+                      tls:
+                        description: TLS is an optional option to connect to the datastore
+                          using TLS.
+                        properties:
+                          caFileRef:
+                            description: CaFileRef is a reference to a secret containing
+                              the ca file.
+                            properties:
+                              key:
+                                description: Key in the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          certFileRef:
+                            description: CertFileRef is a reference to a secret containing
+                              the cert file.
+                            properties:
+                              key:
+                                description: Key in the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          enableHostVerification:
+                            description: EnableHostVerification defines if the hostname
+                              should be verified when connecting to the datastore.
+                            type: boolean
+                          enabled:
+                            description: Enabled defines if the cluster should use
+                              a TLS connection to connect to the datastore.
+                            type: boolean
+                          keyFileRef:
+                            description: KeyFileRef is a reference to a secret containing
+                              the key file.
+                            properties:
+                              key:
+                                description: Key in the Secret.
+                                type: string
+                              name:
+                                description: Name of the Secret.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          serverName:
+                            description: ServerName the datastore should present.
+                            type: string
+                        required:
+                        - enableHostVerification
+                        - enabled
+                        type: object
+                    type: object
+                required:
+                - defaultStore
+                - visibilityStore
+                type: object
+              services:
+                description: Services allows customizations for each temporal services
+                  deployment.
+                properties:
+                  frontend:
+                    description: Frontend service custom specifications.
+                    properties:
+                      httpPort:
+                        description: |-
+                          HTTPPort defines a custom http port for the service.
+                          Default values are:
+                          7243 for Frontend service
+                        format: int32
+                        type: integer
+                      initContainers:
+                        description: InitContainers adds a list of init containers
+                          to the service's deployment.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        type: array
+                      membershipPort:
+                        description: |-
+                          MembershipPort defines a custom membership port for the service.
+                          Default values are:
+                          6933 for Frontend service
+                          6934 for History service
+                          6935 for Matching service
+                          6939 for Worker service
+                        format: int32
+                        type: integer
+                      overrides:
+                        description: |-
+                          Overrides adds some overrides to the resources deployed for the service.
+                          Those overrides takes precedence over spec.services.overrides.
+                        properties:
+                          deployment:
+                            description: Override configuration for the temporal service
+                              Deployment.
+                            properties:
+                              jsonPatch:
+                                x-kubernetes-preserve-unknown-fields: true
+                              metadata:
+                                description: |-
+                                  ObjectMetaOverride provides the ability to override an object metadata.
+                                  It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Annotations is an unstructured key value map stored with a resource that may be
+                                      set by external tools to store and retrieve arbitrary metadata.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Map of string keys and values that can be used to organize and categorize
+                                      (scope and select) objects.
+                                    type: object
+                                type: object
+                              spec:
+                                description: Specification of the desired behavior
+                                  of the Deployment.
+                                properties:
+                                  template:
+                                    description: Template describes the pods that
+                                      will be created.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMetaOverride provides the ability to override an object metadata.
+                                          It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              Annotations is an unstructured key value map stored with a resource that may be
+                                              set by external tools to store and retrieve arbitrary metadata.
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              Map of string keys and values that can be used to organize and categorize
+                                              (scope and select) objects.
+                                            type: object
+                                        type: object
+                                      spec:
+                                        description: Specification of the desired
+                                          behavior of the pod.
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                      port:
+                        description: |-
+                          Port defines a custom gRPC port for the service.
+                          Default values are:
+                          7233 for Frontend service
+                          7234 for History service
+                          7235 for Matching service
+                          7239 for Worker service
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: Number of desired replicas for the service. Default
+                          to 1.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      resources:
+                        description: |-
+                          Compute Resources required by this service.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    type: object
+                  history:
+                    description: History service custom specifications.
+                    properties:
+                      httpPort:
+                        description: |-
+                          HTTPPort defines a custom http port for the service.
+                          Default values are:
+                          7243 for Frontend service
+                        format: int32
+                        type: integer
+                      initContainers:
+                        description: InitContainers adds a list of init containers
+                          to the service's deployment.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        type: array
+                      membershipPort:
+                        description: |-
+                          MembershipPort defines a custom membership port for the service.
+                          Default values are:
+                          6933 for Frontend service
+                          6934 for History service
+                          6935 for Matching service
+                          6939 for Worker service
+                        format: int32
+                        type: integer
+                      overrides:
+                        description: |-
+                          Overrides adds some overrides to the resources deployed for the service.
+                          Those overrides takes precedence over spec.services.overrides.
+                        properties:
+                          deployment:
+                            description: Override configuration for the temporal service
+                              Deployment.
+                            properties:
+                              jsonPatch:
+                                x-kubernetes-preserve-unknown-fields: true
+                              metadata:
+                                description: |-
+                                  ObjectMetaOverride provides the ability to override an object metadata.
+                                  It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Annotations is an unstructured key value map stored with a resource that may be
+                                      set by external tools to store and retrieve arbitrary metadata.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Map of string keys and values that can be used to organize and categorize
+                                      (scope and select) objects.
+                                    type: object
+                                type: object
+                              spec:
+                                description: Specification of the desired behavior
+                                  of the Deployment.
+                                properties:
+                                  template:
+                                    description: Template describes the pods that
+                                      will be created.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMetaOverride provides the ability to override an object metadata.
+                                          It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              Annotations is an unstructured key value map stored with a resource that may be
+                                              set by external tools to store and retrieve arbitrary metadata.
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              Map of string keys and values that can be used to organize and categorize
+                                              (scope and select) objects.
+                                            type: object
+                                        type: object
+                                      spec:
+                                        description: Specification of the desired
+                                          behavior of the pod.
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                      port:
+                        description: |-
+                          Port defines a custom gRPC port for the service.
+                          Default values are:
+                          7233 for Frontend service
+                          7234 for History service
+                          7235 for Matching service
+                          7239 for Worker service
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: Number of desired replicas for the service. Default
+                          to 1.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      resources:
+                        description: |-
+                          Compute Resources required by this service.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    type: object
+                  internalFrontend:
+                    description: |-
+                      Internal Frontend service custom specifications.
+                      Only compatible with temporal >= 1.20.0
+                    properties:
+                      enabled:
+                        default: false
+                        description: Enabled defines if we want to spawn the internal
+                          frontend service.
+                        type: boolean
+                      httpPort:
+                        description: |-
+                          HTTPPort defines a custom http port for the service.
+                          Default values are:
+                          7243 for Frontend service
+                        format: int32
+                        type: integer
+                      initContainers:
+                        description: InitContainers adds a list of init containers
+                          to the service's deployment.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        type: array
+                      membershipPort:
+                        description: |-
+                          MembershipPort defines a custom membership port for the service.
+                          Default values are:
+                          6933 for Frontend service
+                          6934 for History service
+                          6935 for Matching service
+                          6939 for Worker service
+                        format: int32
+                        type: integer
+                      overrides:
+                        description: |-
+                          Overrides adds some overrides to the resources deployed for the service.
+                          Those overrides takes precedence over spec.services.overrides.
+                        properties:
+                          deployment:
+                            description: Override configuration for the temporal service
+                              Deployment.
+                            properties:
+                              jsonPatch:
+                                x-kubernetes-preserve-unknown-fields: true
+                              metadata:
+                                description: |-
+                                  ObjectMetaOverride provides the ability to override an object metadata.
+                                  It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Annotations is an unstructured key value map stored with a resource that may be
+                                      set by external tools to store and retrieve arbitrary metadata.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Map of string keys and values that can be used to organize and categorize
+                                      (scope and select) objects.
+                                    type: object
+                                type: object
+                              spec:
+                                description: Specification of the desired behavior
+                                  of the Deployment.
+                                properties:
+                                  template:
+                                    description: Template describes the pods that
+                                      will be created.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMetaOverride provides the ability to override an object metadata.
+                                          It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              Annotations is an unstructured key value map stored with a resource that may be
+                                              set by external tools to store and retrieve arbitrary metadata.
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              Map of string keys and values that can be used to organize and categorize
+                                              (scope and select) objects.
+                                            type: object
+                                        type: object
+                                      spec:
+                                        description: Specification of the desired
+                                          behavior of the pod.
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                      port:
+                        description: |-
+                          Port defines a custom gRPC port for the service.
+                          Default values are:
+                          7233 for Frontend service
+                          7234 for History service
+                          7235 for Matching service
+                          7239 for Worker service
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: Number of desired replicas for the service. Default
+                          to 1.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      resources:
+                        description: |-
+                          Compute Resources required by this service.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    type: object
+                  matching:
+                    description: Matching service custom specifications.
+                    properties:
+                      httpPort:
+                        description: |-
+                          HTTPPort defines a custom http port for the service.
+                          Default values are:
+                          7243 for Frontend service
+                        format: int32
+                        type: integer
+                      initContainers:
+                        description: InitContainers adds a list of init containers
+                          to the service's deployment.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        type: array
+                      membershipPort:
+                        description: |-
+                          MembershipPort defines a custom membership port for the service.
+                          Default values are:
+                          6933 for Frontend service
+                          6934 for History service
+                          6935 for Matching service
+                          6939 for Worker service
+                        format: int32
+                        type: integer
+                      overrides:
+                        description: |-
+                          Overrides adds some overrides to the resources deployed for the service.
+                          Those overrides takes precedence over spec.services.overrides.
+                        properties:
+                          deployment:
+                            description: Override configuration for the temporal service
+                              Deployment.
+                            properties:
+                              jsonPatch:
+                                x-kubernetes-preserve-unknown-fields: true
+                              metadata:
+                                description: |-
+                                  ObjectMetaOverride provides the ability to override an object metadata.
+                                  It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Annotations is an unstructured key value map stored with a resource that may be
+                                      set by external tools to store and retrieve arbitrary metadata.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Map of string keys and values that can be used to organize and categorize
+                                      (scope and select) objects.
+                                    type: object
+                                type: object
+                              spec:
+                                description: Specification of the desired behavior
+                                  of the Deployment.
+                                properties:
+                                  template:
+                                    description: Template describes the pods that
+                                      will be created.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMetaOverride provides the ability to override an object metadata.
+                                          It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              Annotations is an unstructured key value map stored with a resource that may be
+                                              set by external tools to store and retrieve arbitrary metadata.
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              Map of string keys and values that can be used to organize and categorize
+                                              (scope and select) objects.
+                                            type: object
+                                        type: object
+                                      spec:
+                                        description: Specification of the desired
+                                          behavior of the pod.
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                      port:
+                        description: |-
+                          Port defines a custom gRPC port for the service.
+                          Default values are:
+                          7233 for Frontend service
+                          7234 for History service
+                          7235 for Matching service
+                          7239 for Worker service
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: Number of desired replicas for the service. Default
+                          to 1.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      resources:
+                        description: |-
+                          Compute Resources required by this service.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    type: object
+                  overrides:
+                    description: |-
+                      Overrides adds some overrides to the resources deployed for all temporal services services.
+                      Those overrides can be customized per service using spec.services.<serviceName>.overrides.
+                    properties:
+                      deployment:
+                        description: Override configuration for the temporal service
+                          Deployment.
+                        properties:
+                          jsonPatch:
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            description: |-
+                              ObjectMetaOverride provides the ability to override an object metadata.
+                              It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Annotations is an unstructured key value map stored with a resource that may be
+                                  set by external tools to store and retrieve arbitrary metadata.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Map of string keys and values that can be used to organize and categorize
+                                  (scope and select) objects.
+                                type: object
+                            type: object
+                          spec:
+                            description: Specification of the desired behavior of
+                              the Deployment.
+                            properties:
+                              template:
+                                description: Template describes the pods that will
+                                  be created.
+                                properties:
+                                  metadata:
+                                    description: |-
+                                      ObjectMetaOverride provides the ability to override an object metadata.
+                                      It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          Annotations is an unstructured key value map stored with a resource that may be
+                                          set by external tools to store and retrieve arbitrary metadata.
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          Map of string keys and values that can be used to organize and categorize
+                                          (scope and select) objects.
+                                        type: object
+                                    type: object
+                                  spec:
+                                    description: Specification of the desired behavior
+                                      of the pod.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  worker:
+                    description: Worker service custom specifications.
+                    properties:
+                      httpPort:
+                        description: |-
+                          HTTPPort defines a custom http port for the service.
+                          Default values are:
+                          7243 for Frontend service
+                        format: int32
+                        type: integer
+                      initContainers:
+                        description: InitContainers adds a list of init containers
+                          to the service's deployment.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        type: array
+                      membershipPort:
+                        description: |-
+                          MembershipPort defines a custom membership port for the service.
+                          Default values are:
+                          6933 for Frontend service
+                          6934 for History service
+                          6935 for Matching service
+                          6939 for Worker service
+                        format: int32
+                        type: integer
+                      overrides:
+                        description: |-
+                          Overrides adds some overrides to the resources deployed for the service.
+                          Those overrides takes precedence over spec.services.overrides.
+                        properties:
+                          deployment:
+                            description: Override configuration for the temporal service
+                              Deployment.
+                            properties:
+                              jsonPatch:
+                                x-kubernetes-preserve-unknown-fields: true
+                              metadata:
+                                description: |-
+                                  ObjectMetaOverride provides the ability to override an object metadata.
+                                  It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Annotations is an unstructured key value map stored with a resource that may be
+                                      set by external tools to store and retrieve arbitrary metadata.
+                                    type: object
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      Map of string keys and values that can be used to organize and categorize
+                                      (scope and select) objects.
+                                    type: object
+                                type: object
+                              spec:
+                                description: Specification of the desired behavior
+                                  of the Deployment.
+                                properties:
+                                  template:
+                                    description: Template describes the pods that
+                                      will be created.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          ObjectMetaOverride provides the ability to override an object metadata.
+                                          It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                        properties:
+                                          annotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              Annotations is an unstructured key value map stored with a resource that may be
+                                              set by external tools to store and retrieve arbitrary metadata.
+                                            type: object
+                                          labels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              Map of string keys and values that can be used to organize and categorize
+                                              (scope and select) objects.
+                                            type: object
+                                        type: object
+                                      spec:
+                                        description: Specification of the desired
+                                          behavior of the pod.
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    type: object
+                                type: object
+                            type: object
+                        type: object
+                      port:
+                        description: |-
+                          Port defines a custom gRPC port for the service.
+                          Default values are:
+                          7233 for Frontend service
+                          7234 for History service
+                          7235 for Matching service
+                          7239 for Worker service
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: Number of desired replicas for the service. Default
+                          to 1.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      resources:
+                        description: |-
+                          Compute Resources required by this service.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              ui:
+                description: UI allows configuration of the optional temporal web
+                  ui deployed alongside the cluster.
+                properties:
+                  enabled:
+                    description: Enabled defines if the operator should deploy the
+                      web ui alongside the cluster.
+                    type: boolean
+                  image:
+                    description: Image defines the temporal ui docker image the instance
+                      should run.
+                    type: string
+                  ingress:
+                    description: |-
+                      Ingress is an optional ingress configuration for the UI.
+                      If lived empty, no ingress configuration will be created and the UI will only by available trough ClusterIP service.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations allows custom annotations on the
+                          ingress resource.
+                        type: object
+                      hosts:
+                        description: Host is the list of host the ingress should use.
+                        items:
+                          type: string
+                        type: array
+                      ingressClassName:
+                        description: IngressClassName is the name of the IngressClass
+                          the deployed ingress resource should use.
+                        type: string
+                      tls:
+                        description: TLS configuration.
+                        items:
+                          description: IngressTLS describes the transport layer security
+                            associated with an ingress.
+                          properties:
+                            hosts:
+                              description: |-
+                                hosts is a list of hosts included in the TLS certificate. The values in
+                                this list must match the name/s used in the tlsSecret. Defaults to the
+                                wildcard host setting for the loadbalancer controller fulfilling this
+                                Ingress, if left unspecified.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            secretName:
+                              description: |-
+                                secretName is the name of the secret used to terminate TLS traffic on
+                                port 443. Field is left optional to allow TLS routing based on SNI
+                                hostname alone. If the SNI host in a listener conflicts with the "Host"
+                                header field used by an IngressRule, the SNI host is used for termination
+                                and value of the "Host" header is used for routing.
+                              type: string
+                          type: object
+                        type: array
+                    required:
+                    - hosts
+                    type: object
+                  overrides:
+                    description: Overrides adds some overrides to the resources deployed
+                      for the ui.
+                    properties:
+                      deployment:
+                        description: Override configuration for the temporal service
+                          Deployment.
+                        properties:
+                          jsonPatch:
+                            x-kubernetes-preserve-unknown-fields: true
+                          metadata:
+                            description: |-
+                              ObjectMetaOverride provides the ability to override an object metadata.
+                              It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Annotations is an unstructured key value map stored with a resource that may be
+                                  set by external tools to store and retrieve arbitrary metadata.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Map of string keys and values that can be used to organize and categorize
+                                  (scope and select) objects.
+                                type: object
+                            type: object
+                          spec:
+                            description: Specification of the desired behavior of
+                              the Deployment.
+                            properties:
+                              template:
+                                description: Template describes the pods that will
+                                  be created.
+                                properties:
+                                  metadata:
+                                    description: |-
+                                      ObjectMetaOverride provides the ability to override an object metadata.
+                                      It's a subset of the fields included in k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          Annotations is an unstructured key value map stored with a resource that may be
+                                          set by external tools to store and retrieve arbitrary metadata.
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          Map of string keys and values that can be used to organize and categorize
+                                          (scope and select) objects.
+                                        type: object
+                                    type: object
+                                  spec:
+                                    description: Specification of the desired behavior
+                                      of the pod.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                  replicas:
+                    description: Number of desired replicas for the ui. Default to
+                      1.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  resources:
+                    description: |-
+                      Compute Resources required by the ui.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  service:
+                    description: Service is an optional service resource configuration
+                      for the UI.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata.
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects.
+                        type: object
+                    type: object
+                  version:
+                    description: Version defines the temporal ui version the instance
+                      should run.
+                    type: string
+                type: object
+              version:
+                description: |-
+                  Version defines the temporal version the cluster to be deployed.
+                  This version impacts the underlying persistence schemas versions.
+                type: string
+            required:
+            - numHistoryShards
+            - persistence
+            type: object
+          status:
+            description: Most recent observed status of the Temporal cluster.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the Cluster state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              persistence:
+                description: Persistence holds all datastores statuses.
+                properties:
+                  advancedVisibilityStore:
+                    description: AdvancedVisibilityStore holds the advanced visibility
+                      datastore status.
+                    properties:
+                      created:
+                        description: Created indicates if the database or keyspace
+                          has been created.
+                        type: boolean
+                      schemaVersion:
+                        description: SchemaVersion report the current schema version.
+                        type: string
+                      setup:
+                        description: Setup indicates if tables have been set up.
+                        type: boolean
+                      type:
+                        description: Type indicates the datastore type.
+                        type: string
+                    required:
+                    - created
+                    - setup
+                    type: object
+                  defaultStore:
+                    description: DefaultStore holds the default datastore status.
+                    properties:
+                      created:
+                        description: Created indicates if the database or keyspace
+                          has been created.
+                        type: boolean
+                      schemaVersion:
+                        description: SchemaVersion report the current schema version.
+                        type: string
+                      setup:
+                        description: Setup indicates if tables have been set up.
+                        type: boolean
+                      type:
+                        description: Type indicates the datastore type.
+                        type: string
+                    required:
+                    - created
+                    - setup
+                    type: object
+                  secondaryVisibilityStore:
+                    description: SecondaryVisibilityStore holds the secondary visibility
+                      datastore status.
+                    properties:
+                      created:
+                        description: Created indicates if the database or keyspace
+                          has been created.
+                        type: boolean
+                      schemaVersion:
+                        description: SchemaVersion report the current schema version.
+                        type: string
+                      setup:
+                        description: Setup indicates if tables have been set up.
+                        type: boolean
+                      type:
+                        description: Type indicates the datastore type.
+                        type: string
+                    required:
+                    - created
+                    - setup
+                    type: object
+                  visibilityStore:
+                    description: VisibilityStore holds the visibility datastore status.
+                    properties:
+                      created:
+                        description: Created indicates if the database or keyspace
+                          has been created.
+                        type: boolean
+                      schemaVersion:
+                        description: SchemaVersion report the current schema version.
+                        type: string
+                      setup:
+                        description: Setup indicates if tables have been set up.
+                        type: boolean
+                      type:
+                        description: Type indicates the datastore type.
+                        type: string
+                    required:
+                    - created
+                    - setup
+                    type: object
+                required:
+                - defaultStore
+                - visibilityStore
+                type: object
+              services:
+                description: Services holds all services statuses.
+                items:
+                  description: ServiceStatus reports a service status.
+                  properties:
+                    name:
+                      description: Name of the temporal service.
+                      type: string
+                    ready:
+                      description: Ready defines if the service is ready.
+                      type: boolean
+                    version:
+                      description: Current observed version of the service.
+                      type: string
+                  required:
+                  - name
+                  - ready
+                  - version
+                  type: object
+                type: array
+              version:
+                description: Version holds the current temporal version.
+                type: string
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/temporal-operator/0.21.0/bundle/manifests/temporal.io_temporalnamespaces.yaml
+++ b/operators/temporal-operator/0.21.0/bundle/manifests/temporal.io_temporalnamespaces.yaml
@@ -1,0 +1,231 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  creationTimestamp: null
+  name: temporalnamespaces.temporal.io
+spec:
+  group: temporal.io
+  names:
+    kind: TemporalNamespace
+    listKind: TemporalNamespaceList
+    plural: temporalnamespaces
+    singular: temporalnamespace
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: A TemporalNamespace creates a namespace in the targeted temporal
+          cluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TemporalNamespaceSpec defines the desired state of Namespace.
+            properties:
+              activeClusterName:
+                description: |-
+                  The name of active Temporal Cluster.
+                  Only applicable if the namespace is a global namespace.
+                type: string
+              allowDeletion:
+                description: |-
+                  AllowDeletion makes the controller delete the Temporal namespace if the
+                  CRD is deleted.
+                type: boolean
+              archival:
+                description: |-
+                  Archival is a per-namespace archival configuration.
+                  If not set, the default cluster configuration is used.
+                properties:
+                  history:
+                    description: History is the config for this namespace history
+                      archival.
+                    properties:
+                      enableRead:
+                        default: false
+                        description: EnableRead allows temporal to read from the archived
+                          Event History.
+                        type: boolean
+                      enabled:
+                        default: false
+                        description: |-
+                          Enabled defines if the archival is enabled by default for all namespaces
+                          or for a particular namespace (depends if it's for a TemporalCluster or a TemporalNamespace).
+                        type: boolean
+                      path:
+                        description: Path is ...
+                        type: string
+                      paused:
+                        default: false
+                        description: Paused defines if the archival is paused.
+                        type: boolean
+                    required:
+                    - enableRead
+                    - path
+                    - paused
+                    type: object
+                  visibility:
+                    description: Visibility is the config for this namespace visibility
+                      archival.
+                    properties:
+                      enableRead:
+                        default: false
+                        description: EnableRead allows temporal to read from the archived
+                          Event History.
+                        type: boolean
+                      enabled:
+                        default: false
+                        description: |-
+                          Enabled defines if the archival is enabled by default for all namespaces
+                          or for a particular namespace (depends if it's for a TemporalCluster or a TemporalNamespace).
+                        type: boolean
+                      path:
+                        description: Path is ...
+                        type: string
+                      paused:
+                        default: false
+                        description: Paused defines if the archival is paused.
+                        type: boolean
+                    required:
+                    - enableRead
+                    - path
+                    - paused
+                    type: object
+                type: object
+              clusterRef:
+                description: Reference to the temporal cluster the namespace will
+                  be created.
+                properties:
+                  name:
+                    description: The name of the temporal object to reference.
+                    type: string
+                  namespace:
+                    description: |-
+                      The namespace of the temporal object to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              clusters:
+                description: |-
+                  List of clusters names to which the namespace can fail over.
+                  Only applicable if the namespace is a global namespace.
+                items:
+                  type: string
+                type: array
+              data:
+                additionalProperties:
+                  type: string
+                description: Data is a key-value map for any customized purpose.
+                type: object
+              description:
+                description: Namespace description.
+                type: string
+              isGlobalNamespace:
+                description: IsGlobalNamespace defines whether the namespace is a
+                  global namespace.
+                type: boolean
+              ownerEmail:
+                description: Namespace owner email.
+                type: string
+              retentionPeriod:
+                description: RetentionPeriod to apply on closed workflow executions.
+                type: string
+              securityToken:
+                type: string
+            required:
+            - clusterRef
+            - retentionPeriod
+            type: object
+          status:
+            description: TemporalNamespaceStatus defines the observed state of Namespace.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the Namespace state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/temporal-operator/0.21.0/bundle/manifests/temporal.io_temporalschedules.yaml
+++ b/operators/temporal-operator/0.21.0/bundle/manifests/temporal.io_temporalschedules.yaml
@@ -1,0 +1,1012 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.3
+  creationTimestamp: null
+  name: temporalschedules.temporal.io
+spec:
+  group: temporal.io
+  names:
+    kind: TemporalSchedule
+    listKind: TemporalScheduleList
+    plural: temporalschedules
+    singular: temporalschedule
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type == 'Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type == 'ReconcileSuccess')].status
+      name: ReconcileSuccess
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: A TemporalSchedule creates a schedule in the targeted temporal
+          cluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TemporalScheduleSpec defines the desired state of Schedule.
+            properties:
+              allowDeletion:
+                description: |-
+                  AllowDeletion makes the controller delete the Temporal schedule if the
+                  CRD is deleted.
+                type: boolean
+              memo:
+                description: Memo is optional non-indexed info that will be shown
+                  in list workflow.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              namespaceRef:
+                description: Reference to the temporal namespace the schedule will
+                  be created in.
+                properties:
+                  name:
+                    description: The name of the temporal object to reference.
+                    type: string
+                  namespace:
+                    description: |-
+                      The namespace of the temporal object to reference.
+                      Defaults to the namespace of the requested resource if omitted.
+                    type: string
+                type: object
+              schedule:
+                description: Schedule contains all fields related to a schedule.
+                properties:
+                  action:
+                    description: ScheduleAction contains the actions that the schedule
+                      should perform.
+                    properties:
+                      workflow:
+                        description: ScheduleWorkflowAction describes a workflow to
+                          launch.
+                        properties:
+                          executionTimeout:
+                            description: WorkflowExecutionTimeout is the timeout for
+                              duration of workflow execution.
+                            type: string
+                          id:
+                            description: |-
+                              WorkflowID represents the business identifier of the workflow execution.
+                              The WorkflowID of the started workflow may not match this exactly,
+                              it may have a timestamp appended for uniqueness.
+                              Defaults to a uuid.
+                            type: string
+                          inputs:
+                            description: Inputs contains arguments to pass to the
+                              workflow.
+                            x-kubernetes-preserve-unknown-fields: true
+                          memo:
+                            description: Memo is optional non-indexed info that will
+                              be shown in list workflow.
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          retryPolicy:
+                            description: |-
+                              RetryPolicy is the retry policy for the workflow. If a retry policy is specified,
+                              in case of workflow failure server will start new workflow execution if
+                              needed based on the retry policy.
+                            properties:
+                              backoffCoefficient:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  Coefficient used to calculate the next retry interval.
+                                  The next retry interval is previous interval multiplied by the coefficient.
+                                  Must be 1 or larger.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              initialInterval:
+                                description: Interval of the first retry. If retryBackoffCoefficient
+                                  is 1.0 then it is used for all retries.
+                                type: string
+                              maximumAttempts:
+                                description: |-
+                                  Maximum number of attempts. When exceeded the retries stop even if not expired yet.
+                                  1 disables retries. 0 means unlimited (up to the timeouts).
+                                format: int32
+                                type: integer
+                              maximumInterval:
+                                description: |-
+                                  Maximum interval between retries. Exponential backoff leads to interval increase.
+                                  This value is the cap of the increase. Default is 100x of the initial interval.
+                                type: string
+                              nonRetryableErrorTypes:
+                                description: |-
+                                  Non-Retryable errors types. Will stop retrying if the error type matches this list. Note that
+                                  this is not a substring match, the error *type* (not message) must match exactly.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          runTimeout:
+                            description: WorkflowRunTimeout is the timeout for duration
+                              of a single workflow run.
+                            type: string
+                          searchAttributes:
+                            description: |-
+                              SearchAttributes is optional indexed info that can be used in query of List/Scan/Count workflow APIs. The key
+                              and value type must be registered on Temporal server side. For supported operations on different server versions
+                              see [Visibility].
+
+                              [Visibility]: https://docs.temporal.io/visibility
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          taskQueue:
+                            description: |-
+                              TaskQueue represents a workflow task queue.
+                              This is also the name of the activity task queue on which activities are scheduled.
+                            type: string
+                          taskTimeout:
+                            description: |-
+                              WorkflowTaskTimeout is The timeout for processing workflow task from the time the worker
+                              pulled this task.
+                            type: string
+                          type:
+                            description: |-
+                              WorkflowType represents the identifier used by a workflow author to define the workflow
+                              Workflow type name.
+                            type: string
+                        required:
+                        - taskQueue
+                        - type
+                        type: object
+                    required:
+                    - workflow
+                    type: object
+                  policy:
+                    description: SchedulePolicies represent policies for overlaps,
+                      catchups, pause on failure, and workflow ID.
+                    properties:
+                      catchupWindow:
+                        description: |-
+                          CatchupWindow The Temporal Server might be down or unavailable at the time
+                          when a Schedule should take an Action. When the Server comes back up,
+                          CatchupWindow controls which missed Actions should be taken at that point.
+                        type: string
+                      overlap:
+                        description: |-
+                          Overlap controls what happens when an Action would be started by a
+                          Schedule at the same time that an older Action is still running.
+
+                          Supported values:
+
+                          "skip" - Default. Nothing happens; the Workflow Execution is not started.
+
+                          "bufferOne" - Starts the Workflow Execution as soon as the current one completes.
+                          The buffer is limited to one. If another Workflow Execution is supposed to start,
+                          but one is already in the buffer, only the one in the buffer eventually starts.
+
+                          "bufferAll" - Allows an unlimited number of Workflows to buffer. They are started sequentially.
+
+                          "cancelOther" - Cancels the running Workflow Execution, and then starts the new one
+                          after the old one completes cancellation.
+
+                          "terminateOther" - Terminates the running Workflow Execution and starts the new one immediately.
+
+                          "allowAll" - Starts any number of concurrent Workflow Executions.
+                          With this policy (and only this policy), more than one Workflow Execution,
+                          started by the Schedule, can run simultaneously.
+                        enum:
+                        - skip
+                        - bufferOne
+                        - bufferAll
+                        - cancelOther
+                        - terminateOther
+                        - allowAll
+                        type: string
+                      pauseOnFailure:
+                        description: |-
+                          PauseOnFailure if true, and a workflow run fails or times out, turn on "paused".
+                          This applies after retry policies: the full chain of retries must fail to trigger a pause here.
+                        type: boolean
+                    type: object
+                  spec:
+                    description: ScheduleSpec is a complete description of a set of
+                      absolute timestamps.
+                    properties:
+                      calendars:
+                        description: Calendars represents calendar-based specifications
+                          of times.
+                        items:
+                          description: |-
+                            ScheduleCalendarSpec is an event specification relative to the calendar, similar to a traditional cron specification.
+                            A timestamp matches if at least one range of each field matches the
+                            corresponding fields of the timestamp, except for year: if year is missing,
+                            that means all years match. For all fields besides year, at least one Range must be present to match anything.
+                          properties:
+                            comment:
+                              description: Comment describes the intention of this
+                                schedule.
+                              type: string
+                            dayOfMonth:
+                              default:
+                              - end: 31
+                              description: |-
+                                DayOfMonth range to match (1-31)
+                                Defaults to match all days.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    maximum: 31
+                                    minimum: 1
+                                    type: integer
+                                  start:
+                                    default: 1
+                                    description: |-
+                                      Start of the range (inclusive).
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 31
+                                    minimum: 1
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 31
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              type: array
+                            dayOfWeek:
+                              default:
+                              - end: 6
+                              description: |-
+                                DayOfWeek range to match (0-6; 0 is Sunday)
+                                Defaults to match all days of the week.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    maximum: 6
+                                    minimum: 0
+                                    type: integer
+                                  start:
+                                    description: |-
+                                      Start of the range (inclusive).
+                                      Defaults to 0.
+                                    format: int32
+                                    maximum: 6
+                                    minimum: 0
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 6
+                                    minimum: 0
+                                    type: integer
+                                type: object
+                              type: array
+                            hour:
+                              default:
+                              - start: 0
+                              description: |-
+                                Hour range to match (0-23).
+                                Defaults to 0.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    maximum: 23
+                                    minimum: 0
+                                    type: integer
+                                  start:
+                                    description: |-
+                                      Start of the range (inclusive).
+                                      Defaults to 0.
+                                    format: int32
+                                    maximum: 23
+                                    minimum: 0
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 23
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              type: array
+                            minute:
+                              default:
+                              - start: 0
+                              description: |-
+                                Minute range to match (0-59).
+                                Defaults to 0.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    maximum: 59
+                                    minimum: 0
+                                    type: integer
+                                  start:
+                                    description: |-
+                                      Start of the range (inclusive).
+                                      Defaults to 0.
+                                    format: int32
+                                    maximum: 59
+                                    minimum: 0
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 59
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              type: array
+                            month:
+                              default:
+                              - end: 12
+                              description: |-
+                                Month range to match (1-12).
+                                Defaults to match all months.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    maximum: 12
+                                    minimum: 1
+                                    type: integer
+                                  start:
+                                    default: 1
+                                    description: |-
+                                      Start of the range (inclusive).
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 12
+                                    minimum: 1
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 12
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              type: array
+                            second:
+                              default:
+                              - start: 0
+                              description: |-
+                                Second range to match (0-59).
+                                Defaults to 0.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    maximum: 59
+                                    minimum: 0
+                                    type: integer
+                                  start:
+                                    description: |-
+                                      Start of the range (inclusive).
+                                      Defaults to 0.
+                                    format: int32
+                                    maximum: 59
+                                    minimum: 0
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 59
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              type: array
+                            year:
+                              description: |-
+                                Year range to match.
+                                Defaults to match all years.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    minimum: 1970
+                                    type: integer
+                                  start:
+                                    description: Start of the range (inclusive).
+                                    format: int32
+                                    minimum: 1970
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                      crons:
+                        description: "Crons are cron based specifications of times.\nCrons
+                          is provided for easy migration from legacy Cron Workflows.
+                          For new\nuse cases, we recommend using ScheduleSpec.Calendars
+                          or ScheduleSpec.\nIntervals for readability and maintainability.
+                          Once a schedule is created all\nexpressions in Crons will
+                          be translated to ScheduleSpec.Calendars on the server.\n\nFor
+                          example, `0 12 * * MON-WED,FRI` is every M/Tu/W/F at noon\n\nThe
+                          string can have 5, 6, or 7 fields, separated by spaces,
+                          and they are interpreted in the\nsame way as a ScheduleCalendarSpec:\n\n\t-
+                          5 fields:         Minute, Hour, DayOfMonth, Month, DayOfWeek\n\n\t-
+                          6 fields:         Minute, Hour, DayOfMonth, Month, DayOfWeek,
+                          Year\n\n\t- 7 fields: Second, Minute, Hour, DayOfMonth,
+                          Month, DayOfWeek, Year\n\nNotes:\n\t- If Year is not given,
+                          it defaults to *.\n\t- If Second is not given, it defaults
+                          to 0.\n\t- Shorthands @yearly, @monthly, @weekly, @daily,
+                          and @hourly are also\n\t\taccepted instead of the 5-7 time
+                          fields.\n\t- @every <interval>[/<phase>] is accepted and
+                          gets compiled into an\n\t\tIntervalSpec instead. <interval>
+                          and <phase> should be a decimal integer\n\t\twith a unit
+                          suffix s, m, h, or d.\n\t- Optionally, the string can be
+                          preceded by CRON_TZ=<time zone name> or\n\t\tTZ=<time zone
+                          name>, which will get copied to ScheduleSpec.TimeZoneName.
+                          (In which case the ScheduleSpec.TimeZone field should be
+                          left empty.)\n\t- Optionally, \"#\" followed by a comment
+                          can appear at the end of the string.\n\t- Note that the
+                          special case that some cron implementations have for\n\t\ttreating
+                          DayOfMonth and DayOfWeek as \"or\" instead of \"and\" when
+                          both\n\t\tare set is not implemented."
+                        items:
+                          type: string
+                        type: array
+                      endAt:
+                        description: |-
+                          EndAt represents the end of the schedule. Any times after `endAt` will be skipped.
+                          Defaults to the end of time.
+                          For example: 2024-05-13T00:00:00Z
+                        format: date-time
+                        type: string
+                      excludeCalendars:
+                        description: |-
+                          ExcludeCalendars defines any matching times that will be skipped.
+
+                          All fields of the ScheduleCalendarSpec including seconds must match a time for the time to be skipped.
+                        items:
+                          description: |-
+                            ScheduleCalendarSpec is an event specification relative to the calendar, similar to a traditional cron specification.
+                            A timestamp matches if at least one range of each field matches the
+                            corresponding fields of the timestamp, except for year: if year is missing,
+                            that means all years match. For all fields besides year, at least one Range must be present to match anything.
+                          properties:
+                            comment:
+                              description: Comment describes the intention of this
+                                schedule.
+                              type: string
+                            dayOfMonth:
+                              default:
+                              - end: 31
+                              description: |-
+                                DayOfMonth range to match (1-31)
+                                Defaults to match all days.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    maximum: 31
+                                    minimum: 1
+                                    type: integer
+                                  start:
+                                    default: 1
+                                    description: |-
+                                      Start of the range (inclusive).
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 31
+                                    minimum: 1
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 31
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              type: array
+                            dayOfWeek:
+                              default:
+                              - end: 6
+                              description: |-
+                                DayOfWeek range to match (0-6; 0 is Sunday)
+                                Defaults to match all days of the week.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    maximum: 6
+                                    minimum: 0
+                                    type: integer
+                                  start:
+                                    description: |-
+                                      Start of the range (inclusive).
+                                      Defaults to 0.
+                                    format: int32
+                                    maximum: 6
+                                    minimum: 0
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 6
+                                    minimum: 0
+                                    type: integer
+                                type: object
+                              type: array
+                            hour:
+                              default:
+                              - start: 0
+                              description: |-
+                                Hour range to match (0-23).
+                                Defaults to 0.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    maximum: 23
+                                    minimum: 0
+                                    type: integer
+                                  start:
+                                    description: |-
+                                      Start of the range (inclusive).
+                                      Defaults to 0.
+                                    format: int32
+                                    maximum: 23
+                                    minimum: 0
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 23
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              type: array
+                            minute:
+                              default:
+                              - start: 0
+                              description: |-
+                                Minute range to match (0-59).
+                                Defaults to 0.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    maximum: 59
+                                    minimum: 0
+                                    type: integer
+                                  start:
+                                    description: |-
+                                      Start of the range (inclusive).
+                                      Defaults to 0.
+                                    format: int32
+                                    maximum: 59
+                                    minimum: 0
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 59
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              type: array
+                            month:
+                              default:
+                              - end: 12
+                              description: |-
+                                Month range to match (1-12).
+                                Defaults to match all months.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    maximum: 12
+                                    minimum: 1
+                                    type: integer
+                                  start:
+                                    default: 1
+                                    description: |-
+                                      Start of the range (inclusive).
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 12
+                                    minimum: 1
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 12
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              type: array
+                            second:
+                              default:
+                              - start: 0
+                              description: |-
+                                Second range to match (0-59).
+                                Defaults to 0.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    maximum: 59
+                                    minimum: 0
+                                    type: integer
+                                  start:
+                                    description: |-
+                                      Start of the range (inclusive).
+                                      Defaults to 0.
+                                    format: int32
+                                    maximum: 59
+                                    minimum: 0
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    maximum: 59
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              type: array
+                            year:
+                              description: |-
+                                Year range to match.
+                                Defaults to match all years.
+                              items:
+                                description: |-
+                                  If end < start, then end is interpreted as
+                                  equal to start. This means you can use a Range with start set to a value, and
+                                  end and step unset to represent a single value.
+                                properties:
+                                  end:
+                                    description: |-
+                                      End of the range (inclusive).
+                                      Defaults to start.
+                                    format: int32
+                                    minimum: 1970
+                                    type: integer
+                                  start:
+                                    description: Start of the range (inclusive).
+                                    format: int32
+                                    minimum: 1970
+                                    type: integer
+                                  step:
+                                    default: 1
+                                    description: |-
+                                      Step to be take between each value.
+                                      Defaults to 1.
+                                    format: int32
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                      intervals:
+                        description: Intervals represents interval-based specifications
+                          of times.
+                        items:
+                          description: "ScheduleIntervalSpec matches times that can
+                            be expressed as:\n\n\tEpoch + (n * every) + offset\n\n\twhere
+                            n is all integers ≥ 0.\n\nFor example, an `every` of 1
+                            hour with `offset` of zero would match every hour, on
+                            the hour. The same `every` but an `offset`\nof 19 minutes
+                            would match every `xx:19:00`. An `every` of 28 days with
+                            `offset` zero would match `2022-02-17T00:00:00Z`\n(among
+                            other times). The same `every` with `offset` of 3 days,
+                            5 hours, and 23 minutes would match `2022-02-20T05:23:00Z`\ninstead."
+                          properties:
+                            every:
+                              description: Every describes the period to repeat the
+                                interval.
+                              type: string
+                            offset:
+                              description: |-
+                                Offset is a fixed offset added to the intervals period.
+                                Defaults to 0.
+                              type: string
+                          required:
+                          - every
+                          type: object
+                        type: array
+                      jitter:
+                        description: |-
+                          Jitter represents a duration that is used to apply a jitter to scheduled times.
+                          All times will be incremented by a random value from 0 to this amount of jitter, capped
+                          by the time until the next schedule.
+                          Defaults to 0.
+                        type: string
+                      startAt:
+                        description: |-
+                          StartAt represents the start of the schedule. Any times before `startAt` will be skipped.
+                          Together, `startAt` and `endAt` make an inclusive interval.
+                          Defaults to the beginning of time.
+                          For example: 2024-05-13T00:00:00Z
+                        format: date-time
+                        type: string
+                      timezoneName:
+                        description: |-
+                          TimeZoneName represents the IANA time zone name, for example `US/Pacific`.
+
+                          The definition will be loaded by Temporal Server from the environment it runs in.
+
+                          Calendar spec matching is based on literal matching of the clock time
+                          with no special handling of DST: if you write a calendar spec that fires
+                          at 2:30am and specify a time zone that follows DST, that action will not
+                          be triggered on the day that has no 2:30am. Similarly, an action that
+                          fires at 1:30am will be triggered twice on the day that has two 1:30s.
+
+                          Note: No actions are taken on leap-seconds (e.g. 23:59:60 UTC).
+                          Defaults to UTC.
+                        type: string
+                    type: object
+                  state:
+                    description: ScheduleState describes the current state of a schedule.
+                    properties:
+                      limitedActions:
+                        description: |-
+                          LimitedActions limits actions. While true RemainingActions will be decremented for each action taken.
+                          Skipped actions (due to overlap policy) do not count against remaining actions.
+                        type: boolean
+                      notes:
+                        description: |-
+                          Note is an informative human-readable message with contextual notes, e.g. the reason
+                          a Schedule is paused. The system may overwrite this message on certain
+                          conditions, e.g. when pause-on-failure happens.
+                        type: string
+                      paused:
+                        description: Paused is true if the schedule is paused.
+                        type: boolean
+                      remainingActions:
+                        description: |-
+                          RemainingActions represents the Actions remaining in this Schedule.
+                          Once this number hits 0, no further Actions are taken.
+                          manual actions through backfill or ScheduleHandle.Trigger still run.
+                        format: int64
+                        type: integer
+                    type: object
+                type: object
+              searchAttributes:
+                description: |-
+                  SearchAttributes is optional indexed info that can be used in query of List/Scan/Count workflow APIs. The key
+                  and value type must be registered on Temporal server side. For supported operations on different server versions
+                  see [Visibility].
+
+                  [Visibility]: https://docs.temporal.io/visibility
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            required:
+            - namespaceRef
+            - schedule
+            type: object
+          status:
+            description: TemporalScheduleStatus defines the observed state of Schedule.
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the Schedule state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/temporal-operator/0.21.0/bundle/metadata/annotations.yaml
+++ b/operators/temporal-operator/0.21.0/bundle/metadata/annotations.yaml
@@ -1,0 +1,10 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: temporal-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.23.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3


### PR DESCRIPTION
Thanks submitting your Operator. Please check below list before you create your Pull Request.

### New Submissions

* [ ] Are you familiar with our [contribution guidelines](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-via-pr.md)?
* [ ] Have you [packaged and deployed](https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md) your Operator for Operator Framework?
* [ ] Have you tested your Operator with all Custom Resource Definitions?
* [ ] Have you tested your Operator in all supported [installation modes](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md#operator-metadata)?
* [ ] Have you considered whether you want use [semantic versioning order](https://github.com/operator-framework/community-operators/blob/master/docs/operator-ci-yaml.md#semver-mode)?
* [ ] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-prerequisites.md#sign-your-work)?
* [ ] Is operator [icon](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#operator-icon) set?

### Updates to existing Operators

* [x] Did you create a `ci.yaml` file according to the [update instructions](https://github.com/operator-framework/community-operators/blob/master/docs/operator-ci-yaml.md)?
* [x] Is your new CSV pointing to the previous version with the `replaces` property if you chose `replaces-mode` via the `updateGraph` property in `ci.yaml`?
* [x] Is your new CSV referenced in the [appropriate channel](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#channels) defined in the `package.yaml` or `annotations.yaml` ?
* [x] Have you tested an update to your Operator when deployed via OLM?
* [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-prerequisites.md#sign-your-work)?

### Your submission should not

* [x] Modify more than one operator
* [ ] Modify an Operator you don't own
* [x] Rename an operator - please remove and add with a different name instead
* [x] Modify any files outside the above mentioned folders
* [x] Contain more than one commit. **Please squash your commits.**

### Operator Description must contain (in order)

1. [x] Description about the managed Application and where to find more information
2. [x] Features and capabilities of your Operator and how to use it
3. [x] Any manual steps about potential pre-requisites for using your Operator

### Operator Metadata should contain

* [x] Human readable name and 1-liner description about your Operator
* [x] Valid [category name](https://github.com/operator-framework/community-operators/blob/master/docs/packaging-operator.md#categories)<sup>1</sup>
* [x] One of the pre-defined [capability levels](https://github.com/operator-framework/operator-courier/blob/4d1a25d2c8d52f7de6297ec18d8afd6521236aa2/operatorcourier/validate.py#L556)<sup>2</sup>
* [x] Links to the maintainer, source code and documentation
* [x] Example templates for all Custom Resource Definitions intended to be used
* [x] A quadratic logo

Remember that you can preview your CSV [here](https://operatorhub.io/preview).

--

<sup>1</sup> If you feel your Operator does not fit any of the pre-defined categories, file an issue against this repo and explain your need

<sup>2</sup> For more information see [here](https://sdk.operatorframework.io/docs/overview/#operator-capability-level)


--

As per the Operator author @alexandrevilain's suggestion on https://github.com/alexandrevilain/temporal-operator/issues/568#issuecomment-1877615625 for contributing to updating the operator.

I've just bumped it to the latest version using the operatorhub automation script provided and marked the same checkboxes from [previously published version PR](https://github.com/k8s-operatorhub/community-operators/pull/3731).
