### PR TITLE
operator [N] logicmonitor-openshift-operator (0.1.0)

### DIFF
--- a/operators/logicmonitor-openshift-operator/0.1.0/manifests/lm-credentials_v1_secret.yaml
+++ b/operators/logicmonitor-openshift-operator/0.1.0/manifests/lm-credentials_v1_secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: lm-credentials
+    app.kubernetes.io/part-of: logicmonitor-operator
+  name: lm-credentials
+stringData:
+  accessID: REPLACE_WITH_ACCESS_ID
+  accessKey: REPLACE_WITH_ACCESS_KEY
+  account: REPLACE_WITH_ACCOUNT
+type: Opaque

--- a/operators/logicmonitor-openshift-operator/0.1.0/manifests/logicmonitor-openshift-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/logicmonitor-openshift-operator/0.1.0/manifests/logicmonitor-openshift-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: logicmonitor-openshift-operator
+    control-plane: controller-manager
+  name: logicmonitor-openshift-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: logicmonitor-openshift-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/logicmonitor-openshift-operator/0.1.0/manifests/logicmonitor-openshift-operator-lmcontainer-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/logicmonitor-openshift-operator/0.1.0/manifests/logicmonitor-openshift-operator-lmcontainer-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: logicmonitor-openshift-operator
+  name: logicmonitor-openshift-operator-lmcontainer-admin-role
+rules:
+- apiGroups:
+  - monitoring.logicmonitor.com
+  resources:
+  - lmcontainers
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.logicmonitor.com
+  resources:
+  - lmcontainers/status
+  verbs:
+  - get

--- a/operators/logicmonitor-openshift-operator/0.1.0/manifests/logicmonitor-openshift-operator-lmcontainer-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/logicmonitor-openshift-operator/0.1.0/manifests/logicmonitor-openshift-operator-lmcontainer-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: logicmonitor-openshift-operator
+  name: logicmonitor-openshift-operator-lmcontainer-editor-role
+rules:
+- apiGroups:
+  - monitoring.logicmonitor.com
+  resources:
+  - lmcontainers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.logicmonitor.com
+  resources:
+  - lmcontainers/status
+  verbs:
+  - get

--- a/operators/logicmonitor-openshift-operator/0.1.0/manifests/logicmonitor-openshift-operator-lmcontainer-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/logicmonitor-openshift-operator/0.1.0/manifests/logicmonitor-openshift-operator-lmcontainer-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: logicmonitor-openshift-operator
+  name: logicmonitor-openshift-operator-lmcontainer-viewer-role
+rules:
+- apiGroups:
+  - monitoring.logicmonitor.com
+  resources:
+  - lmcontainers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - monitoring.logicmonitor.com
+  resources:
+  - lmcontainers/status
+  verbs:
+  - get

--- a/operators/logicmonitor-openshift-operator/0.1.0/manifests/logicmonitor-openshift-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/logicmonitor-openshift-operator/0.1.0/manifests/logicmonitor-openshift-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: logicmonitor-openshift-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/logicmonitor-openshift-operator/0.1.0/manifests/logicmonitor-openshift-operator.clusterserviceversion.yaml
+++ b/operators/logicmonitor-openshift-operator/0.1.0/manifests/logicmonitor-openshift-operator.clusterserviceversion.yaml
@@ -1,0 +1,627 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "monitoring.logicmonitor.com/v1alpha1",
+          "kind": "LMContainer",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "lm-monitoring-full",
+              "app.kubernetes.io/name": "lmcontainer",
+              "app.kubernetes.io/part-of": "logicmonitor-operator",
+              "environment": "production"
+            },
+            "name": "lm-monitoring-full",
+            "namespace": "logicmonitor"
+          },
+          "spec": {
+            "argus": {
+              "clusterName": "prod-openshift-east",
+              "clusterTreeParentID": 1,
+              "deleteDevices": true,
+              "disableAlerting": false,
+              "enabled": true,
+              "loglevel": "info",
+              "resourceContainerID": 1
+            },
+            "collector": {
+              "escalationChainID": 0,
+              "groupID": 0,
+              "replicas": 2,
+              "size": "medium",
+              "useEA": false
+            },
+            "collectorset-controller": {
+              "enabled": true
+            },
+            "global": {
+              "companyDomain": "",
+              "image": {
+                "pullPolicy": "Always",
+                "registry": ""
+              },
+              "userDefinedSecret": "lm-credentials"
+            },
+            "kube-state-metrics": {
+              "collectors": [
+                "daemonsets",
+                "replicasets",
+                "statefulsets",
+                "persistentvolumes",
+                "persistentvolumeclaims",
+                "endpoints",
+                "cronjobs",
+                "jobs",
+                "pods",
+                "nodes",
+                "deployments",
+                "services",
+                "poddisruptionbudgets"
+              ],
+              "enabled": true,
+              "replicas": 1,
+              "selfMonitor": {
+                "enabled": true,
+                "telemetryPort": 8081
+              }
+            },
+            "lm-logs": {
+              "enabled": false
+            },
+            "lmotel": {
+              "enabled": false
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.logicmonitor.com/v1alpha1",
+          "kind": "LMContainer",
+          "metadata": {
+            "name": "lm-monitoring-minimal",
+            "namespace": "logicmonitor"
+          },
+          "spec": {
+            "argus": {
+              "clusterName": "my-cluster"
+            },
+            "global": {
+              "userDefinedSecret": "lm-credentials"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.logicmonitor.com/v1alpha1",
+          "kind": "LMContainer",
+          "metadata": {
+            "annotations": {
+              "openshift.io/description": "LogicMonitor container monitoring for OpenShift"
+            },
+            "labels": {
+              "app.kubernetes.io/instance": "lm-monitoring-openshift",
+              "app.kubernetes.io/name": "lmcontainer",
+              "app.kubernetes.io/part-of": "logicmonitor-operator"
+            },
+            "name": "lm-monitoring-openshift",
+            "namespace": "logicmonitor"
+          },
+          "spec": {
+            "argus": {
+              "clusterName": "openshift-prod",
+              "clusterTreeParentID": 1,
+              "deleteDevices": true,
+              "enabled": true,
+              "loglevel": "info"
+            },
+            "collector": {
+              "replicas": 2,
+              "size": "medium"
+            },
+            "collectorset-controller": {
+              "enabled": true
+            },
+            "global": {
+              "userDefinedSecret": "lm-credentials"
+            },
+            "kube-state-metrics": {
+              "collectors": [
+                "daemonsets",
+                "replicasets",
+                "statefulsets",
+                "persistentvolumes",
+                "persistentvolumeclaims",
+                "endpoints",
+                "cronjobs",
+                "jobs",
+                "pods",
+                "nodes",
+                "deployments",
+                "services",
+                "poddisruptionbudgets"
+              ],
+              "enabled": true,
+              "replicas": 1
+            },
+            "lm-logs": {
+              "enabled": false
+            },
+            "lmotel": {
+              "enabled": false
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.logicmonitor.com/v1alpha1",
+          "kind": "LMContainer",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "lmcontainer-sample",
+              "app.kubernetes.io/name": "lmcontainer",
+              "app.kubernetes.io/part-of": "logicmonitor-operator"
+            },
+            "name": "lmcontainer-sample",
+            "namespace": "logicmonitor"
+          },
+          "spec": {
+            "argus": {
+              "clusterName": "",
+              "clusterTreeParentID": 1,
+              "enabled": true
+            },
+            "collectorset-controller": {
+              "enabled": true
+            },
+            "global": {
+              "accessID": "",
+              "accessKey": "",
+              "account": "",
+              "collectorsetServiceNameSuffix": "lm-container-collectorset-controller",
+              "companyDomain": "",
+              "image": {
+                "pullPolicy": "",
+                "registry": ""
+              },
+              "userDefinedSecret": ""
+            },
+            "kube-state-metrics": {
+              "collectors": [
+                "daemonsets",
+                "replicasets",
+                "statefulsets",
+                "persistentvolumes",
+                "persistentvolumeclaims",
+                "endpoints",
+                "cronjobs",
+                "jobs",
+                "pods",
+                "nodes",
+                "deployments",
+                "services",
+                "poddisruptionbudgets"
+              ],
+              "enabled": true,
+              "replicas": 1,
+              "selfMonitor": {
+                "enabled": true,
+                "telemetryPort": 8081
+              }
+            },
+            "lm-logs": {
+              "enabled": false
+            },
+            "lmotel": {
+              "enabled": false
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    createdAt: "2025-12-11T01:14:04Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.42.0
+    operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
+    categories: Monitoring
+    containerImage: ghcr.io/ryanmat/logicmonitor-openshift-operator:0.1.0
+    repository: https://github.com/ryanmat/logicmonitor-openshift-operator
+    support: LogicMonitor
+  name: logicmonitor-openshift-operator.v0.1.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: LMContainer deploys LogicMonitor container monitoring components including Argus, Collectorset Controller, and Kube State Metrics to monitor Kubernetes resources.
+        displayName: LM Container
+        kind: LMContainer
+        name: lmcontainers.monitoring.logicmonitor.com
+        version: v1alpha1
+  description: |
+    ## LogicMonitor Container Monitoring Operator
+
+    **Note**: This is a community-maintained operator. For official LogicMonitor
+    support, please contact LogicMonitor directly. Issues and contributions are
+    welcome on [GitHub](https://github.com/ryanmat/logicmonitor-openshift-operator).
+
+    The LogicMonitor Operator provides a native OpenShift experience for deploying
+    and managing LogicMonitor's container monitoring solution.
+
+    ### Features
+
+    - **Automatic Discovery**: Automatically discovers and monitors pods, nodes,
+      services, deployments, and other Kubernetes resources
+    - **Pre-configured Alerting**: Ships with pre-configured alert thresholds
+      based on best practices
+    - **Long-term Data Retention**: 2-year data retention for capacity planning
+      and trend analysis
+    - **Unified Monitoring**: Integrates with existing LogicMonitor infrastructure
+      monitoring for end-to-end visibility
+
+    ### Components Deployed
+
+    - **Argus**: Kubernetes resource discovery and monitoring agent
+    - **Collectorset Controller**: Manages LogicMonitor collector pod lifecycle
+    - **Kube State Metrics**: Exports Kubernetes object metrics
+
+    ### Prerequisites
+
+    - LogicMonitor account with Container Monitoring license
+    - API credentials with appropriate permissions
+    - OpenShift 4.12 or later
+
+    ### Getting Started
+
+    1. Create a Secret with your LogicMonitor credentials:
+       ```
+       oc create secret generic lm-credentials \
+         --namespace logicmonitor \
+         --from-literal=account=YOUR_ACCOUNT \
+         --from-literal=accessID=YOUR_ACCESS_ID \
+         --from-literal=accessKey=YOUR_ACCESS_KEY
+       ```
+
+    2. Create an LMContainer resource:
+       ```yaml
+       apiVersion: monitoring.logicmonitor.com/v1alpha1
+       kind: LMContainer
+       metadata:
+         name: lm-monitoring
+         namespace: logicmonitor
+       spec:
+         global:
+           userDefinedSecret: "lm-credentials"
+         argus:
+           clusterName: "my-openshift-cluster"
+       ```
+
+    ### Documentation
+
+    For detailed documentation, visit:
+    https://www.logicmonitor.com/support/lm-container
+  displayName: LogicMonitor Container Monitoring
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAACXBIWXMAAAsTAAALEwEAmpwYAAAKT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdpr+h0teletkEWRLdJn6n25/ppQqu+b1I/pHPpt5UlPxLTJRaZtxz+u+avZsaMnOZm2LmlmWGdj3lnV3bjvs+/7qedmzfu+BT3b/c3HG85y19/dH0cv9p5zfNPGnO7/7H7v76/37v7h/3L/1/Nv9/83P73/u3+a/7//X/5/B/8J/sXz8f95/3P/l/63/t/7//u/+3/3f/d/93/3f/d/93/3f/d/93/3f/d/93/3f/d/8QACAAJABUAHgAlAC8ANwBBAE0AWQBcAAP/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCABgAGADASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+iiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigD//2Q==
+      mediatype: image/jpeg
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - security.openshift.io
+              resourceNames:
+                - logicmonitor-scc
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - use
+            - apiGroups:
+                - ""
+              resources:
+                - namespaces
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - monitoring.logicmonitor.com
+              resources:
+                - lmcontainers
+                - lmcontainers/status
+                - lmcontainers/finalizers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - pods/log
+                - services
+                - services/finalizers
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                - serviceaccounts
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+                - cronjobs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - roles
+                - rolebindings
+                - clusterroles
+                - clusterrolebindings
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+                - bind
+                - escalate
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - ingresses
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - security.openshift.io
+              resources:
+                - securitycontextconstraints
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+                - use
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+                - podmonitors
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - discovery.k8s.io
+              resources:
+                - endpointslices
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - autoscaling
+              resources:
+                - horizontalpodautoscalers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+          serviceAccountName: logicmonitor-openshift-operator-controller-manager
+      deployments:
+        - label:
+            app.kubernetes.io/managed-by: kustomize
+            app.kubernetes.io/name: logicmonitor-openshift-operator
+            control-plane: controller-manager
+          name: logicmonitor-openshift-operator-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: logicmonitor-openshift-operator
+                control-plane: controller-manager
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  app.kubernetes.io/name: logicmonitor-openshift-operator
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - args:
+                      - --metrics-require-rbac
+                      - --metrics-secure
+                      - --metrics-bind-address=:8443
+                      - --leader-elect
+                      - --leader-election-id=logicmonitor-openshift-operator
+                      - --health-probe-bind-address=:8081
+                    image: ghcr.io/ryanmat/logicmonitor-openshift-operator:0.1.0
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: logicmonitor-openshift-operator-controller-manager
+                terminationGracePeriodSeconds: 10
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: logicmonitor-openshift-operator-controller-manager
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - monitoring
+    - observability
+    - kubernetes
+    - openshift
+    - logicmonitor
+    - metrics
+    - apm
+  links:
+    - name: Documentation
+      url: https://www.logicmonitor.com/support/lm-container
+    - name: LogicMonitor
+      url: https://www.logicmonitor.com
+  maintainers:
+    - email: support@logicmonitor.com
+      name: LogicMonitor
+  maturity: alpha
+  provider:
+    name: LogicMonitor
+    url: https://www.logicmonitor.com
+  version: 0.1.0
+  minKubeVersion: 1.23.0

--- a/operators/logicmonitor-openshift-operator/0.1.0/manifests/monitoring.logicmonitor.com_lmcontainers.yaml
+++ b/operators/logicmonitor-openshift-operator/0.1.0/manifests/monitoring.logicmonitor.com_lmcontainers.yaml
@@ -1,0 +1,302 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: logicmonitor-operator
+    app.kubernetes.io/part-of: logicmonitor-operator
+  name: lmcontainers.monitoring.logicmonitor.com
+spec:
+  group: monitoring.logicmonitor.com
+  names:
+    kind: LMContainer
+    listKind: LMContainerList
+    plural: lmcontainers
+    shortNames:
+    - lmc
+    singular: lmcontainer
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: LogicMonitor cluster name
+      jsonPath: .spec.argus.clusterName
+      name: Cluster
+      type: string
+    - description: Deployment phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Number of collectors
+      jsonPath: .status.collectorCount
+      name: Collectors
+      type: integer
+    - description: Argus ready status
+      jsonPath: .status.argusReady
+      name: Argus
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LMContainer deploys LogicMonitor container monitoring to a Kubernetes
+          cluster.
+        properties:
+          apiVersion:
+            description: APIVersion defines the versioned schema of this representation
+              of an object.
+            type: string
+          kind:
+            description: Kind is a string value representing the REST resource this
+              object represents.
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of LMContainer deployment.
+            properties:
+              argus:
+                description: Argus configuration for Kubernetes resource discovery.
+                properties:
+                  clusterName:
+                    description: |
+                      Unique name for this cluster in LogicMonitor.
+                      Appears as "Kubernetes Cluster: <clusterName>" in the portal.
+                      WARNING: Do not change after initial deployment.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$
+                    type: string
+                  clusterTreeParentID:
+                    default: 1
+                    description: |
+                      Parent resource group ID in LogicMonitor where the cluster tree is created.
+                      The resource group must exist before deployment.
+                    minimum: 1
+                    type: integer
+                  enabled:
+                    default: true
+                    description: Enable Argus deployment.
+                    type: boolean
+                  resourceContainerID:
+                    description: Resource container group ID in LogicMonitor.
+                    minimum: 1
+                    type: integer
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              collector:
+                description: Collector configuration.
+                properties:
+                  escalationChainID:
+                    description: Alert escalation chain ID for collector alerts.
+                    minimum: 0
+                    type: integer
+                  groupID:
+                    description: Collector group ID in LogicMonitor. Auto-created
+                      if not specified.
+                    minimum: 0
+                    type: integer
+                  replicas:
+                    default: 1
+                    description: Number of collector pod replicas.
+                    maximum: 10
+                    minimum: 1
+                    type: integer
+                  size:
+                    default: small
+                    description: Collector size determining resource allocation.
+                    enum:
+                    - nano
+                    - small
+                    - medium
+                    - large
+                    type: string
+                  useEA:
+                    default: false
+                    description: Use Early Access collector version.
+                    type: boolean
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              collectorset-controller:
+                description: Collectorset Controller configuration for collector pod
+                  management.
+                properties:
+                  enabled:
+                    default: true
+                    description: Enable Collectorset Controller deployment.
+                    type: boolean
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              global:
+                description: Global configuration shared across all components.
+                properties:
+                  accessID:
+                    description: |
+                      LogicMonitor API access ID. Generate from Settings > Users and Roles > API Tokens.
+                      Ignored if userDefinedSecret is set.
+                    type: string
+                  accessKey:
+                    description: |
+                      LogicMonitor API access key.
+                      Ignored if userDefinedSecret is set.
+                    type: string
+                  account:
+                    description: |
+                      LogicMonitor account name. This is the subdomain from your portal URL.
+                      Example: If your URL is "acme.logicmonitor.com", use "acme".
+                      Ignored if userDefinedSecret is set.
+                    maxLength: 64
+                    minLength: 1
+                    pattern: ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$
+                    type: string
+                  companyDomain:
+                    description: |
+                      LogicMonitor domain. Leave empty for standard logicmonitor.com.
+                      Use "lmgov.us" for government cloud.
+                    enum:
+                    - ""
+                    - logicmonitor.com
+                    - lmgov.us
+                    type: string
+                  image:
+                    description: Global image configuration overrides.
+                    properties:
+                      pullPolicy:
+                        description: Override image pull policy for all components.
+                        enum:
+                        - ""
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      registry:
+                        description: Override image registry for all components.
+                        type: string
+                    type: object
+                  userDefinedSecret:
+                    description: |
+                      Name of a Secret containing LogicMonitor credentials.
+                      The Secret must contain keys: accessID, accessKey, account.
+                      When set, inline credential fields are ignored.
+                    type: string
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              kube-state-metrics:
+                description: Kube State Metrics configuration.
+                properties:
+                  enabled:
+                    default: true
+                    description: Enable Kube State Metrics deployment.
+                    type: boolean
+                  replicas:
+                    default: 1
+                    description: Number of KSM pod replicas.
+                    maximum: 5
+                    minimum: 1
+                    type: integer
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              lm-logs:
+                description: LM Logs configuration for log forwarding.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enable LM Logs deployment.
+                    type: boolean
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              lmotel:
+                description: LMOTEL configuration for OpenTelemetry integration.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enable LMOTEL deployment.
+                    type: boolean
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of LMContainer.
+            properties:
+              argusReady:
+                description: Whether Argus is ready and registered with LogicMonitor.
+                type: boolean
+              collectorCount:
+                description: Number of running collector pods.
+                minimum: 0
+                type: integer
+              collectorsetControllerReady:
+                description: Whether Collectorset Controller is ready.
+                type: boolean
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the LMContainer state.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message for the condition.
+                      type: string
+                    reason:
+                      description: Machine-readable reason for the condition.
+                      type: string
+                    status:
+                      description: Status of the condition (True, False, Unknown).
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - type
+                  - status
+                  type: object
+                type: array
+              helmReleaseName:
+                description: Name of the managed Helm release.
+                type: string
+              helmReleaseStatus:
+                description: Status of the Helm release.
+                type: string
+              lastReconcileTime:
+                description: Last successful reconciliation time.
+                format: date-time
+                type: string
+              message:
+                description: Human-readable status message.
+                type: string
+              observedGeneration:
+                description: Last observed generation of the LMContainer resource.
+                format: int64
+                type: integer
+              phase:
+                description: Current phase of the LMContainer deployment.
+                enum:
+                - Pending
+                - Installing
+                - Running
+                - Failed
+                - Updating
+                - Deleting
+                type: string
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/logicmonitor-openshift-operator/0.1.0/metadata/annotations.yaml
+++ b/operators/logicmonitor-openshift-operator/0.1.0/metadata/annotations.yaml
@@ -1,0 +1,14 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: logicmonitor-openshift-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/


### PR DESCRIPTION
## New Operator Submission

**Operator Name:** logicmonitor-openshift-operator
**Version:** 0.1.0
**Category:** Monitoring

### Description

LogicMonitor OpenShift Operator provides a native OpenShift experience for deploying and managing LogicMonitor's container monitoring solution.

This Helm-based operator wraps the official `lm-container` Helm chart (v11.2.0) and integrates with OLM for seamless installation via OperatorHub.

### Features

- **Automatic Discovery**: Discovers and monitors pods, nodes, services, deployments, and other Kubernetes resources
- **Managed Collectors**: Collectorset Controller manages LogicMonitor collector pod lifecycle
- **Kube State Metrics**: Integrated KSM for Kubernetes object metrics
- **OpenShift Security**: Custom SecurityContextConstraint for OpenShift compliance
- **Flexible Monitoring**: Essentials and Advanced monitoring modes

### Tested Platforms

| Platform | Version | Status |
|----------|---------|--------|
| AWS ROSA | 4.14 | Verified |
| Azure ARO | 4.14 | Verified |

### Links

- **Repository**: https://github.com/ryanmat/logicmonitor-openshift-operator
- **Documentation**: https://www.logicmonitor.com/support/lm-container
- **Container Image**: ghcr.io/ryanmat/logicmonitor-openshift-operator:v0.1.0

### Checklist

- [x] Bundle validates with `operator-sdk bundle validate`
- [x] CSV has required metadata (categories, containerImage, repository, support)
- [x] CRD has descriptions and validation
- [x] Tested on real OpenShift clusters
- [x] Community-maintained disclaimer in description

### Note

This is a community-maintained operator. For official LogicMonitor support, please contact LogicMonitor directly.