### PR TITLE
Pin OPM version after breaking change

### DIFF
--- a/ci/pipeline-config-k8s.yaml
+++ b/ci/pipeline-config-k8s.yaml
@@ -19,7 +19,7 @@ production:
     multiarch:
       base: quay.io/operator-framework/opm
       base_tags:
-        - latest
+        - v1.57.0
       postfix: s
     registry: quay.io
     organization: operatorhubio


### PR DESCRIPTION
This is a temporary fix, as the [changes](https://github.com/operator-framework/operator-registry/pull/1750) in OPM version v1.58.0 are blocking any new releases.