### PR TITLE
operator [CI] tektoncd-operator

### DIFF
--- a/operators/tektoncd-operator/ci.yaml
+++ b/operators/tektoncd-operator/ci.yaml
@@ -2,6 +2,10 @@
 # Use `replaces-mode` or `semver-mode`. Once you switch to `semver-mode`, there is no easy way back.
 updateGraph: semver-mode
 reviewers:
+- anithapriyanatarajan
+- jkhelil
+- mbpavan
 - nikhil-thomas
-- vdemeester
+- savitaashture
 - sm43
+- vdemeester


### PR DESCRIPTION
## Summary
This PR adds four additional reviewers to the tektoncd-operator ci.yaml file, based on the current approvers list from the [tektoncd/operator OWNERS file](https://github.com/tektoncd/operator/blob/main/OWNERS).

## Changes
Added the following approvers as reviewers:
- anithapriyanatarajan
- jkhelil
- mbpavan
- savitaashture

## Rationale
These individuals are current approvers in the tektoncd/operator repository and should be able to review and approve operator updates in the community-operators repository.

## Related
- Upstream OWNERS file: https://github.com/tektoncd/operator/blob/main/OWNERS
- Documentation: https://k8s-operatorhub.github.io/community-operators/operator-ci-yaml/