### PR TITLE
operator jupyter-notebook-validator-operator (1.0.0-ocp4.19)

### DIFF
--- a/operators/jupyter-notebook-validator-operator/1.0.0-ocp4.19/manifests/jupyter-notebook-validator-operator.clusterserviceversion.yaml
+++ b/operators/jupyter-notebook-validator-operator/1.0.0-ocp4.19/manifests/jupyter-notebook-validator-operator.clusterserviceversion.yaml
@@ -1,0 +1,496 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "mlops.mlops.dev/v1alpha1",
+          "kind": "NotebookValidationJob",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "jupyter-notebook-validator-operator"
+            },
+            "name": "notebookvalidationjob-sample",
+            "namespace": "jupyter-notebook-validator-operator"
+          },
+          "spec": {
+            "notebook": {
+              "git": {
+                "ref": "main",
+                "url": "https://github.com/tosin2013/jupyter-notebook-validator-test-notebooks.git"
+              },
+              "path": "notebooks/tier1-simple/01-hello-world.ipynb"
+            },
+            "podConfig": {
+              "containerImage": "quay.io/jupyter/scipy-notebook:latest",
+              "env": [
+                {
+                  "name": "JUPYTER_ENABLE_LAB",
+                  "value": "yes"
+                }
+              ],
+              "resources": {
+                "limits": {
+                  "cpu": "1000m",
+                  "memory": "1Gi"
+                },
+                "requests": {
+                  "cpu": "500m",
+                  "memory": "512Mi"
+                }
+              },
+              "serviceAccountName": "notebook-validator-jupyter-notebook-validator-runner"
+            },
+            "timeout": "30m"
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: AI/Machine Learning, Developer Tools, Integration & Delivery
+    containerImage: quay.io/takinosh/jupyter-notebook-validator-operator:1.0.0-ocp4.19
+    createdAt: "2025-11-29T06:00:00Z"
+    description: Kubernetes operator for validating Jupyter notebooks in MLOps workflows
+    operators.operatorframework.io/builder: operator-sdk-v1.37.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/tosin2013/jupyter-notebook-validator-operator
+    support: Community
+  name: jupyter-notebook-validator-operator.v1.0.0-ocp4.19
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: NotebookValidationJob is the Schema for the notebookvalidationjobs
+        API
+      displayName: Notebook Validation Job
+      kind: NotebookValidationJob
+      name: notebookvalidationjobs.mlops.mlops.dev
+      version: v1alpha1
+  description: |
+    ## Jupyter Notebook Validator Operator
+
+    The Jupyter Notebook Validator Operator automates Jupyter notebook validation in MLOps workflows on Kubernetes and OpenShift.
+
+    ### Features
+
+    * **Git Integration**: Clone notebooks from Git repositories (HTTPS, SSH) with credential support
+    * **Papermill Execution**: Execute notebooks using Papermill with configurable parameters
+    * **Golden Notebook Comparison**: Compare outputs against golden notebooks with configurable tolerances
+    * **Model Validation**: Validate notebooks against deployed ML models (KServe, OpenShift AI, vLLM, etc.)
+    * **Build Integration**: Auto-detect requirements.txt and build custom images using S2I or Tekton
+    * **Credential Management**: Inject credentials via Kubernetes Secrets or External Secrets Operator
+
+    ### Supported Platforms
+
+    * Kubernetes 1.31+
+    * OpenShift 4.18 - 4.19
+    * Tekton Pipelines v0.65+ (optional, for build integration)
+
+    ### Getting Started
+
+    1. Create a NotebookValidationJob resource pointing to your notebook repository
+    2. The operator clones the repository, builds dependencies if needed, and executes the notebook
+    3. Results are stored in the job status with detailed cell-by-cell execution information
+
+    ### Example
+
+    ```yaml
+    apiVersion: mlops.mlops.dev/v1alpha1
+    kind: NotebookValidationJob
+    metadata:
+      name: my-notebook-validation
+    spec:
+      notebook:
+        git:
+          url: "https://github.com/myorg/notebooks.git"
+          ref: "main"
+        path: "notebooks/analysis.ipynb"
+      podConfig:
+        containerImage: "quay.io/jupyter/minimal-notebook:latest"
+      timeout: "10m"
+    ```
+
+    ### Documentation
+
+    * [Architecture Overview](https://github.com/tosin2013/jupyter-notebook-validator-operator/blob/release-4.19/docs/ARCHITECTURE_OVERVIEW.md)
+    * [Testing Guide](https://github.com/tosin2013/jupyter-notebook-validator-operator/blob/release-4.19/docs/TESTING_GUIDE.md)
+    * [ADRs](https://github.com/tosin2013/jupyter-notebook-validator-operator/tree/release-4.19/docs/adrs)
+  displayName: Jupyter Notebook Validator Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QA/wD/AP+gvaeTAAAAB3RJTUUH6QscEikCJWqwBQAAXxhJREFUeNqNvXecJFd1NnzODVXVcfLszs7O5qTVKueEkAQSQQSTjEnGJvj9bGOCee0XDJaxjcEGbIxtMMbGgMEkY5JACQEySCisslbaXW0Ok0Pnrqp77znfH9Xd093Ts/L8VqvZme7qqhvOPec5z3kOWmcQkAEAGICZERHavghBMDAAIgIzAAACMAMiMDCCAGBOvkUEYARkZkBAaPwUAJgBGpflxse1XYGBERgAkw9qexkCUOv2GpdqXgEbNwLt98sACG0f1rocACJy8gDNL2y+gIEBROt5V1yWm29vXAjAAYjWlZtXS+6/deXk8owoIBkRaHu+5pXROoPLVwBmXv5n+0MlowwCoeMZ2h4weQbufFfbnXQOU/MuG/fXeanm2LRfpP3jGlPc/o7WdEAyscuz0xiWrpvAtudre1fzzptLh5bHAZsvRtEcJQQkYLFiJfDy3LZWXfe4JddEdM62PRv1GNiOmybg9sXVXJTQPi/c6xLYvB9uLqLlqW3uBwIQy8/ZvkAbA9Rc98DNF2DXSl4xxa3B7Py7uSnaJm/lMmrf9z2XHXTvva47wbanZ4ReX+ic69qpzTe0LoGdL1ixfVfMamOUO1658p9tj934lDNNITY2KHTsD0Tk1sZescC59V5gQEBufNO+4Trfh8CAojVazF2WrO3ekpnBtqu1tlrbR69YNz0mwK542hVGdeVUd6xN6DB90FzgPQxL10bBtl9yr03XOfeNt3Pz+qvcbfdWwPZTq2lGsGvNMHdYprax7VrSAMCN8wB6r8D2cVuxgdoGLfnPWduYve4H7jH6yaSvsMgrVkbv0WmzuXiGjdz12dhrWHsuiBXLCJ/zNlZsu5VLZOXJ1cM4r5yMMwwjt58r6Mglp07zIGnfMm3DDivXQZdJbLwMEbhhtVZ58uf46jq8kLHrnht/cfeO5uXjF3oNLJ/xY1cb1tWeAjuPsN5Pyj3XaPtPRPNbZMbW99AawJaN7nGAN/60PNg2n6LdR1lx388xKe2bFBrmGFt2DZtWhDsXJi/vz9VGouevEJNbwsZ3K3fmKk8B3DameMZZ7fQKoc1thGQHdDjqDIgIHeulzap03QG2hqjjRGizpG3rFZvXOePOwF72o7k1ibm5Gxv3CW0Gj5lQSCna44kVVrP3km8zR3wGe7JsG5B7W8Turda07V1Wsun6YmsC2ixul6cBzYHrdJUBEIEYsNsOdJ4zXcsSG4sXl4+BdvuGvbZC836YWEr5nCaMiM50YKzcCHzGMwaX908zmGoEqwy9PMF2B7LjwZvOb5ez1pgAWMVIdVj9bi+SuzY+N90DbJ202H2F1R6S29ynXt58Mvr3PnPkJw8fKNfqpVpcjWxkiQAkcsYT/ZlgMJe5+pyt15+305HDbscRl0OklcZhtbXcsUBWOV97umzPfbo1Dznn3CoHVGOxdMYQbTHXavuae75xlWDgzPfd2mjEUsr5SvmKd/3jidmCJ5CBESWiQAFARM4iomXRn/Xv/czvbx4dss4JIbq9Blxxux2mtsOLbt8ePYP4HtZsNRdpNZcJWUETZEB47oOkY0S5h1MFy5ALdoRBq60F7r3el+NVAGYgZgmw98Dp+WJtfLiflKc9H5VElDaOE+eLTSRcvFCq7N1/YvPoMPOKO+wBDHQeD9wykW3e1HLw0TZwXVaXEYCTdcx4hu3eFlon1gJQnfmkbzvj2o0yt2MJ2B7VJ+u+FadAm7eAHWPBzEQAwFJg55JrPVW7WWcAeGj/MWOsA9p8xfP8XB8zOOuWpuaAAYSwYa188BFn7SPPnn7t8y4kJtnA1zpdjLYhZ+bkygIFYi/D0u57rGo8sXPXdMfr3edJ81ROJl/1WvztoSZ0h3PcPl/YeYO9cZMVd8BErJWSjfFh57hlLVqfS5zsTJAofE8DwMOHJrUUfibvZfucc8BA1pKzgoGJle+LVFqXy48dmQIAX3tERETc8pi7cEgGIYRsDpyxVoh2E4LA/4tghTtGDZCXbVoPn7j9tG8ANqqXj9X92cy9NnK3K4FnilyaP3BEWkkJOF+ufPUnexfL9Q++4QWB0sYaKSQwEDMzK4mq6fAw8Gyx/OSRUwdOLQSBHwytEVI5awRKFAJRcLLfhFTZgVSpcGiq8OOHnrpw+8Rwf06JxhZnIusIRWMmHJFWith97Ot3B556y42XDOdyAGyslUJ0QFA95qHzAXHFXjlTIL28q5tQhLMdMN4Kv753XMcrgCA808oHBEesBCKKYq32uR/c+5Xb7ju9WA0d3HzZzq998I2BDqLYaCWFEABA7A5Nzj5y4OTeZ08/dWzq6Om5Qj32gjQ52nz5NX3jG6N6XQhhnVuanm8sOiHjwlzh0KMglI3j/kwwsWZgz+Z1l+6cuGDb+PbxESU1ADCTsc7Tmtj+5se/+q1fPhMoXDeQfstNl/6fl189kMkyk3VOCrH6sdj0MtrRc6ZeZ30XptA1VdgMxM48Vd1D2XLL20e/EwHFrr3JzpGnNQN/+c4HP/P9+w+emk0LqwUqJZfq7gWX7Pr6B9/oS81Ajz576vaHnv75Y4cPnJ4vVOrOsZLoSdBKAqPKD2x/3o0qCJy1iEhECzPzQAzAwERxtHDgEYrqQqC1zjgwBAjQl/Z2rB+59rytL7rkrIt2TAgUBPTmj3/t+/c9NZzVZMk4qhjcNrHmXS+//K03XSJAGmPa7NNybN8jq8JnMFOtwelMGbR7Xt1xwBmCxh7bqu1+uMuJbrjPxCwQBYoHDx79k3+99aGD04GvtZap/qE1W3csnD5ZmjxViuwLz9/44ot3fONnj+07uVCpGwXsaeFpqVNpPz/o5/v8TF6l0l6uT3k+MwGAFILILczMExEwk3MIADa2UUQmoqjuwpqrVygOLVFkbESYCfTusf7X33DB/zxx5LsPPjuUS8v8SGZkbW120lWLURzX69Gl29b82VtffNXZ25idI5ZCtLI/+L/xL7uRgl7+Sxug3DYBvDpm1NtV7OFWdO04ZpZCMtBfff2uv//2z5yjtAKZHxrbc9Hwho2oNNv40EMPFE8dMXEU1kKlZeBrLzuQGRzKDAylBod0tk95QRPEZ2ZqwTpCSiA3PzXn2AExEwMTICIKwQCIxAzOUlg39WpcLblawdTLYRTFsfUDPwh8NTjRv/1cKZgdR4sz1ePPUL1YjZwAfterr/3TN78YQDhyuOzorUjvrcCFebUzgGEF0tC1A1ZOLp7hzF09GdP8NTFIgfOl8m9/8ls/eezoQEogQN/GbaNnnedncmQNMAsplBRHHryvcPyQlEKnU5l1m/o2bOsbGBCI1joiB4yMKKRAQAJyxloTO2vYObK2NDuHykOpQUohlBASkZGYgIkBAQQiC0HkqFIKl6bjwhyZmADl4PjA9rPBOXZGMCMKjuvVqeP1hUliKtbdDRdu/8J7Xz2azzfnoA1y5RWgDWInYt+ZGeYVphnbIuEVQ9kLFTjzuDcBOG47nR2xlvIH9z78uo9+a92aIZnJje+5MDU0YuOY2InEIwEWQkpwC8eO6HQ2PbyGpSRrE6dGKwVEJqxH5VJULUWVclytmFrFhBW2lomBCFCA1EIqUJ6QSkgpvEAGaZXKSD+FWiMAkWNrMdk0AFGtZqJ6emQMyLF1SaoNiEGgUMpUK+WpoyKunZpZ+sr/feXrr73UWCOlWCWn2Ikj4fKqXzH63UOWvE61eUQdv+xl79out3J7NVODXZmRszeOrR/MVKr1TTv3DI6vr5RKiEKi5EbYiESOEUe272Zy1lh2hFJRFJXnZmoLM1GhGNcqLgqtNcY6S2yJyVkmk3yCEJoxSp5XIEgpPSmUAKmEkAq1p1I5Lz/gZfqE5zMAA/q5gVT/kLMRO9eM+RCFAARyzh8YdXFYPPzU2nywZ9PaJlmhNzDajAZayVFs51msckQ0onxengDsEbLzSqikM3najb+uCCAQwDm3ZXxky7qBBw9MFaenhrfuFCgIuMlbaexXci6qh8rzlFLVpcXF40er08dNpRjFJrRsGJXW/blg/Wjf+FDfuqHcYDbIBzrjaaUkAlqicmjKYbRYiU7PF0/NLk0tlJaKJXZOK+XreTV3SgU5f3BNamhMp7IA5KIo+WjENrYAIIAkZ01pMTJ218TQ9vFRatgf7Mh4dwWjjB0wDbd58z2sOHIbmqB6MTVacSD3ApC6nVZeLfxCcJal1BfvWP/Lp47Vl+br5ZJOZ8HZ1tphACCQ2iPrlk4dL544Wl+ci8OwFsWWTH8m2DM+dOGOiUvP2rhn87qJkYFsEDxXQoeK1eqxmcVnjk/t3X/ikUNTh6cKizWjbDUdH48XZmQmFwyM+PkhVIqcI2hftiwEuHrJFBfqYXzprglfBcYYKcTK9HfH4HY7L51cjRXZ1cY2YAAAhT2yOrh69nXFhGLbudQJuSAgAwHATZfs/Ox3fxGX5otTJ4Z2nA0OBApmYgalNJNbOnF0/tlnosJ8bF1oRV8udf2eTS+6cMvzztu6Y2JUgG5+PjlrqZWUWQkLIAoh+tLZ87bkztuy8fXXXQ4AR6fmfvbYoVsfOvDgwcmFYjFVLcdL0zKVS62ZSA+uQSGcdYBNjExgVJiztQJy/MILdwCAI5YS2/EgxPaUBgLwiuQM93Dfm95nB/cKQLVydfy/TNgmOV9MTpgm+NNjDsE68j0dmvjfbt+rA9/aqF4tMQAxCcdCSuHp8szU9L7HagvTsaGaseuHc6++5pw3XH/hnk0TjfXs4tiGgCikklJKJeRz3yKQc+QcAEglN4+NbB4b+e0XX/HUsdP/effe7/ziqVML5Yx1NizV509l1231+ofJOSZKYGFnDAGmUpnP33r/pbs2DuVysTVayuYxhw2WHLQYYqsMXUcqpN22d563jqgHsMC9UPvV0te9gP4EbDm9VHjDx772yOHprIeZwdENl1wpvZSzTnqeC2szzzxZOnnM2LgSmYmRvt++6eK33Hjxmr4BAHDOOueklFI2jKQhFy7NmPmT8eKMKczbSoHqFTYRAIPUMkjJ3IAeWBOMrk+NbPT6RppAKDhrnbNS6SSbNr209KW7HvzKnQ8fny/lU74SQg+sza3bLDyfnAMhgLhweJ8tzZVCd9aG4W/+yZs2rxmObaykaku2dgI3K2lhreh3tdC1bQJsj/Qp9pzOLh+rk8TWxoGzljytD0xO//pHv3ZsrpJVkF+/acOFl6KQzpLQevHEkcnH7qd6WDHUlw3edtPFv/fKq0fyfQAQm0ggKuUl16vPn6oeeqTyzAO1Q4/HsyepXAATIbkGl5R5+fBDRK1lkFL5QTW6wdt4dnrbxZnt56VGNyUvMCYmZt/zAWC+UvzcD+77wm17i5UoFwjUqfzETn9ojbMGEYCoePygK89VHY7mU9/449eet3lDbG0Lv22NR2MrdDEE8Iy4JHf8rw0L4t6OKnfPWivN285DaQ4BcAJ1PX70xKtv+bfFmkkpPbRzz/ieC5yxgCiknH76ibkDTxhrq/XoRZds/+jbbt61fh0Ax7GRAqXSABAWpguP3VN86Lb40GNQnENjARWjJKFAImohtJQSQQADi+RAI2AisgTGkjVkLQuE7IC35dy+y140cPH16aENAOBs7Ig9zweAZydn/vRLt//ooYOZwFMCveGJ3PimxEMTUpcnj0azx0Pj0hq//advvnT7ltjESqmOLGoX+eDM+cjm2xrJJmyfgJ6coW7rwl0p+MTaYiOdAYjCOquVfvrU5Ms+8M9LlTCQYvicS9fsPo/iSCpto/rpvb+qzk7XLOdT4pY33fBbN10FALGJBYDSHgCUTjw1e8dXSnt/goszglEoTwSezAXeQBAMB14+UBmp0koqhQIQmRywJYqdC42tRnE1ikpxXDRRKbY1y7EVcd2CE0Nr+y67aeTGt+Q3nQsAzhpi0FoDwFfueuBPv3znUi3KaqmyA31bd0s/YLJCetXJY9XTB+vG5QP9w4++Y8/G8dhaLWWy8xLkXAhs+KndMCgv505WRdiSSLjHL1onbdfB0GLcITEjsBASAIicIyZi39PTS8UbP/j5k3OllIDhPRcN7TqHwlB7flRaPHn//5hqpVi3l+0a+9wfvHrH+jFHjp1V2geA0ol909//XOWhO7FSBhGw1v5Qqm9zf27TYGo4I9MKJTARO2pmDZNnEgAILIAtW0vGuMi4WmzDKCpEtfl6OBfZikNj0IWYyaYveuHIy/5PbuM5AGDiGIVQSj17auqdn/7OA89ODmU91Kn+reeIVJZsJLVXnTxenTwSOhofzP/4o29bPzQQxkYiSonJszNTAjjy/wakW5GgRmddt2PZye5e9lI7UzxCYBjHtz+wb9O6wd2bxj2pAaAa1V76wX997PhSxpMju88f3nW2qVal59fmp0/d/3MypliP33TDef/4rtdoqWNjlEAhVRyWT3/n75fu/KqsljHIgRCpidzQOUPZsaxM+QDItoHCNQA+5La0ruA2okYCwbExZIyLY7aWDMWFuHKyXJ8OOTYcVsjPZq/79XWv+YMgN+KssUS+51uy7/7c97/8k8cH0poR+jbv1vkhslb5QW36dG3yUCU0Z433/+ijb+/PZgGA2B4+PX9ybvHqc7Z7SjpqFVaspDj0ojZjBzu6zaFvFjEse7sraweYHbNW6v1f+N7f/dcv1w2kt6zpv2jH+A0X7/z6XQ9971cH+9Kpod3njZ97UVivKc+vzE6duO8nZF25Hv3JG67/wG+8CIBjY7TyEGHhsbunvvIXdPIg6gwGOpfzh4ZTwXgO12QprUkBCgQhARETW88smFrZKuImVw5YAMqEqoQSkJnZhsbVaswsJMaFaPGxuepcCM65WlGs2TD2m386evnLmNkY43kaAD/1X3d/5Ks/zQRKIPZvOdcbGGFnlReUThwMp44uVcMXXbLt7S+54mcPH9j77KnD00uTS7X3vuaaj//WzcYYKeVz8FKwA8BI8v9NMK7N7PNzEZWsdZ7W373vkTd//BuDfX1RFMVxHBsrUQQpT5HJjm/ZfPUNxhildbi0cPTeu5xx1Xr4N2+/6Xdufr4jx46U1gTu6Ff+vHjrv3pSkU6nN/StvXTCJ8snl7gcAQCkPM5oyGhMe5DW6CnQEkUTHmZgYsZkXSADC+BkDAiREVEgKolkTbEWnS7auRgrLq5FhUItihlN5Ezc/5K3bvytj0hUzhoWqIT6/K3/80f/ekc2rRHEwI4LvFw/WSu1t3joiXDxtHUijEJL5GvP9z1Pe0vF0n984NdfecUFxlop8DmIQSg6OY1JShKxB1WmJ1sIkZmlEMVa9dr3/cPpuVI6nx/cvLNWWIyKS7ZeM7Wy1ze4+YaXaa2FlHG1fOwXd9l6vRrGn3zHi97+kmuMs4JZKh2W547+/e9Hj/4MUv1S4uiG/NA1W8RIyllL5Yhnq7xUg5oTjoFcA2mRCEqylqAk+BLSGvOBSHuAwIknkBAsGJiIjYO64WoE5UjUDNRMVLX1OiWwW6VcLxQjRIHVRX3e8za96zOpvjFrYgL0tP632+79w3/5cSblS6WHdl0k/CyQIxfNPXW/rZWkH0g/rdJ5lc5Gs6dq1eq64dzP//ZdA5mMc66rwquNY9nkfHYFyx0ZsRX0urawglsmSyv9oS/f+unv398fqLELrhjetstGEcVRrbBYmZvJjG8M8v3ABEzH7/2JKZWKtfCv3vqCd73iOuOcYJJKV07vP/zJd+DkYQj60hkxtqk/CKSxBCMZHM+LrIdKcEyuGkEt5siiYSZGYBSCPYW+xJQGXwolEJAZ2BIYR5GFuoGa4brB0EJMyCQYCAVIQIE2dtWScTFJJYxxxULdEkCtZIfWb37fZ/s2X2hNRCA9rf71x/e+/1/vyKd9DFID285LHB0TVmqLszo/GGT7hPak1tXpE5VjzyzWzLtfcflH33qzsVZKsYL4vsxd6YDOuqiJvdioHfUxnMS3Uj1x7OQL//hfkCE/vmHrVdebMGJAKaVUkoU0NnbGOCFP/erueHayGMO7X3H5R9/6MuccsJPKKx5//NjH3oqFefLSA0P+uo0DKJgcIwM5x1rCUEYMpTDngZYgEVG08a8ZmJEYHHPkIDRcN1w1UIshsmBJMCMgIrLA5oprnGoNejBwrWyjmlVKAOLSfLVSthDXbTq77QNf7N9xGVlDKJUUf/mfd3z8W/8zkBKYzg9tv4BBoFJCaQRkZ5ksAUsdLB14tL40A4B3fvzt52xab13DEHEXv2w5fupY3fLPbrkFuxHQRj4AO8nRCVlHCPmez377qcOT6VSw7qKrVJBJEoEEnPiUglkH6bn9j5cO7SuG7kUXbv78e36DmIFIKq904unjH3uzKC+Bl14znhmb6CfHRIwCABmkEAxYjniuynM1mq/xYkiLdVoMeaHOCzWarcJkmU+X4HQRpsswV4ViXdRjNISIKBCEAIEJ7alVziIAqLUGEb2MFFLEdUuGA09ximsh+jZcevjO1J4rUkPjQJYBrj1325OHjjx+bNbjmIUMhsfYERAxOSAmASQRQEg/ZZamSuXKfKn8qqsvcORQtDHdAVdLqCfBQ9OHY1zmN7RNUqvUiAGJQCl9//6jdz18NB/4ufGNwcCwjaLE9HKD7QVS69rCTOHQM0akto8NfO59rwcAZ4xUujZ79MQnflvXS+hl1k3kRsb7yBIgNNd4I64HKVBKtCwrRszXcaqKp0vidFFMldRMVRQirFk0hMlib5Y4IAFywyXCRuErN/J0iAIRRPJaZAOBxsAX5LHcFIxdtXbNOYOsAz8snfjUOyqnDwilnbUA8I/ved2O8cGIvXB+2lSKKBUTC2YERhbSCTDWS2d1fqgvpe985PCvDhzRShO1ph+7qgFW5pBFN9OxA9TGZf+6+Zsv37E3Zull+9bsOg+dayaUuJWXsdZOPvYAWauk+Of3vX401xfHsfL8qDx/+K/fhvOnLKs163MD432GyAkgZnYOLAtKPkq0okoWiBKFBqlRaJH8QQkCCRwBsUNwSrCvOVDkCRKCmNkQOULL4AAdATEQg2M0BIbYWAa2+cC/cG3/1RNqKOUMD+8eHr1g1KqUW5g9+PG31pdOaM+P43go2/fP736dryQ7Kh3dBzZukRkSG4FM4Cg/tlmlsobEF2/f2zHe3KznbEP5se1I5Y6ETAf2ie1FKAxAzFrK/Senb997IK1wYPP27OBQWKsJKVosPGQWnjfzzGPR4lypTh943dWX79pijNVKM8Dhf3wPHXnCeX3DZ48MXjJuGRoIhiGuRVwMuRhi7IAFJsu6eVoJ4oYbwUwCnSchG0A2RWkv3SdBYj1CRBTAQMCx49hyaCG0GFu2lLCGGAVoAYHETABZD1Mq2f6akco1Z2wwrNFnitNu8tjBz/zhObd83dPaWHvpri3vecXlf/61n/bbsDJ5LL9hB9mYQDC7BH0BZpUb8Mc25U4fu2Pvs48dOX3+lnHrnOjM4y+XvkBH7lJ1lSm2VX90VJYn3x2dmpucX1rTn6vMT5uwprR2xqAUyXQKKcNSYeHQ/tCKczcNve911wOzAEYhTn3/H80jd4mgL7NjYO3zN1rHCI3oHQPFeR/W5ji0UIy4FHLdYGTBUeJOkBSsJaQ0ZzRmPUxpp5RWHATyZ4f6nKUXbCva0MZOKg3gKSWDxJdmZqDmwyJwwjkkZCIkQimFJ+WALM/XFp+ZrpyuomPJoHKDbt+9p777Txt+7d0SHAC/5zXPv/W+J/edWIK5U8HIOun74GyjUh4BlCYAU6lIhFMzc/uOTZ6/ZZzbHCFss+6dJwEys/zTW25pobmt12M3uwIEIhHtmFgzV6r88unj2oaluZn+8QmhdIIaAYNQavrJB+vzs8byP7zrlbvWj8VxrD2v8Oze6c//oRbaW5Pf+LI9zAwuOeMRE+eGgAlQCch6OJjC4QyMpGEkyyNZWJuFtTkYy+NIDvtS5HuImPK4HupP3DP4J3ePfPdAX6GCF62L8xlrDBIhMqFjIGjRtTEpfyNARCGl1BIYwsV68cD83AMnSwcWzUIEjhxBeiSQnhTs1w7u9XdfnhpZH0exp72xkdy3/+dxjUQ2Sg2NITMICUlMwWbp2SeotLBQqr3pBRf+0a/fkNjOlSnGxggjYhtyJ//sz25p1tohtleD9ah8RkTx4kt2H5udf/DAKc+G1eJS//gGRAHEUqmouDT75CPl0N182bY/et2N1lqplHPh0b/7HTF/2nnBxEvP8voDtoCYSB408cJWkokJCAERpAAtwROgJQgJDNYCEgceKJ3+0aHR3/vxyPcP9lsbO2fun8rdcSjdH4hz11ntOWuBoOGESoFSCeFJUAIATTWuni4V9s0sPHRq6fGZ+vGiK8RsnUyrYG0wvGdoaM+gN5gqnqphWC89+8Tgtb+mvMBau3Ni7InDx588Me+D9ftHhJcGdiwECFE4/KQrzC6Ww9dcs/uLf/hGKQRRApE2zwps6mi0ZZBbx4C85ZY/68wj4ErAKJk0RCAmgfzyy/ccnVnYd3rRlBaNjfNjG5wxytPTzzxeX5hXWv7TH7xqbLDfWaOUPvnDf67c/XWQ6cFL1g/tWWPrkZCISiTlLSCazolo6CBwkwTClJCa0TmQSIFPEsUvTuQ/+NO1f//g0GRFkC2//PJdm9cNHDp+csFmbz/S/9BUeiRN2/ojpQ0gOodx3dUXw/KJYuHp2cVHTxUemyo/MxueKtpSCIaEFt5oJr9nZPSqjQO7hqVmJvDT2sZxcc7Z6aPOCwbPvtI5K6Xatn74W7/Yx+AAMDWwhuJICFE+eTCcPRkSvPyyHV/8ozcIAOuclKKLJYidxaHtVTeqrYKzI4ef6KZw88DgZC4RjXNayj/69et/9OB+QCmlBgCUsrK0UD55pGLcq6/efcHWjdZa7fn14nThjn9XOqNGMiMXjbswFhKpbuDEnECABFTQAjzJngRPshScOPIACKCBpCAQWKx6P9rnf+3x3H2T/TUSTMXNY/1/9NpXveG6S2Zr4VXnP/KFW+8/NlO480jwi+NjV60NXrV+5tzKqVxxydVMGDprGGxSEYCoUeY9fyidGstnxvuCkYwMJDhiApAeRzVLPLIjXzpdi11m4fYvrbnu1enhjdba87ZsuPnynd+850m1OGlG1gmVYiJwJuEjvf/1N0hUsY2VkM3UITL0yLhzWylRMgHYVb+BLQ5kq+KonaPCAADfueeRaqkyNDQwumWHBFSeP/vMkbheFSB+88aLoLmAp279PC6cZr9vzVWbVKBcPQYhQEtIK54qi8giQIMRJRElKg/BE+BL8D3wvILMPBWO/OR47u7Dwf5ZWYsd2MraPu+NN176nlddO5jLW+dsZN58wyUvvOisL93xwDfvenBmqX7bkYGfnhjarCYu09NX68kdcm4oZYKclDktB1J6JKcHczLnSy3ZMRnnahaAQaIaSMdx5Mo2mqv3pVUhTEF1afbO/9j0hg8lvuTbbrrkv3/xeBzWK7OnchO7GDA1tsWWF8pLpe//8olzN63HHqSR5WqtllvUClOw3Q3tKgrBzuqb1i+kFDHZHz+4XyJ4uT4v28eOgF19fia0cOlZY1fv2eKcUdqrzp8s/OxbkvzUukx+yxBFDqVkFigQNw7xuj5XCmGphqUIYycc1UjNV71FK0/Vg0P1zP6wf180cDzKlWJkFwfa7Z7I3nzJBb/5oks3jY4CkHExogSExVIt46n3v+76V1x17n///NGfPHzgxFz5Weo7xKPfc3vGbWGHXz13xOwed+v7eSBwgz4pMrbmMIlgtAQENhaLkTterU3VEDAdeGGKDGRLv/x+7aa3pofWW2sv37Xlsu3rfvHEMV1YgHFGKXUqJ4KML4p37N3/R6+/wZOSmRFls/CuVWzVRPebEE9L2kO1qVhwWzk5riiOYgR0xErKxw+dOnBy3vdUes04sUBB5dmpuFwhod/0gksE6NjFUsLsT78mFmc56B86fwwlsmGmJqXAMguJAxkYTLNxVLPauj/86YYfTw4JhTWnIovWOXBxgMX1g5nLz9r0iqvOecH527OpAACMNUIIJZQjIgYh0Dkuluobh/o/+IabfudlV9+77+idDz79yIHjk4XqPtL7aiPfnwFPQFo6C/DyXfV/eelUBDbhQHA1hsUazFWwGgeOQi0T3mo2owsGeWlm9qff2PTa9ztrlVKvvfaCnz9xHGxsy4te/xogq/OD/uLsgVNzTxyZvGTHZkemg0a0SpF7K/JS3F5e1IEKYWOWmsAcN4O6+/Ydr8U8lA2yw2vIGqlV4fSxsF4bH8zedPFuANCeF0eV8q9u1X4q6PdzhdAenMXhLKR9UIBM7ABcoz6TUYi8jkXmYNwfcqBMLClan/E2jPSdt3388rM2Xn7WxnVDg8kDGWMSQjW3H2sMiCglxLENTRxo+bLLdt982e7JxcKjh07t3X/iqaOTkwvlpWpEIB3rA3McGRC12BVCWKxjORSWUAhQUnvSiygOQQB4npbSOhUU7/1hfPPbtd8HwDddvGvDSH+xGkVLs17/KBF52QHp6Xq5dt++Y5fs2Myc1LdhM5ptRiHcbpWWC+3UsonBlUoRyxoNyf5JVLp+8cQhLUXQPxL0DQJzHNarc9O1KHrRzl2j/X0mjrXnFZ9+wE0eRy81MJL2DNmTBZoscVpDX8B5HzIe+BKEQEYgEMTVkK3BOKq/5vm73/1rV/al/bWDfaJZ4WWtZQAhhFSyyUbpEJDAhF8uGQVa4kK1joRD2cxLL93z0sv31EOzUKyUwvDfb3vwv36+rx5R+fG5wbBIEQjBoAR6soUcpAJlQpsMSMoXUd2LTx0pPP6L0ctfZuJ43fDQlWdt+O59T6cqS2QiFlIGWZ3p8+rxPU8cefevXSeFaFFluTOpgtijYFMsJ1OXpTSahzg34klu0N9YSjm9sLjv6ElPctA/qD1PaRWXC6ZWBYHXX7AtKWkHgMKDt0tnVKCyOZ+I0FdSCFmN5amifGYOn5jmfTN0ZJHmKlyPEThkDC0aa8/fPnbWhnXrhvsRhLXWWOfICSmkFKKHRkNzpTVPLEwcWQGoILauWKsXKjVyNJhLX7Zj43nb1jtykcWoZAQCpAR7sklqaVxIe1JIJGYi8HwlFUjgxQfuaA3hdRdus+zI1G29LIQUSst03kd45ujMdGFJCNnmZHJ7uXGXUgk2uKG4QnOkFwUuKVcHgIOnZmeWKp6SwcAAMQuBYWHRWhjqy121ezMASN8PK0u1J3+B2kvntPbQJZVaiKAw2UXKMRdjXooYwUrElIwgb8wmAZSsiMhYLZWQncJ42LKW7bS/DrZAu+vNgiUKYEAG46hSjxFAIMUkouRaBCiSqBAQGoJtKEBptAZQghRSa8GpdHzokagy72WHAeDKs7cMZANjYltZ9PLDQKxSOSXFXLFy8MTc2v4BZsuo2yMu7BaBSbx7BGbRLqXSBt5xi8aITXA7eeInT0yHsVFaebl+Zx0R1RbnjeNt60e3jo2SsxKhcvRJN3cSpc7nNDZwYMREki5RPEEEJcCTQgsJKKLYFSLHDMi+JxPkYzmdslyi30YMxLaF1NwFhA33TislBHrCc0kxeBLqCaGVBGACto39j0KIxvhzA3MEYq0FA1DMYlDltmdR+Vyarx7bhwBMdvPY8Ja1g/XY2WoRgIBZpXNCqTCK952YBgBuIRHYLuPTxY1urPwkH4CdIkAt1mmShyJmdsTUwOMWhZBeOq3TGWCOwjAszEcm3rNhFIVMHrj67CPSRcJXOi1dbLCRisIWiz6ByTARIUjOFoWJxGPbQYRtAkPNdyWgxbJmHAMiIzhkEoACHFNWZfYvPft//+cDxyvH+oK8ZXLM1AgtAZLyYyFACGSA2LFxpJA82UKPlYdoSY4ob0cQrPUx0OBs+dBjAGCtEyjP3TJmHFGcxHgglCeVBwIPn15IjmBHjtt4uy3UhTvq5wCXd18HLb0ZiDUlk6SQSkpf6zCOn51c8vwgyA96nicEmlrZVEpk450bRlpmKzr1jAShB1Lqkol4Xd5qycaxIwYBDXGuZUYnIDCiECwRAdFYasGzy2IR7QUnzNwl5tKMWSxRVqVO1U//7d5/eKZw6CP3f/yJ+ScDFTBzsjNiawFQKekhgGP2lRvL0c5h3j0KF47TgA/MIFESeON+sC0NBnRKqYxER/WjTzaWCMB5W9YhIMcxRSEzoJIylU153r6Tc7Uo9LWnpJZCJvPemWNpsjqb4JfqrB1u+ptNvI4ZpFDH5+Z/+eSzP3/s8IMHphbrNqWVl+3ztG8d2VrdOfKV2LZuCACEkNZFZvooKJ0azemBnE35PGbtYg1nq7JqscHLaKXcWCAyohasBABjPbJNqLZxsi47EogrQELBzSSOI/KlP12f/8gv/2o+WhhNj5Si8p/88i/+/vl/PZFZV7UhCqyFMTErBN3v87jP2TQoaOT65ytYCAUDWeLNA0EWXKWesOK9LNZZxpNHbFwWKgsA29aNeFpZayisqlQGhQI/7Wn15InFK9/72Yu3jj7vvM3Xnr9z4/AQkQUUnbo3zG0wm+pB2W0G1I5ISfXF2+/94L/9OIwckfWl1Fqi9vPDa5hYIHIcOVD5Pn/DmkEARinC2Wk7PylQ6r4UOIaYhBQw0U81C8UIfcXUth4wyd+CL9kXzIyFStiZnqNlGZJu/wCBCRuYP3lCG4o+8eDfHS+e7Pf6nLUG7Us23jSaGgldnOShalFMJDwF/vY+51swgIAQGT65JKYqQGxzGjYNyjU5XCg0fHhmlVEolFucCxdnMmtzADAx0t+XCkJjyVmUigH8gdHa/CTXy1MV+tap6W//Yl8muPMvfuumt910pbVWijYuH3Z4O4q7qjlwWWkicU1/8Msn63U73JdCLwj6h9LDa7Jrxv1M3kSx9rUL60Qw0t83NtgPTAJltDhNlaKQUmd9ds2rx4TDGVeKuBI1D3ZeVna0nAKTBgPgLxQrySnVLqzSJOJz88xdBk6QgZklSMv8ib2febZ0aDAzwESLYeGa9df87rnvsM4YZ5mRHCyVagQy51MaDEWMIGGyjCeKEFvOezCaxTVZ0IKNA9HaqazTSkjJYS1emMmt3QbkRgdzg/2Z49MFJodSkYm93ODw7kvj4pytFtP1qnB2vlT90a+efttNVyYEvnYftB0uUqvXH5FAQUyVmLSU3sDIhsueL7QHKNg6spYAkCGOQ0d2IBvkUwE5JySY4jyYGNM5ldHA1LASRJj3+Ny1VKxDPQbDYAkdNeqyBHhS5o8xA84UKsmp3I6FE5NESeCW5aibs0fMgkF7+hMPfubek/cPpgcQscy1i8cufN+F74ps7JASyQHraHqxxMQDgU15GDsJhRrPVnFNBoZSmPNBSbaOjQOhEAUzIiMQa19KKSiOTWkRABy5TBD0Z/wjjjiuMxE4AiClfbV2MxCwM+VjT3nlajV0zJQc9ssZr84v1SQzrChTYkSBtSgqV0Ng9vMDMp2Oq1VMcg0iAZfYRXXnbMpLAlQCAFdeQiahpPQUEy3zYhyjEDicXdZr4eWSbhXA6DMIx3B2qeLIJTed2B5HTkldNdWMTjM5BoKG94yJh5by0v/61L//7NTP+1J5Ilcx1e392z9wyfsDpUKKgQUzSYlhbGaXyoBqTbqKisiCHAhwOJ3kn9kBGFomI7QsAaPUAiWAs7ay1PgRymzac0BkIyCX5JwZGKxjIun7KsggwFK1Xo/jtO9xg7rbg+spOpIwK2YhMrYWRQJJai0ApESZJFIQUCAAkzPAkPJ1yz1x9aoAFkqKpAAQueGCJkkG4zh2bIiNY8tskC27mMGYiXysPG+xUi9WaihkEoETsJJ6sjrz5u//4Zee+C8UitrKUZgpF2S/+vQ3v3Pw+/2pvECsUX1tau0fXfKHKZ0OKUqcfGYUKAqV+lyhLJVa3+eW3WzHYIFdu0CngGUsgZkZFWBCwq9VWiOT9j1iZmuAbAPuQQmIKBSgBKWlENUorhvXjN57lDhyIpbdszQmcVOMpdg5RIFKISYxPrYF2pRITiWCSo2RcRYYE5pUi7ecRD0gG8aFgZsSlA7YIhAAnzVqUr6YL9aPzC42Hh5QCXmsdOpdd37kZHT6s09+9YeHf6Kkts4ykyPnae/Hx27/6sFvZPwMM4cU9fv9H7ri/42lR+uujii5acc9LacWi4VK3Ve4ddBAY5wbaEvCe2pEeNzpuyeRh2RABhe1ZklrxY0wMQEylotkWABLAQKMo9jatip6XClbI9oSZriinKzp/CXsoaZ+fssdbyBF7Uj3MiuGG4lGjaAkM3NkuRpDPQZrEQGUQMUgEqklBoCdQ3FGu6VK/ZFDJ5MPlkJUTPXdd/zFyerkYHow7ac/eu8//ODgHZ72DFkl9V1H/+efnvy3XDorhYwpliz/+NL3benbVLVViXI5DmLWSh48PVONOOvTjoEQXGNAGjRHIGjXnUVo1SOgApBICVOmUzYGALnVVACIk32UhDlJ4h27FRd5WYOxYRdUr0KmVqDDWglPCWZmZ5masWgD20iWuUREmxQZJO9R2iFSMgMEXIh4qQ7lEGOHyaKXAnwNGc19PvSlhK+ZnHU8nquOBvUZkE8eTQJ6ts5kdfrt57/ub/Z+3sShsuyD/NgDn+3P9D1v/PJ7T+295Z5PK09Ih4TMAH948XvOGT6nFJWkkNjE2ZMVQ8xPHD4VM47laGM+Mo7FMijQDEuXIUskQ8wklYyWzNL+IhsSQoDWreG0xgIACokC2bV0PBGT4IuIAJWQuqH71aUjsBzwqlU1OBAAONA6E3gAgp0DxMRsNA6BJJJWGlHUIgsAySIRQRoFCiLaP8PIUDOSoUEcT3IMFsAYqMQ8V2e/7IZSMJqxkgf86Ny18b657OOHTlfjWlp5BIIYXrb9hmpc/etffrY/ndN+wNJ97Fefndk9/5X938UANMvYmIii9130+9eMX1GISgKFaCEczMggtSyF4b6jk47EjsH6YNrUQyEELaeamuUnCIgChSeURmNo/tBS8UgNLOlAEoFM5VomuhZZKQQKJVAw2KQqHckhM5Mk54Bl2vdTnmpG/e2p+OUBF800C6/QnUFmTvm6L5sBgKhcjKoVVFrooHFCAiMIqX0hoFqPGBgFAIDO9iMIZx0vlFXdiMZhQQlBB1CAFKBEI21Xi+Hwgj0wzyxAwpXrQy3F4dOL+47OoFDJuMQmfv3ZL3/v5e+sg0EpPCvq9fATD3y+ZEop6YPESlR+86433rjphaWwJFEgQ9N+sAAAR75WB0/NnJwvelpfNlYCYUhJVCr5I7SSWklfSV8LTxJDfa668Nj89K8Wy89WkQEUOgfWCZHua7qTVAmtlBq1B0IkQBUKFFqjUhzWqFoEgL5MEGjNDB2VrJ2mXi2nvVaYOCKQUuQCHTkRLy4cv/tWne9LDY/l100E2byzViDqIK2kKNbDahRnPQ0AOj9olRaxiwz7AkkJzARgHZQjlCLZqMTsMhpyPqQ88JXSglGCcdesr4+meaaMdz96+NKdm8mRECiFsM6+5bxXxRx/9uH/GEzlhRZ5P0eW2EHZVl5/1mvesPu1xbCMUiQIC0leltdm0J6865EDS+V4ZCD1/E0WCg4WixQTGjJ1MpExlhwDMcU1Y0uhKRuOLShQvtCeFIjVSkRSqvxAUhxXrkWFaqSklF4KhACJgMLVK/HSrKkWKaoKgigyKYVKyEQaty073LHW1XKpN3YVFjRSH6+8+twHnjm1UKywNd5SwZ+cnNv/5IZLr8qObWAmFQRKeQvlaGaplF07QgCqfwS8lKnUw4FM/4XrgBl9ASxopgpHF5JKR+tJefYo+pqNA2IgQILQqu1D0aXrou8f8H5431O//8orcl7gGAQKRiCit5//+kKt9PWDPxjK9FnnBIqF6tKNm2747XN+sxpXRcLKb4rANww7gVJisVL7+SMHnUhflJo7+9QBUzG+dVHdTE1Ww7rjJJ6gRmlWYlekJzxfptO+l9a1cqRK9SCT8wfHHIAUOLVUmiuUhGChNACiDqLCYvHQo2yi2FIUOylVX9Z7zTXnQFtjpM6aI4R2uRrsAXaxFOjIven6S264YMe9Tx36xRNHfrX/9NRSzYa1pclT+fFNwKyCNAIVi6XjM/Nb146QI39wnRwYg8ph54TIpKhWZwsAJMYyFogOz0tGFRHtm+WRLORT6GuUmLADQMWv3LF428E1+49N/+jBZ17/vIvJGhQNnQYiev+V7zRg//uZHw9lB5dc4YWbrn7vpb9XjyNCFii4HR5lRkZnXSaf+vG9jx8+Ne8HA6/qOwXVCpEnlfCy3tpNsl6zUeSMIeuIHCOA7wklBSBqTwoATvjUQN7IeGponB2BFCfn5ivlchD4IAQRgdRhaYkJQWcmhr2rzpq49rwtV+3Zunagn8gJIRL6RTuS3rL5CnFVDQgAFIjOubGB3Guuueg111zkyL3mz790z+NHIaoTWWKUQSAFRmH87KnZ6887i6zVQTa1foeZPGQWQusQpSBHwMShlaNp8tfakwVRjuV8nRdCCDSnPU5rSCsMPKPhhevmtw32PT0ffOWOva973gVSNGiUCS7CRB+48neNNd84+INrxi/58+e/v1LlCKmhENdq25QoEjEoJevWff2uhwzr7XLpxv4ZEErLhlhXxpeZrHaOuU3cXAAWC1Gt1hRLAzSGyVl/bLP209YYkOLY9FJkXCYtpPbAxOgcRuVabK7Zs+7bH3qjp7ymIK1t1mrgalWT6rmER0AI4YiYnXPke/qcTWvufuRQXC1FUSiVJ1IZFaSwVH/q+Cw0KqYhve28wt4fm8VydHLOX5tiKTDRHgTGIQ+H1nDFuHKM5RirBsMYyjUgYMQYoM+L3jjk31I968FnTnzj5w+/4fmXGmuUlA15LWAJ8MGrfzenM6/d89JA+QtUEoiMy+XprYyZJRrKp7/1y8cff3aSvfwbBx8dgNJSySMbJco0SgvfV1pLYGhgtIjWkolJCgAgRCRjTeyctXrDWa349ODpRdA+BmnhBcjMUc1WlkwU7p4Y9JQXxkYKIURSWYu46vpOeEHdxJUewuACRStA3LZ+mJGjei2uVYOcp/3Azw+qpfJTx2cdW6UkAGR3XrSkvTg01YdPeON5zviQ9cCT3HQYIAlgUtIpZKMgthgZdKwsE+m3rJ38j9mNR1z6U9++58WX7hlIpx05hAaJzhEJkO+94u0AYJxFIZLCGBKcpEtamVXfk5Olyuf++x72MltU6SY4dOhQuR5jIkwDKFCi9kQ2pwYG0+msx8TAEMYOmLUWQMI6KldCZ50RKr39vEQrEwAePzbreb5K90vtg3PWRGQicGbj2kEAkAKVbG+ahKsNLwMI6BC86Q1ZNEFJAQA7J9YEnjRxZMoFKZWSKj047Es4fGru6NRCAo5nNp7Ng+tcFFYqVkZWzFTEkUU8MC/2z+H+eTywIA7M48F5PLwoTxbVbEUVIxkROkbBMah+XXnfxFFW3pGp0oe/9KOEo9vCn5PCB0uJ8h82gHYGauXYGJiByPlp/5Nfv/vo5KIMUu9IP50tztdqDpBESuq80ikE50w5LszUTxxamjpRcMYJZBNZIdBZqlajpYVavc5AVgwMZzbvIQAh1eHp2YMnZnyBKpMH6bPybFQn6wJfn71xLSz7OdimSt7eE2Y51YqAalnwo6Xj1jENy1OXSCpvGRsc7c/OLVZNsSA2grU2GBzRnlqqRPftO7pt3RprYi+VD3ZdXjn5n7VqKjTO871mtNOgmmKzdWD7eZSIQAmEyOjfGDl2+9zQ92nd1+965PwtY29/0dVxHKOSDRIWogCNwMSUcNpZgORl1806OzCY/eLt93/n7ocoN3K92X+z/wxtXLtuY18wmpIpiVKQ4WghKh1dKh9edDW3OFsvFaMgpckxOTKG2JGQ6AepuFRJnXO1nx01ceR5/n1PHppbLPbnMjqVZXIolIvqhnB4ML9jw3CjbKanhnHH4zYGVrQzT7CtjGkFj44BwRGN5Pt2bxyLCauL8zaOybmgb8DP5RHh7kefbe2X/otvdEKYiGoloyQ22gUxJLn4psg4IoAARAYBLAAENyNDY/9qw74JXEKd/dC/3Hbbw/s8z7OOlgUa25qqMLBgEATSARJY4wb6srfv3f+3/3GnSveN1qbev/axwes2rXv5jqFLxoKhvKCAI6FSXv+uwfUv2LLpVbtzu4YAMK660lJUq0RhzdiYpa9V2nPGgpBDV74Cm97iTx85CIDSC2SQIWvYRq5WtoxnbRpbk+8nskljgDYR9U71807rolqkGmyvUero1rZcUkZEUojn7dl82wP7w+J8WCoEfYNS6fTQ2mCx8MCBU1OLi2ODg464f88Vp8e3iemTpbIdHAVBnCCkbUrryS02isFEi5stQCJa0uOp8me3P/n6Zy40KvidT/7XVz/kPe/s7cZaKdrpKUmijBOnMxGpHhnI3f3ksx/4x/92whM2+uSlhy+9cl2USYdHytXHa26OMAZyDD54O1J9l2T9AW/ihZvKu4eLT89RoQosWKM3qPPjmbkninahKMY353dfzgza8+aKpQcPTmU8T+f6ldLknK2VTa0UOXfN2ZsA0BEouaw52SFLwNyWe8HlpHbbnuCVuoiNnd0E4ADg6j2bM740YVydnxZSAUPfuonA907PFX70wFMAYOPID/JDV79SsIkqVELJA2kngByRIbJMrkX3QRIChHCISTlXWHeFpdribOX4ieic+pEP5/cyihj1Wz/+zVsffFIrlWh2dyroJCJpzAxDg7kfPvTUez/9nRopy/h3L5h62QtSkZ+uPFCY/9qiecLAImFIImZRpPrPi4V7CsxgI5dbnxu9cHDkijWjV65Zc8nw4K6+qBJVZkI2tdzFN2kvY+IIAH76yP7JhUrK94O+UWAQUkXlJRPWU564+pwtzSOqVaLWWSuMbXu3ObptxUwrwerkIrysUigQ2Llzt4zt3jgaxa4+N6WRgSg9vEalU4LcN376GIFVSjHAyHW/LgbXUBwtztVg9xo4Zw3tGqaNeRpJUc5jLRgArAPjOLZsLBsC5+JaXC/HYT2m2MzX5ev6jn18zaNSqDqpt3/i23/9jTsRUUllEvXEhugRGyLP0zJQH//mne/99H/VLEqBn3nR3OsvrUVGUplr90e+r2UOQQIREBMr8PLKHIsoJumreKEcF6pknbPGGWaLpSNVYWPIDw09/7UAkEjOff0nDzM7CAIvP8BIhCIuL0Wx2zzad87mtcCEK5okAra3WYPO7kKoOm19Z+4YV7TFQLSOtNYvueysvYem6sWlamFB5/oZZHp4bbiw8Njh2V88eeTac3ZYY9JD67JX/1rp1s9Xji4VD8z0nzVifS2GM432GDGxsWAsxATGoXFsCRxnhlJZZiBKEiQW8G16cXTuqT94fHOR1ce+dtd9+47+1dtvPnvjOABYaxjYlzKbCx4/OvnRL//o3icOo5frx9pnX7L44l2lWpm1L1zswDihJLUCZQHIbMtWb07JtHKV0JSrKFVSGCq1qM/W6/MWXT137Ruya7YkjOMH9x+59+kTaU+qfD8KQQA2rlO9ahheeNGOQPlJ/wfmjkYy2Mmp6ZIblbc0qyRXqK4ni6v9EEZEcMxSiP6s/7W7HnQmIoDs2glyzktnq1On6hYiY15xxR5iFkL4E1vnfvE9DGu1herA1iGhFTtK+HooBXoSUx5mfcynYCADQxkeyvBQmofSPJSlkRyPZHAkEw3k92yOr5uo7T0hZ+K+U3OL3/75o7U4vmDbeDrwPV8v1Wqf/+F9H/nSjw+eXnQie+7A0pdfefqazeVqDSUiEKuMiEsuPhGiowYdzziKndyq+28aRAHx3FIzbZs4WTjz6DyVQu4b3PD/fUqn8kQkpfzIV29//OhMOpPKbdgJKBGhOnUkKsyzUB9920vWDfY55xKhiJVU3JXdohpKvbfccgt0ZMQQobObZNJpstH5g7WSBPy+f/7vwzMlJJseGs2PbQBns/m+qFqxpYWDk/PXnrd5YmQwjqMgOxC5sPrYT8H5bEzftmHnaPn+EoVzSr5JaJaNRtooBDTLDBGhbnFDX/Sas+s1I/Yt5SvWu/epoz/81RPE7r6nD3/g8z+4/eEjVfLTgfc7Fy7988tmN/TFpbpQAhuCrEyprSmxxsNAiJyQI0pt8tNX5fNX9wstotkCGYOJPC6DCmTxUKF8IqSoOPCadw+f/0JrYq29J46e/PCXbvOVDIbWpkc3OBsLIU25GJUWCeXUwtIrrj7bU9oRC9FLgW9FX+VGV/DmgdYtRLkyGCMGKQSBe8NfffmH9x8cCHRm3cTGy54HgEAklIqKC4d/fluxUr/pku3f+vA7rLUopaNw/y2vEcf2sU6tf/76vrPX2YiICBN1+TbXCBpKu9jqB9rSa2QAR+Ap0oG690T/J+4bvPdEEEWx4BqyiyHwPXXtZvv/rileNlGwdRcZIQVxInyPAEgAKDzRZG4ACmAmcGiWyq5cAyGYGBmEJ00pPvXLGajVcONZO//ye0r4zlml9G994ivf+eVT/dl0385LVDoPzjIKFKJw6HGzOFOs25su3fGND71ZoUr0Opoqu10qrNhVCiZvueVPV8IPLS2E9v0iBdbi+M0f/8qtDxwczKTSa9dvvuL5KBCJAdE5J9O5eqnAlcL+ycKeraO7JsasiT0d+BvPWrzvexqxOlNRklXWF54UnhIqUWVusg+aRSHI3Q2yEEAIJJCx4a0DtdedVdo1WFmswXQtDUJfsbZ0y9VTtzxvbqKvHhop/MDzFRliYiFFUyBAkkEyjh0AIVhElqZQNsUKoEgoBCglWJh6cIbrwBIn/uAfMiObrIm09n/y2DN/8bWf5nzlDa5Nj24k61AIwQTA6f4RE9UDtE8dn3302RMvveKsQClqCIkgdHfBRWwn1kPTpetsMQ0r+9ZaYi3lV+6877c/9e3xkYFgZHzr5c9zzNa5ZkqHUQhTrx6557ZaLdy5fuinn/q9QHrOGKn1iR/80+J/fFRmBmxUV1kvNZxOjWb84azXH+iMlr4SSoBopbEpoRkwL8vUtUyqYxRggxQDencdzVniF20po4jDqrMRc81Fi3G4UBdpb3D3iNBArr31Iyfiw0KCLVdsuYJSsGMwRBFJwLkDS5XJkOvF/jf88cZfew9ZI5SKyd7wvn94+vh8Jpvu33W50B4TNSUFnJCKpSwc2cflhdMzC59976veftNVpk3llVvtOHu0hWzUCbcfvtyzEVNysfO3TawbGY4tDfQNgFK2XqdmTatAZHKp/oHhHXvmnnjoySOzn/jGTz/8xhcRoCBa//LfKz/9QPzAHbp/mENTO1msHVtsqDWktUwrmfFUytcZrTOeymiV8qSnUEmUIikWaHDtGQU5IigtAJrqdX6Bamb2gai+VLeL1fpS3cSUGQ4Gzl3Xv2MQFLJrVA4kaqzAgBKFBLtUNItliIGrsas4qlm0vLhYK1cc1grexddP/Np7mNkxCMBPf+tnjx6aHUzrYGi99NLkLAoJRI2WddZKKf1sX2VpcXRo4JyNY43i3qb0ZzujewU0hGo5C9Z9Snc07RNCWOvO3TJx4/mbv/2Lp5cOPZ1bNyGzeSDXUC5lABQuika2nlU5fYIX5v/phw+84KKdV+zaHEex9r0tv/fJg9PHcfqwzPchaukrU43JcLwQ0Ww9KRhBAUIKIREkopKoBUoEhdio+GcmBmIyjmJiwzYkciQEKE94famBXWuy2wbSa7OghIssGIutsEgACEQBEJr4yGI8VXZV4tAxMQpUnqzW41oM0tZofNum3/9bARAb43neQwePffq79/Vn0yKTy4xtYRs39JgQARrpeFct1yePVOrhSy/ddtmuLc450ZL37qFU2Ylx0rJqYnf3za4N4xwpJe978uDLP/xFT3B+y651l1wDJobGqc/JUlPai0tLR+65sx7G64cyd3zy/4zksnFkPN+vzBw59rE3q+I060x+cy6/Pqgu1I1Vthbbcsiho8hSTOSIXBIzMrc6Ozb5XSgAJaAUMlAqG3iD6WBNNr026w9mhC/JEcXMTA1+TsOZQowd1qJ4tlo/UaKSSVgaiMCChcBaOSpXrDCRyQ5t+tBXc+t2GBNrrZeqlRe+/3PHZ8upwOvbealO58malvQZgGAmJbB04pn6zPGaoW9++M0vvOhsYxNn9Aw9eNqS8u0HLfZ4xXK3ByHRWnvlOduvO3/TnQ8fVVOnwuJiqq+frePmcYMAZOPUwPDQrj0zj9536HTt/3zqP7/zZ7+jPe2sya7ZsvGP//3Yx94iFqfnnolMnB49dxB9X+XywvdsaEwtdjXjQuciY5PJMI6TyRCIEqUnpK91xlNpT2U8GWjhCUzMkiVXjVEAJv3iULB1UDdcDrEU0lJYL0Sm5lAI4cmk8gcAhRDlYr1accLUTGZgw//799y6Hc4mIqD4u3/3zf0nZgdSOhjZpjN9zkatpCICAjghtYmqUWGuFtEVu8dfeNEuZ60UiKv3kuyCG5DIrpIAaLUERk4OR2wUaj944MjNH/6SRpHdsHHjpc8zYQhCqAZvFJ0xbA1LffL+n9UnjxcN/u4rLv/r3345ETE5qXTxxBNHPvoWsTTPOpMd90fOHhEKMdBqMCvTXiJv2MCml2ma2OLiLVPyqIm3NEXamBmtA2O5GkMpwnKEkeHYRXUKQyJKgidOGDdCIDOXCrV6RFiv2tzQhj/+Yv+WC5w1jFJJ8ZH/uO1vvv0/gykpc0ODW89zDCglKoUoiBwTATmh/dKxfdHCVC2Mv33LG2847yxjjRLyjF0+OvqPJIGYWIYtOiRVcNkxwoZqkCM3MTI0tbD4q2enZb3sZbOZ0TF21tZr1bnpxSMH0fOFn2ZyAxObqotzHrt7nzkhFV999lZmYLKpgXXZi59fePp+VZ4h41cmq6JKsBDGp4pmtgbFEKqGqzHXLIWWYssxcewoAYuMA+vAEMcGYouxxchAJYRCBefKOFOCqRJMlcVCVVZiiFwUUq3mopgQEWUrQAWhhI1dcalmLEKtyOu2bfrAV/o27HE2ZpRKyn/4/s8/+p/39GcCke3v335+QiV1YakyfYydFVILqZTnRUsz4eSRUsivuWb3e155nXVOyWVgt82xbP/ToRuX7AA8Qz4SWl1yARNynBBitlh63ns/s1QKs7lsfsPW2tKCKZdMvWbqVX9gaPP1N2stpVImqh/6+e1UD8th9CdvvP7/vuoGR46dU9qLw8Kxz74/fPDHIpUHhGxWZzMBMBGR8qUXaJWSSguWArGRwVyOETnhBTM4TnxWbJzhCW8enWUTuTi0znKrCDpJQggpGLhWiSoVI4htvehdeOPG3/2UnxlyxrAQSsp/uvWeD3zh9nzaRy8Y3HUxegGQQ2cXnv6Vq5akFwgdiCClswPx4kxcraVS8md/+/sTw4OWnESxsqtgl1ort/2ohQUhL/OiV3bjEc0oDlGgtS6fTuXT+nu/fCrjB8WpqfJSsVyuGmfQ8zkObVgd3LDVGqP8IDsytnTyuAd850MHHNvnn7tDCGGt1X5m4IqXR8C1ffcJG0dOhlGsfeWlPQA0BkxINnQUEzpGYkx0xqjBIxTE2ECnEFAkWqIm4rjmaiUblo2NHBMjICa8IwCZUiqnjbOF+Wqt6jisxuT6XvXuze/4G+2lrTFCSinl3/733R/+t9vyGZ+lHNh+vvIzbC0qWTz+tCstWBbVelSthyaKqFbRUi6WKn/x2y+8rmF8RDcA3cv4tP+0hQUxrtqsBJZV4oERMOFJXLBtw8mFwj1PHuvP+bs3Dr/imrM/8MYbwjB87Mgc1ivOuf71m+Iw9DLZ1NCawsmjKYF3P3pkqV678cJdQso4jiVi/9lXebsvKR/fBzPHhdShYRM7KaWSEgDJNZpCRnUX1cnUnamzCRvtGaxjY8HEYGIyMUcR2ZisA0ZAjagF+kJkpRoK/HUpb12KPCjO1cozEYcx10pi41nr3/X3a6/9DWAyxmjPQ8QP/vsP/+YbP+tLBSzkwLbzvcyAM1b5qfLpZ83c6VLdvuDCLX/1zpeN9mWBqVyLJhdLr7/hvD9/y8uInGyNfm9djkYqCjt6oCASuVZpAndHCq3Xcqt4uNlcAIQQ9Sj62WP7t44Pb1/f6HUUmvpLPvCFR48XMh6O7DpncNe5tl5TXhAWFk/d/zOKwmLd3nzZts+997V9QTo2RiJL5VkXTt/6+eJtX4bivAhSqJTWIpXSXtBIv5BjRkBfYkqqjBRpCVqgEiBaBxUzN5pANwJDicITiMgxhfNh9VStvhBT6NhUOT/Uf9Nvrn3pO5VOO2McgKd1Oar/3qe/9b37Dg5mPCdl/9bzdDpPscEgqM0er58+Wo1p9/q+H330Hfl0OpGvPzI5d3hy7upzd2T8gIiws71LZ9NZgA6meltXAHJ2uf0dwmqeKEB3GxMiaHUjZybnyDH7Ws8USjd94Asn50pptANnnT9y9oUUh54f2Hrt+P33RItzpchuH+//hz949RU7twBzsvoAoDZ7fOZHX6jd+30sLYIOQAdCg5SYHvbS69J6wMeURCUaHB7GRlVEg+bfkptlBCDHFJpoMapNh+F8bCuxcJY5woGR9BUvH33x29OjG5MGDkopFOLBg0d//zP/tf/EwlAmoFS2f+u50kuTiYRSlelj4enDdQsjg+k7PvbOieHBKDZCoBICmwGQI2oXqezqsbw8tryyyyogNbWjuxWnV6Kp3MFgSFadIxaiJdWL1jmt1NMnT9/8gX8pV20gYeici8fOPt9GIWpNzp7a+6vyyaMxkZT4vtc+//2vuU6AsNYCU9LCpDp1aP7u/yzcdyvNnFJCoPZBKxUIP+f7/SmV1zotpS9RIYq2BpqO2YGLbVx1pmyjQmRKsasajmN2oUMHIxv6rnzJyA1vyoxtBwBrYgahtWKgv/2vn33q2/c4y75G1Tea33QWSA/ISaUrU0dqpw6GhgIN3/voOy/atrHVwgQxaf4NDcwbujSCuKvdMnPPYBiXJ6AnMY7bdKexvX6pd5dPhGYTn0cOH3/tR75SDjmlxNDOs0fOPs/EMQMrpRcP7pvb/wQ5KoXm0p3jf/6bN1151hYAiOMYAZTnIUC9NFN89OflvXeaw49CcQ6dEUIBBiAEKolSgmpI1y5L0zpiR0QAzjHFDA6E5Eyft3VP32U39194g58dSYaeGDzPA4C9zx770L/96L6nT/ZnApAyWLMpt2YDOXIMUuv61NH6zIl6bDM+f+PDb75s59bYGK3kqq0Z2vsOw3ITgFU6gjUj3BUT0IaG8gpBv97NxLpDPmtJa7XvxOTr//JrU8U4pTi7bv3YBZehlGCdn0pV52ZOP/ZgtDhftywlv/rqs9/96ufvHF/bnAZWnp98QFicqh15qnbwofDIY27mGJWWXFhnY9k1JK+bcoKMEkArkUpj/7BesznYeHZ66/npLecFg+PJ/Zk4BmgM/fHZub//73u+/rPHjYGsLzDIZDbsDLKDzhlEBeRKpw7Y4nwl5jX9/jc++IZzNq1vApwJo6m7yQWvzKnjql3d2lMCyQRgz24nz9WOo7tLcfuLrSOt1PG5+df/5X88cWQ2n5Kp4bUbLr1GpdJkjPI8Nmb2wL6lowc4jqqRyabUr19/wTtuvmrH2JrkULHGokClGn0MCSAuzcXzJ8OFKbs0Y0sLNqyxNQiAnqeCrMoP6IE13uAaPTTh5Ufl8mqw5JzSKum5c3Rm9ou3/+o/f/LofLHel/ZBed7I+tzaDQIlOSOkciYuHnvGVgrFujl749A3PvSmjSMjsYm1Urxam+szda3qzUtsTSA2aJfLocAZWxr2bKuxSsuyZA4Wa6V3fuIb9zx5XDiz5tyL155ziY3CxJp5nlcvLE4//Xht+rg1rhrbgXzwokt3vemGS67cvUU0+WXGGCYWUgqlxP/iuRmArCVyCKC1hoY0Oz24/9jX7t77w1/tmyvWs2nPk1r1DafHNvuZPDjLzMAkpC6eOFCdPOJQXnPOhn/5w9cPZvOxNUqJljYUL/f1xdXaXXcIkPVgybXNzzLH5jm+sNmMoFfnwjalufbvY2t97d39xIFX/skX8oG37rJrBzZscyZOUoIILJRixOr06YVnn64tTDtja449LfdsGrvx4p03nLd198axjO+3bt1Z2xLwalPPwlabTSmkkLL1tLU4Onhi+iePHbrz4UNPHJmuxSbjCa2UzPanRib8/qGkF1oCs4AjIVV19mTl+L5iLfrOX7zthRfsjkzsNdY+tq/OVQ7VblcIeyS4OnxLtdLurzBerRlY2S99ZQfX9j5YmKziOx54yhF72f7c8Bg512RkAQMaZwEgvXZdenSsOj9dOn7En58xYfjE4cmHD5z+9Ld/PjGcO3fz2AU7JvZsWbttfHSsP6+EPlMzW3bTheLhyfknDp9+eP+xJ45On5grV2PytE77ciid1/lhb2BUZ/LMTNaKVmE8N4r6/P6RcL6Po8JtDx144QW7pcBl3ckVhp6X2bQ9CuGxh3fJK6UKeLkvZYe72nV0MLc6mvCy5BnjykRmK/3PUgpD8YPPnPClDPIDfjpjrYFmgrAJrIM1hplzI2ODayeiSmlp8mTp1PF4adbE4bGT8weOTX/7Z48GqWBoILduuH/dYH7tQK4v46c9pZVAQGOpEsZL5dp8oTpdqEzNF2cL1Vo9AnCeEr7vDWR9mcr5A6PBwJgM0kzkrAUkbOTmGQEEMQh0CDKdU9n+oFZ/+NnTsYs1SmoktwS2VJ+4KUXGiRaDgN7oT+I9JiLEDSVR7E5JtmXEcFXEoiVg3NnbG9vrLrt7LJJjpeRTx6aOnF5KeX52dEx6vomjpGyh1QU9Cap9z2ei2MTopwa37urbsDUsLtbnpuuLc6ZWdXFsrVkqRTNLpx9yp4mYyDJZ0SA9CACZlHcpIXxPer4fpNPC86XvqyDrZfp0OodSEYEzFqWSOmAbATtIhNSwOcjMQnlefsSfnz56ev7AyelzNm1ga1Fgu6xqM9zmTkl6bCuxb1+f3JAy6NWTXC1vkh75yM4fNtVeuxI93GEcl5WYku8OHJuZKUXja4aLM5Pp4dFgYDg2ETknEjV/ACmlRph7dr8XpDPDI056bCwTBf1DuZG1EoGNiWuVsFyKK+WoWja1molCF9XYGiaHSamF8oXnC+0J7Qk/Jf2MClLCD6TSwEAmZufAWUQBjuLyEhmTGhljYiSHQjROAkShvHhxJlyYCoL0qdnFp4/NnLNpQyMf1HLuuefhy50nLGNbwXsvcK2ZE25b+NjthrZ61SMuE4m4pzzyitiNG8UkN1y06+VX7vrx3sP5eiWcP52b2Dqw8zw/kyZrkVlKpZU6+tCvisePKATtq2BobXZic25krfZ9ZiIiEKhy+Wy+vyHPQUTWkjFMzkRRbXYehUTtCaVRKmhkwwnIMTBZK4RMegWbciFcOB0X59kaAowri31bzkYp0VkAlEo7E5aOPxsuTBKLxVp0/YWbr7tgR7MqprFKe4h2tZ8BbeFBSyVhlVis4UQgkekk0WFXJnKVE597CEtwQxaqtUWoMQ38ye/89JPfuDuKbdYTKjuwZs9FAxObUClkOrL3gdLxI8aasFYWiIGn/FTW7x/KDI+kB4e9XJ/wUw01CWB2REwJ8i+FBKLF6YWEoADsgBJkQDQtBFEcU1iN62Vbrdh6OQ5rYRgZZ/3AS/mBN7yhf8vuBDcIF2eqJw9QtViOjFbiXa+65oO/caMUypETHeld7CWwtNxfG58jUmg3LdiOBa0adTF0rXqG5Q4v2Lt1aNvrqSHXjY8cPvrhf7vtlwemAk8HSqYGhka27ihMTxVOHitG7sXnTbzqyrO+ec9jjxxbWCiHkslX4EmpfM/L5r38kJfrk+mMl+tXQSqpqJMokGhpdqnhlzojmK0Jbb3s4piiugtrFNddHBnj6pYIRX8udf7Goddde+6P9x689eFjg2mt+0aD/uHa3GlbK4eRq0fhFTvX/sVvvejSnVuByVEit4QrxEq5R/q2AzLoOTI9XFIkpq7YapWp6LXkO0l3nR/ZuhNkZudIKwUAX/vpg3/3/fsPnpwL0PoSlFTz1fi687d858/epoUCgCPTc3c+cuCuvfsfP3x6rlgjB0qglkILZECVzmy69iadyXLSNJCoMLOQnI7MwHF9/pkHqF5DFNZxTGCJlcThvtQ5m9a+4KIdL7hwx47xtQnz69c/9tU7HjowlJLkXGhc1eL2idH3vPKq33zBxQDCWCtEg7fX1eX3DLyFTrlixOco0kMGOCMYt6ITZVec3MGjbhg7XCVSQ0ckBAiU5Xr1Cz/61b//+FcnFiux5avOGv/un789l8pExigppEhABDo1v/jYoVMP7j/15NHpI1Pzc6W6FMrZeOPlz+/bsMXGoRDCOVeYmksSXyhVtDhbPPwECOFMNJxPbV03fO6WdZftmjh/+/j44GBDHZesIfCVCm302r/88l0PH/UlTwym33zTZe+8+aqBTJaZHLEU+Ny9gNtc95Xqw71FiLs9nTNFwrhigXf+3Vh3vCKLwL14XtzEJ1grAYDFavUrdz24/8TMR37rpcO5nHVWCtFo6UMkRaNdcvJVqtWeOnb67X/7ncVCZe1Ze9aed6mLo4QrtjSzwI4BSCqvcvJA4fSx0aH+L7z7lTsnRvszmeUAjZzjRmcZRHTOKalqcfThL92+fjj/1hsvGchmASAh+CP2OmBhVdihjfrfc8TaPE1u6+bTqBPugPmhV0u39vbO3NbysLu9eS/YlLuaUyqJjpiI+jKZd73yusaskJFSQjN/njBqnUvwdhAI+XTqyt3bz9o4+pO5pbCwCESMaJmJCa0DSERzna0UojDevjZ/2a7NyaATNwp7EHFZJptACuHIpT3/U+98RfJDY6yUokXobGcPdo9+S0Kz2dJtpQpQW0NzXtafbStUwmXOZ0P1qlFGw3yGuYak/r95Y4wdWsM9VJ+a+uvQRuxhAaCkcOSMtdYZR1aiXNbUaZJ/EBvgvxAYGwsAF25bRyhMtRxViogCUQihAAUIAULaqOaiugU+b8sYAMTGAqIUKIVoqxttiDgliRQiMtYaY5yzatnoYPegt2SFmiJl7dKzrT3WibVxuxJ3QyyJ20PXxgcpaCuNXJ6aNtSTWyUbnSoquFpA0uoJye25fm6lnVtdClEitkeP7T2b2jKoyWABwIXb1isBaO3JX9ylvAC1h0La2DAREJGNJIJS8sKdG7qELzt8hAbXrHE/Uorlpl24wntpJXdbzb0YO1O9XY542+bo2jO4EkDgLmpiZ5Vqp8x0x8ZEwNXAbu4RFbaLba+4ertT3BbsY/t0NCQOLtoxMZoPjs8saIGMQgiNCdzHjp1jREs0NpS9aPv6RNWnDS9sJAlxueADlqs+sae/2EPlFlZWfnW6Qwk2tyyhxyvpodg1x4kXtJqLia2WVh1sl97RNfNKhnUPj7h38ue5WHxMzFLIJ46euufxZ2cLlWI1qkQ2Mg4RPC2zvurPeCP9uWvO2Xb+lolOjkJzxFdIhvVG3VcwlHu9uP2E6H6Kle7iiuqw1kLELmbcKq5nR+6B2lhcy2cU9wwzVo1H2pst9mKC9ep6Q8y9uDcrEGlyuNxPuMMTX/FJ/L/KbnW8ut1m4krxjTZknlfhl3QAeuiIsCNL2eOKsNz3oWtfdhSeNVNFiNCTaLEipl517WOHN92W9XHE3BKWaTusuPHhKESjSWgze9SeJ4dVuhnB/y4l1Q7Lt5rb8XP57l2LM9lhy/usKw7ANmnmHtajW8O81aMbeoQC3NsMNmelA4Pl7rvv9v06ttrKhYKrJmt5FRvYc1CgF/TVlXvi9rUIy+Fnj43eNlyrzVOrp3w3Tvec6TZodRbpjESgk0y3WlqOe+7+VdJ8y2J3uKKUs8M36C5xYHguS7javPakyXZO5srB7WE527MCvaK2JjUR2+CELlypZe65Iy3XDDd6LYHu+K8zddxqbNwD0uo+6XuSPjqv1kpVdCJaiHAmuLDX8uyS0eiMLxOMf7nlHXZ4otyJKPfA4FreedcTiUZsBdzpNa5wZJs54XZ94s6+KNwrj4wtghG36fWewebisjAytQ6Ypn+7XPHWETByO+zesxaufT02l1qrQxf3zJbQSvOF3AYlcLuvir04aiv0TniFww+IzjUrZBDbpGuWUYu2QLqThYDtJrH9bqj1wxWrgTsb1DeNBre1lGmXQVmWU8OOcoWOEmg+E4lmuR0UctfZtMIKITZboHJHJ5GOscblrPhybIcd5wS2pEChfdC6aOuNRlbJBDTHhaH7OXvrHPAqh37XI3F3d+IeDIGOm2NmXNU/aXO6mJqs6NVuktscjZXKVQ2vD1EwdxAJus+RHp7MmY0+r/INL9cgdUCajK6lu83dU7g8jp2+D/fAILCptHLG1A6KFYlV6imX2em2rkhQL9/RapTAVcKS5VuFVTDOFSgQrhY/9mRG9Zrorl3Zrj4D3DJBLcSz63ZpBeeiaw+3LfblBGaSNaPue0Vuz2lwZ8XC6pHzanmo9txcux1coTUCbX2DsC152ztEb++XuLJshXhFh+zVzvnGECN2HpXtjj78/84gKBsOB0TPAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDI1LTExLTI4VDIzOjQxOjAyLTA1OjAwJxiXfQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAyNS0xMS0yOFQyMzo0MTowMi0wNTowMFZFL8EAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/log
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - pods/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          - builds
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - machinelearning.seldon.io
+          resources:
+          - seldondeployments
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - mlops.mlops.dev
+          resources:
+          - notebookvalidationjobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - mlops.mlops.dev
+          resources:
+          - notebookvalidationjobs/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - mlops.mlops.dev
+          resources:
+          - notebookvalidationjobs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ray.io
+          resources:
+          - rayclusters
+          - rayservices
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - pipelines-scc
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - get
+          - list
+          - update
+          - use
+        - apiGroups:
+          - serving.kserve.io
+          resources:
+          - inferenceservices
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - serving.kserve.io
+          resources:
+          - servingruntimes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - serving.yatai.ai
+          resources:
+          - bentodeployments
+          - bentos
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - tekton.dev
+          resources:
+          - pipelineruns
+          - pipelines
+          - taskruns
+          - tasks
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: notebook-validator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: jupyter-notebook-validator-operator
+          control-plane: controller-manager
+        name: notebook-validator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                - --leader-elect
+                command:
+                - /manager
+                env:
+                - name: PLATFORM
+                  value: kubernetes
+                - name: ENABLE_WEBHOOKS
+                  value: "false"
+                image: quay.io/takinosh/jupyter-notebook-validator-operator:1.0.0-ocp4.19
+                imagePullPolicy: Always
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                volumeMounts: []
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: notebook-validator-controller-manager
+              terminationGracePeriodSeconds: 10
+              volumes: []
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: notebook-validator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - jupyter
+  - notebook
+  - validation
+  - mlops
+  - machine-learning
+  - papermill
+  - tekton
+  - openshift
+  links:
+  - name: Documentation
+    url: https://github.com/tosin2013/jupyter-notebook-validator-operator/tree/release-4.19/docs
+  - name: GitHub Repository
+    url: https://github.com/tosin2013/jupyter-notebook-validator-operator
+  - name: Architecture Decision Records
+    url: https://github.com/tosin2013/jupyter-notebook-validator-operator/tree/release-4.19/docs/adrs
+  maintainers:
+  - email: takinosh@redhat.com
+    name: Tosin Akinosho
+  maturity: alpha
+  minKubeVersion: 1.31.0
+  provider:
+    name: Tosin Akinosho
+    url: https://github.com/tosin2013
+  version: 1.0.0-ocp4.19

--- a/operators/jupyter-notebook-validator-operator/1.0.0-ocp4.19/manifests/mlops.mlops.dev_notebookvalidationjobs.yaml
+++ b/operators/jupyter-notebook-validator-operator/1.0.0-ocp4.19/manifests/mlops.mlops.dev_notebookvalidationjobs.yaml
@@ -1,0 +1,943 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: jupyter-notebook-validator-operator/notebook-validator-serving-cert
+    controller-gen.kubebuilder.io/version: v0.14.0
+  creationTimestamp: null
+  name: notebookvalidationjobs.mlops.mlops.dev
+spec:
+  group: mlops.mlops.dev
+  names:
+    kind: NotebookValidationJob
+    listKind: NotebookValidationJobList
+    plural: notebookvalidationjobs
+    shortNames:
+    - nvj
+    - nvjob
+    singular: notebookvalidationjob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.notebook.path
+      name: Notebook
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.message
+      name: Message
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NotebookValidationJob is the Schema for the notebookvalidationjobs
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NotebookValidationJobSpec defines the desired state of NotebookValidationJob
+            properties:
+              comparisonConfig:
+                description: ComparisonConfig specifies advanced comparison configuration
+                  (optional)
+                properties:
+                  customTimestampPatterns:
+                    description: CustomTimestampPatterns specifies additional regex
+                      patterns for timestamp detection
+                    items:
+                      type: string
+                    type: array
+                  floatingPointTolerance:
+                    default: "0.0001"
+                    description: |-
+                      FloatingPointTolerance specifies the tolerance for floating-point comparisons
+                      Stored as string to avoid float serialization issues across languages
+                    pattern: ^[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$
+                    type: string
+                  ignoreExecutionCount:
+                    default: true
+                    description: IgnoreExecutionCount specifies whether to ignore
+                      execution count differences
+                    type: boolean
+                  ignoreOutputTypes:
+                    description: IgnoreOutputTypes specifies output types to ignore
+                      during comparison
+                    items:
+                      type: string
+                    type: array
+                  ignoreTimestamps:
+                    default: true
+                    description: IgnoreTimestamps specifies whether to ignore timestamp
+                      differences
+                    type: boolean
+                  strategy:
+                    default: normalized
+                    description: Strategy specifies the comparison strategy
+                    enum:
+                    - exact
+                    - normalized
+                    type: string
+                type: object
+              goldenNotebook:
+                description: GoldenNotebook specifies the golden notebook for comparison
+                  (optional)
+                properties:
+                  git:
+                    description: Git specifies the Git repository containing the notebook
+                    properties:
+                      credentialsSecret:
+                        description: CredentialsSecret is the name of the Kubernetes
+                          Secret containing Git credentials
+                        type: string
+                      ref:
+                        description: Ref is the Git reference (branch, tag, or commit
+                          SHA)
+                        type: string
+                      url:
+                        description: URL is the Git repository URL (supports https://,
+                          git://, ssh://, and git@host:path formats)
+                        pattern: ^((https?|git|ssh)://|git@).*$
+                        type: string
+                    required:
+                    - ref
+                    - url
+                    type: object
+                  path:
+                    description: Path is the path to the notebook file within the
+                      repository
+                    pattern: ^.*\.ipynb$
+                    type: string
+                required:
+                - git
+                - path
+                type: object
+              modelValidation:
+                description: ModelValidation specifies optional model-aware validation
+                  configuration
+                properties:
+                  customPlatform:
+                    description: CustomPlatform specifies custom platform configuration
+                      for community platforms
+                    properties:
+                      apiGroup:
+                        description: APIGroup specifies the Kubernetes API group for
+                          the platform's CRDs
+                        type: string
+                      healthCheckEndpoint:
+                        description: HealthCheckEndpoint specifies the health check
+                          endpoint pattern
+                        type: string
+                      predictionEndpoint:
+                        description: PredictionEndpoint specifies the prediction endpoint
+                          pattern
+                        type: string
+                      resourceType:
+                        description: ResourceType specifies the resource type for
+                          model resources
+                        type: string
+                    type: object
+                  enabled:
+                    default: true
+                    description: Enabled specifies whether model validation is enabled
+                    type: boolean
+                  phase:
+                    default: both
+                    description: Phase specifies which validation phase(s) to run
+                    enum:
+                    - clean
+                    - existing
+                    - both
+                    type: string
+                  platform:
+                    default: kserve
+                    description: Platform specifies the model serving platform
+                    enum:
+                    - kserve
+                    - openshift-ai
+                    - vllm
+                    - torchserve
+                    - tensorflow-serving
+                    - triton
+                    - ray-serve
+                    - seldon
+                    - bentoml
+                    - custom
+                    type: string
+                  predictionValidation:
+                    description: PredictionValidation specifies prediction consistency
+                      validation configuration
+                    properties:
+                      enabled:
+                        default: true
+                        description: Enabled specifies whether prediction validation
+                          is enabled
+                        type: boolean
+                      expectedOutput:
+                        description: ExpectedOutput specifies the expected prediction
+                          output
+                        type: string
+                      testData:
+                        description: TestData specifies the test input data for prediction
+                          validation
+                        type: string
+                      tolerance:
+                        default: "0.01"
+                        description: Tolerance specifies the tolerance for floating-point
+                          prediction comparisons
+                        pattern: ^[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?$
+                        type: string
+                    type: object
+                  targetModels:
+                    description: TargetModels specifies the list of model names to
+                      validate against
+                    items:
+                      type: string
+                    type: array
+                  timeout:
+                    default: 5m
+                    description: Timeout specifies the maximum time for model validation
+                    pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                    type: string
+                type: object
+              notebook:
+                description: Notebook specifies the notebook to validate
+                properties:
+                  git:
+                    description: Git specifies the Git repository containing the notebook
+                    properties:
+                      credentialsSecret:
+                        description: CredentialsSecret is the name of the Kubernetes
+                          Secret containing Git credentials
+                        type: string
+                      ref:
+                        description: Ref is the Git reference (branch, tag, or commit
+                          SHA)
+                        type: string
+                      url:
+                        description: URL is the Git repository URL (supports https://,
+                          git://, ssh://, and git@host:path formats)
+                        pattern: ^((https?|git|ssh)://|git@).*$
+                        type: string
+                    required:
+                    - ref
+                    - url
+                    type: object
+                  path:
+                    description: Path is the path to the notebook file within the
+                      repository
+                    pattern: ^.*\.ipynb$
+                    type: string
+                required:
+                - git
+                - path
+                type: object
+              podConfig:
+                description: PodConfig specifies the pod configuration for validation
+                  execution
+                properties:
+                  buildConfig:
+                    description: |-
+                      BuildConfig specifies optional container image build configuration
+                      When specified, the operator will build a custom image before validation
+                    properties:
+                      autoGenerateRequirements:
+                        default: true
+                        description: |-
+                          AutoGenerateRequirements specifies whether to auto-detect and use requirements.txt
+                          ADR-038: Enable automatic detection with fallback chain
+                          When true, operator searches for requirements.txt in notebook dir → tier dir → repo root
+                          When false, only uses explicitly specified RequirementsFile or Dockerfile
+                        type: boolean
+                      baseImage:
+                        default: quay.io/jupyter/minimal-notebook:latest
+                        description: BaseImage specifies the base image for the build
+                        type: string
+                      dockerfile:
+                        description: |-
+                          Dockerfile specifies the path to a custom Dockerfile in the Git repository
+                          ADR-031: Support custom Dockerfile for advanced build scenarios
+                          If specified, this takes precedence over BaseImage (Dockerfile will be used as-is)
+                          If not specified, a Dockerfile will be auto-generated from BaseImage
+                        pattern: ^[a-zA-Z0-9._/-]+$
+                        type: string
+                      enabled:
+                        default: false
+                        description: Enabled specifies whether to build a custom image
+                        type: boolean
+                      fallbackStrategy:
+                        default: warn
+                        description: FallbackStrategy specifies what to do when requirements.txt
+                          is missing
+                        enum:
+                        - warn
+                        - fail
+                        - auto
+                        type: string
+                      preferDockerfile:
+                        default: false
+                        description: |-
+                          PreferDockerfile specifies whether to prefer Dockerfile over requirements.txt
+                          ADR-038: When both requirements.txt and Dockerfile exist, this determines priority
+                          If false (default), uses requirements.txt to generate Dockerfile
+                          If true, uses existing Dockerfile and ignores requirements.txt
+                        type: boolean
+                      requirementsFile:
+                        description: |-
+                          RequirementsFile specifies explicit path to requirements.txt in the Git repository
+                          If specified, this path is used directly without fallback chain
+                          Example: "notebooks/tier2/requirements.txt"
+                        type: string
+                      requirementsSources:
+                        description: |-
+                          RequirementsSources specifies custom fallback chain for requirements.txt detection
+                          ADR-038: Advanced use case for complex repository structures
+                          If not specified, uses default chain: notebook-dir → tier-dir → repo-root
+                          Example: ["notebooks/tier2/requirements.txt", "notebooks/requirements.txt", "requirements.txt"]
+                        items:
+                          type: string
+                        type: array
+                      strategy:
+                        default: s2i
+                        description: Strategy specifies the build strategy to use
+                        enum:
+                        - s2i
+                        - tekton
+                        - kaniko
+                        - shipwright
+                        - custom
+                        type: string
+                      strategyConfig:
+                        additionalProperties:
+                          type: string
+                        description: StrategyConfig contains strategy-specific configuration
+                        type: object
+                      timeout:
+                        default: 15m
+                        description: Timeout specifies the maximum time to wait for
+                          build completion
+                        type: string
+                    type: object
+                  containerImage:
+                    description: ContainerImage is the container image to use for
+                      validation
+                    type: string
+                  credentials:
+                    description: |-
+                      Credentials is a simplified way to specify secrets for credential injection
+                      This is syntactic sugar that automatically converts to envFrom with secretRef
+                      Example: credentials: ["aws-credentials", "database-credentials"]
+                      This is equivalent to:
+                        envFrom:
+                          - secretRef: {name: "aws-credentials"}
+                          - secretRef: {name: "database-credentials"}
+                    items:
+                      type: string
+                    type: array
+                  env:
+                    description: Env specifies environment variables for the validation
+                      pod
+                    items:
+                      description: EnvVar represents an environment variable
+                      properties:
+                        name:
+                          description: Name is the environment variable name
+                          type: string
+                        value:
+                          description: Value is the environment variable value
+                          type: string
+                        valueFrom:
+                          description: ValueFrom specifies a source for the environment
+                            variable value
+                          properties:
+                            configMapKeyRef:
+                              description: ConfigMapKeyRef selects a key from a ConfigMap
+                              properties:
+                                key:
+                                  description: Key is the key in the ConfigMap
+                                  type: string
+                                name:
+                                  description: Name is the name of the ConfigMap
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            secretKeyRef:
+                              description: SecretKeyRef selects a key from a Secret
+                              properties:
+                                key:
+                                  description: Key is the key in the Secret
+                                  type: string
+                                name:
+                                  description: Name is the name of the Secret
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    description: EnvFrom specifies sources to populate environment
+                      variables in the validation pod
+                    items:
+                      description: EnvFromSource represents a source to populate environment
+                        variables
+                      properties:
+                        configMapRef:
+                          description: ConfigMapRef references a ConfigMap to populate
+                            environment variables
+                          properties:
+                            name:
+                              description: Name is the name of the ConfigMap
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        secretRef:
+                          description: SecretRef references a Secret to populate environment
+                            variables
+                          properties:
+                            name:
+                              description: Name is the name of the Secret
+                              type: string
+                          required:
+                          - name
+                          type: object
+                      type: object
+                    type: array
+                  resources:
+                    description: Resources specifies the compute resources for the
+                      validation pod
+                    properties:
+                      limits:
+                        additionalProperties:
+                          type: string
+                        description: Limits describes the maximum amount of compute
+                          resources allowed
+                        type: object
+                      requests:
+                        additionalProperties:
+                          type: string
+                        description: Requests describes the minimum amount of compute
+                          resources required
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    default: default
+                    description: |-
+                      ServiceAccountName is the name of the ServiceAccount to use for the validation pod
+                      Defaults to "default" which exists in all namespaces
+                      The mutating webhook will inject this default if not specified
+                    type: string
+                required:
+                - containerImage
+                type: object
+              timeout:
+                default: 30m
+                description: Timeout specifies the maximum execution time for the
+                  validation job
+                pattern: ^([0-9]+(\.[0-9]+)?(ms|s|m|h))+$
+                type: string
+            required:
+            - notebook
+            - podConfig
+            type: object
+          status:
+            description: NotebookValidationJobStatus defines the observed state of
+              NotebookValidationJob
+            properties:
+              buildStatus:
+                description: 'BuildStatus contains the build status (Phase 4.5: S2I
+                  Build Integration)'
+                properties:
+                  availableImages:
+                    description: AvailableImages lists available OpenShift AI ImageStreams
+                      (if installed)
+                    items:
+                      description: AvailableImageInfo represents an available OpenShift
+                        AI ImageStream
+                      properties:
+                        description:
+                          description: Description describes the image
+                          type: string
+                        displayName:
+                          description: DisplayName is the human-readable name
+                          type: string
+                        imageRef:
+                          description: ImageRef is the full image reference
+                          type: string
+                        name:
+                          description: Name is the ImageStream name
+                          type: string
+                        s2iEnabled:
+                          description: S2IEnabled indicates if this is an S2I builder
+                            image
+                          type: boolean
+                        tags:
+                          description: Tags lists available tags
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - description
+                      - displayName
+                      - imageRef
+                      - name
+                      - s2iEnabled
+                      type: object
+                    type: array
+                  buildName:
+                    description: BuildName is the name of the build resource
+                    type: string
+                  completionTime:
+                    description: CompletionTime is when the build completed
+                    format: date-time
+                    type: string
+                  duration:
+                    description: Duration is the build duration in human-readable
+                      format (e.g., "5m30s")
+                    type: string
+                  imageReference:
+                    description: ImageReference is the reference to the built image
+                    type: string
+                  message:
+                    description: Message provides a human-readable summary of the
+                      build status
+                    type: string
+                  phase:
+                    description: Phase represents the current phase of the build
+                    enum:
+                    - Pending
+                    - Running
+                    - Complete
+                    - Failed
+                    type: string
+                  recommendedImage:
+                    description: RecommendedImage is the recommended image for S2I
+                      builds
+                    type: string
+                  startTime:
+                    description: StartTime is when the build started
+                    format: date-time
+                    type: string
+                  strategy:
+                    description: Strategy is the build strategy used (s2i, tekton,
+                      etc.)
+                    type: string
+                type: object
+              comparisonResult:
+                description: ComparisonResult contains the golden notebook comparison
+                  result
+                properties:
+                  diffs:
+                    description: Diffs contains detailed diff information for mismatched
+                      cells
+                    items:
+                      description: CellDiff represents a difference between executed
+                        and golden notebook cells
+                      properties:
+                        actual:
+                          description: Actual is the actual output from executed notebook
+                            (truncated if too long)
+                          type: string
+                        cellIndex:
+                          description: CellIndex is the index of the cell (0-based)
+                          minimum: 0
+                          type: integer
+                        cellType:
+                          description: CellType is the type of cell (code, markdown)
+                          enum:
+                          - code
+                          - markdown
+                          type: string
+                        diff:
+                          description: Diff is the unified diff format (truncated
+                            if too long)
+                          type: string
+                        diffType:
+                          description: DiffType describes the type of difference
+                          enum:
+                          - output_mismatch
+                          - execution_error
+                          - missing_cell
+                          - extra_cell
+                          type: string
+                        expected:
+                          description: Expected is the expected output from golden
+                            notebook (truncated if too long)
+                          type: string
+                        severity:
+                          description: Severity indicates the importance of the difference
+                          enum:
+                          - minor
+                          - major
+                          - critical
+                          type: string
+                      required:
+                      - cellIndex
+                      - cellType
+                      - diffType
+                      - severity
+                      type: object
+                    type: array
+                  matchedCells:
+                    description: MatchedCells is the number of cells that matched
+                    minimum: 0
+                    type: integer
+                  mismatchedCells:
+                    description: MismatchedCells is the number of cells that did not
+                      match
+                    minimum: 0
+                    type: integer
+                  result:
+                    description: Result is the overall comparison result (matched,
+                      failed, skipped)
+                    enum:
+                    - matched
+                    - failed
+                    - skipped
+                    type: string
+                  strategy:
+                    description: Strategy used for comparison (exact, normalized,
+                      fuzzy, semantic)
+                    enum:
+                    - exact
+                    - normalized
+                    - fuzzy
+                    - semantic
+                    type: string
+                  totalCells:
+                    description: TotalCells is the total number of cells compared
+                    minimum: 0
+                    type: integer
+                required:
+                - matchedCells
+                - mismatchedCells
+                - result
+                - strategy
+                - totalCells
+                type: object
+              completionTime:
+                description: CompletionTime is when the validation completed
+                format: date-time
+                type: string
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the job's state
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastRetryTime:
+                description: LastRetryTime is when the last retry occurred
+                format: date-time
+                type: string
+              message:
+                description: Message provides a human-readable summary
+                type: string
+              modelValidationResult:
+                description: ModelValidationResult contains the model validation result
+                properties:
+                  cleanEnvironmentCheck:
+                    description: CleanEnvironmentCheck contains Phase 1 validation
+                      results
+                    properties:
+                      crdsInstalled:
+                        description: CRDsInstalled lists the detected CRDs
+                        items:
+                          type: string
+                        type: array
+                      message:
+                        description: Message provides a human-readable summary
+                        type: string
+                      networkConnectivity:
+                        description: NetworkConnectivity indicates if network connectivity
+                          to model endpoints is available
+                        type: boolean
+                      platformAvailable:
+                        description: PlatformAvailable indicates if the model serving
+                          platform is available
+                        type: boolean
+                      rbacPermissions:
+                        description: RBACPermissions indicates if required RBAC permissions
+                          are present
+                        type: boolean
+                      requiredLibraries:
+                        description: RequiredLibraries lists the detected required
+                          libraries
+                        items:
+                          type: string
+                        type: array
+                      success:
+                        description: Success indicates Phase 1 validation success
+                        type: boolean
+                    required:
+                    - networkConnectivity
+                    - platformAvailable
+                    - rbacPermissions
+                    - success
+                    type: object
+                  existingEnvironmentCheck:
+                    description: ExistingEnvironmentCheck contains Phase 2 validation
+                      results
+                    properties:
+                      message:
+                        description: Message provides a human-readable summary
+                        type: string
+                      modelsChecked:
+                        description: ModelsChecked lists the models that were validated
+                        items:
+                          description: ModelCheckResult represents validation results
+                            for a single model
+                          properties:
+                            available:
+                              description: Available indicates if the model is available
+                              type: boolean
+                            healthy:
+                              description: Healthy indicates if the model passed health
+                                checks
+                              type: boolean
+                            message:
+                              description: Message provides a human-readable summary
+                              type: string
+                            modelName:
+                              description: ModelName is the name of the model
+                              type: string
+                            resourceStatus:
+                              description: ResourceStatus contains resource utilization
+                                information
+                              properties:
+                                cpuUsage:
+                                  description: CPUUsage is the CPU usage percentage
+                                  type: string
+                                gpuUsage:
+                                  description: GPUUsage is the GPU usage percentage
+                                  type: string
+                                memoryUsage:
+                                  description: MemoryUsage is the memory usage
+                                  type: string
+                              type: object
+                            version:
+                              description: Version is the detected model version
+                              type: string
+                          required:
+                          - available
+                          - healthy
+                          - modelName
+                          type: object
+                        type: array
+                      predictionValidation:
+                        description: PredictionValidation contains prediction consistency
+                          validation results
+                        properties:
+                          actualOutput:
+                            description: ActualOutput is the actual prediction output
+                            type: string
+                          difference:
+                            description: Difference is the calculated difference between
+                              actual and expected
+                            type: string
+                          expectedOutput:
+                            description: ExpectedOutput is the expected prediction
+                              output
+                            type: string
+                          message:
+                            description: Message provides a human-readable summary
+                            type: string
+                          success:
+                            description: Success indicates if predictions matched
+                              expected output
+                            type: boolean
+                        required:
+                        - success
+                        type: object
+                      success:
+                        description: Success indicates Phase 2 validation success
+                        type: boolean
+                    required:
+                    - success
+                    type: object
+                  message:
+                    description: Message provides a human-readable summary
+                    type: string
+                  phase:
+                    description: Phase indicates which validation phase was executed
+                    enum:
+                    - clean
+                    - existing
+                    - both
+                    type: string
+                  platform:
+                    description: Platform indicates the detected or specified platform
+                    type: string
+                  platformDetected:
+                    description: PlatformDetected indicates whether the platform was
+                      auto-detected
+                    type: boolean
+                  success:
+                    description: Success indicates overall model validation success
+                    type: boolean
+                required:
+                - phase
+                - platform
+                - platformDetected
+                - success
+                type: object
+              phase:
+                description: |-
+                  Phase represents the current phase of the validation job
+                  State machine: Initializing → Building → BuildComplete → ValidationRunning → Succeeded/Failed
+                enum:
+                - Initializing
+                - Building
+                - BuildComplete
+                - ValidationRunning
+                - Succeeded
+                - Failed
+                - Pending
+                - Running
+                type: string
+              results:
+                description: Results contains cell-by-cell execution results
+                items:
+                  description: CellResult represents the execution result of a single
+                    notebook cell
+                  properties:
+                    cellIndex:
+                      description: CellIndex is the zero-based index of the cell
+                      minimum: 0
+                      type: integer
+                    errorMessage:
+                      description: ErrorMessage is the error message if the cell failed
+                      type: string
+                    executionTime:
+                      description: ExecutionTime is how long the cell took to execute
+                      type: string
+                    output:
+                      description: Output is the cell's stdout/stderr (truncated if
+                        too long)
+                      type: string
+                    status:
+                      description: Status is the execution status of the cell
+                      enum:
+                      - Success
+                      - Failure
+                      - Skipped
+                      type: string
+                  required:
+                  - cellIndex
+                  - status
+                  type: object
+                type: array
+              retryCount:
+                description: RetryCount tracks the number of retry attempts
+                type: integer
+              startTime:
+                description: StartTime is when the validation started
+                format: date-time
+                type: string
+              validationPodName:
+                description: ValidationPodName is the name of the pod executing the
+                  validation
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/jupyter-notebook-validator-operator/1.0.0-ocp4.19/metadata/annotations.yaml
+++ b/operators/jupyter-notebook-validator-operator/1.0.0-ocp4.19/metadata/annotations.yaml
@@ -1,0 +1,17 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: jupyter-notebook-validator-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.37.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # OpenShift version compatibility (4.18 - 4.19)
+  com.redhat.openshift.versions: "v4.18-v4.19"
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/


### PR DESCRIPTION
New release for OpenShift 4.19 compatibility:
- Full support for OpenShift 4.18-4.19
- Kubernetes 1.32 compatibility
- Updated operator logo
- All E2E tests pass on OpenShift 4.19.17

Thanks submitting your Operator. Please check below list before you create your Pull Request.

### Updates to existing Operators

  * [x] Did you create a `ci.yaml` file according to the update instructions?
  * [x] Is your new CSV pointing to the previous version with the `replaces` property if you chose `replaces-mode` via the `updateGraph` property in `ci.yaml`?
  * [x] Is your new CSV referenced in the appropriate channel defined in the `annotations.yaml`?
  * [x] Have you tested an update to your Operator when deployed via OLM?
  * [x] Is your submission signed?

  ### Your submission should not

  * [x] Modify more than one operator
  * [x] Modify an Operator you don't own
  * [x] Rename an operator
  * [x] Modify any files outside the operator folder
  * [x] Contain more than one commit

  ---

  ## Update Details

  **Operator:** jupyter-notebook-validator-operator
  **New Version:** 1.0.0-ocp4.19
  **Replaces:** 1.0.2
  **OpenShift Compatibility:** v4.18-v4.19
  **Image:** `quay.io/takinosh/jupyter-notebook-validator-operator:v1.0.0-ocp4.19`

  ## What's Changed

  - Added OpenShift 4.19 (Kubernetes 1.32) support
  - Updated operator logo
  - Maintains backward compatibility with OpenShift 4.18

  ## Testing

  All tests passed on OpenShift 4.19.17:
  - CI workflow ✓
  - Build workflow ✓
  - Unit tests ✓
  - E2E tests (Tier 1-4) ✓