### PR TITLE
adds Observablity category

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -12,6 +12,7 @@
       "Modernization & Migration",
       "Monitoring",
       "Networking",
+      "Observability",
       "OpenShift Optional",
       "Security",
       "Storage",


### PR DESCRIPTION
The Observability group added a new category, however this category doesn't seem to exist in this repo which is blocking https://github.com/k8s-operatorhub/community-operators/pull/7793