### PR TITLE
operator dapr-kubernetes-operator (0.0.13)

### DIFF
--- a/operators/dapr-kubernetes-operator/0.0.13/manifests/dapr-kubernetes-operator.clusterserviceversion.yaml
+++ b/operators/dapr-kubernetes-operator/0.0.13/manifests/dapr-kubernetes-operator.clusterserviceversion.yaml
@@ -1,0 +1,302 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.dapr.io/v1alpha1",
+          "kind": "DaprControlPlane",
+          "metadata": {
+            "name": "dapr-control-plane",
+            "namespace": "dapr-system"
+          },
+          "spec": {
+            "values": {}
+          }
+        },
+        {
+          "apiVersion": "operator.dapr.io/v1alpha1",
+          "kind": "DaprCruiseControl",
+          "metadata": {
+            "name": "dapr-cruise-control",
+            "namespace": "dapr-system"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "operator.dapr.io/v1alpha1",
+          "kind": "DaprInstance",
+          "metadata": {
+            "name": "dapr-instance",
+            "namespace": "dapr-system"
+          },
+          "spec": {
+            "values": {}
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Application Runtime
+    certified: "false"
+    containerImage: "docker.io/daprio/kubernetes-operator:0.0.13"
+    createdAt: "2026-03-31T00:00:00Z"
+    description: Dapr Control Plane Operator
+    operators.operatorframework.io/builder: operator-sdk-v1.41.1
+    operators.operatorframework.io/project_layout: unknown
+    repository: https://github.com/dapr/kubernetes-operator
+    support: contact@dapr.io
+  name: dapr-kubernetes-operator.v0.0.13
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: DaprControlPlane is the Schema for the Dapr ControlPlane API.
+        displayName: DaprControlPlane
+        kind: DaprControlPlane
+        name: daprcontrolplanes.operator.dapr.io
+        version: v1alpha1
+      - kind: DaprCruiseControl
+        name: daprcruiscontrols.operator.dapr.io
+        version: v1alpha1
+      - description: DaprInstance is the Schema for the Dapr Instance API.
+        displayName: DaprInstance
+        kind: DaprInstance
+        name: daprinstances.operator.dapr.io
+        version: v1alpha1
+  description: Dapr Control Plane Operator
+  displayName: Dapr Control Plane Operator
+  icon:
+    - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMzY3cHgiIGhlaWdodD0iMjcwcHgiIHZpZXdCb3g9IjAgMCAzNjcgMjcwIiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPCEtLSBHZW5lcmF0b3I6IFNrZXRjaCA1MS4zICg1NzU0NCkgLSBodHRwOi8vd3d3LmJvaGVtaWFuY29kaW5nLmNvbS9za2V0Y2ggLS0+CiAgICA8dGl0bGU+QXJ0Ym9hcmQ8L3RpdGxlPgogICAgPGRlc2M+Q3JlYXRlZCB3aXRoIFNrZXRjaC48L2Rlc2M+CiAgICA8ZGVmcz48L2RlZnM+CiAgICA8ZyBpZD0iQXJ0Ym9hcmQiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxwYXRoIGQ9Ik04OS43OTE3MTE5LDE5My41MDg3NjEgTDYyLjkwMDAzOTIsMTkzLjUwODc2MSBMNjIuOTAwMDM5MiwxODUuMDY0MTIgQzYwLjMzMTEwNjQsMTg4LjI4ODk1IDU3LjczNDg4MzUsMTkwLjYzOTIxNSA1NS4xMTEyOTI2LDE5Mi4xMTQ5ODUgQzUwLjUyMDAwODQsMTk0LjY4MzkxOCA0NS4zMDAyMzM5LDE5NS45NjgzNjUgMzkuNDUxODEyNCwxOTUuOTY4MzY1IEMyOS45OTU5NTM0LDE5NS45NjgzNjUgMjEuNTc4NzI1NCwxOTIuNzE2MjU0IDE0LjE5OTg3NTksMTg2LjIxMTkzNSBDNS4zOTk5MTQ2NCwxNzguNDUwNDc4IDEsMTY4LjE3NDkwMSAxLDE1NS4zODQ4OTUgQzEsMTQyLjM3NjI1NyA1LjUwOTIyOTI5LDEzMS45OTEzNjUgMTQuNTI3ODIzMSwxMjQuMjI5OTA5IEMyMS42ODgwNDAxLDExOC4wNTM1MzggMjkuOTEzOTY3NCwxMTQuOTY1NCAzOS4yMDU4NTIsMTE0Ljk2NTQgQzQ0LjYxNzAwODMsMTE0Ljk2NTQgNDkuNzAwMTM5NSwxMTYuMTEzMjAzIDU0LjQ1NTM5ODEsMTE4LjQwODg0NSBDNTcuMTg4MzA1MywxMTkuNzIwNjQxIDYwLjAwMzE1NzYsMTIxLjg3OTYwNSA2Mi45MDAwMzkyLDEyNC44ODU4MDMgTDYyLjkwMDAzOTIsNzAuMzY0NTc2NiBMODkuNzkxNzExOSw3MC4zNjQ1NzY2IEw4OS43OTE3MTE5LDE5My41MDg3NjEgWiBNNjMuNzE5OTA3MywxNTUuNDY2ODgyIEM2My43MTk5MDczLDE1MC42NTY5NjUgNjIuMDI1NTMwMiwxNDYuNTcxMzMgNTguNjM2NzI1MywxNDMuMjA5ODU1IEM1NS4yNDc5MjAzLDEzOS44NDgzNzkgNTEuMTQ4NjIxLDEzOC4xNjc2NjYgNDYuMzM4NzA0MiwxMzguMTY3NjY2IEM0MC45ODIyMDYxLDEzOC4xNjc2NjYgMzYuNTgyMjkxNCwxNDAuMTg5OTg3IDMzLjEzODgyODMsMTQ0LjIzNDY5IEMzMC4zNTEyNjI5LDE0Ny41MTQxNzggMjguOTU3NTAxMiwxNTEuMjU4MjA1IDI4Ljk1NzUwMTIsMTU1LjQ2Njg4MiBDMjguOTU3NTAxMiwxNTkuNjc1NTU5IDMwLjM1MTI2MjksMTYzLjQxOTU4NiAzMy4xMzg4MjgzLDE2Ni42OTkwNzUgQzM2LjUyNzYzMzMsMTcwLjc0Mzc3NyA0MC45Mjc1NDc5LDE3Mi43NjYwOTggNDYuMzM4NzA0MiwxNzIuNzY2MDk4IEM1MS4yMDMyNzkxLDE3Mi43NjYwOTggNTUuMzE2MjQyOCwxNzEuMDk5MDUgNTguNjc3NzE4NywxNjcuNzY0OTAzIEM2Mi4wMzkxOTQ2LDE2NC40MzA3NTYgNjMuNzE5OTA3MywxNjAuMzMxNDU3IDYzLjcxOTkwNzMsMTU1LjQ2Njg4MiBaIE0xOTAuNjUwMDYsMTkzLjUwODc2MSBMMTYzLjc1ODM4NywxOTMuNTA4NzYxIEwxNjMuNzU4Mzg3LDE4NS4wNjQxMiBDMTYxLjE4OTQ1NCwxODguMjg4OTUgMTU4LjU5MzIzMSwxOTAuNjM5MjE1IDE1NS45Njk2NDEsMTkyLjExNDk4NSBDMTUxLjM3ODM1NiwxOTQuNjgzOTE4IDE0Ni4xNTg1ODIsMTk1Ljk2ODM2NSAxNDAuMzEwMTYsMTk1Ljk2ODM2NSBDMTMwLjg1NDMwMSwxOTUuOTY4MzY1IDEyMi40MzcwNzMsMTkyLjcxNjI1NCAxMTUuMDU4MjI0LDE4Ni4yMTE5MzUgQzEwNi4yNTgyNjMsMTc4LjQ1MDQ3OCAxMDEuODU4MzQ4LDE2OC4xNzQ5MDEgMTAxLjg1ODM0OCwxNTUuMzg0ODk1IEMxMDEuODU4MzQ4LDE0Mi4zNzYyNTcgMTA2LjM2NzU3NywxMzEuOTkxMzY1IDExNS4zODYxNzEsMTI0LjIyOTkwOSBDMTIyLjU0NjM4OCwxMTguMDUzNTM4IDEzMC43NzIzMTUsMTE0Ljk2NTQgMTQwLjA2NDIsMTE0Ljk2NTQgQzE0NS40NzUzNTYsMTE0Ljk2NTQgMTUwLjU1ODQ4NywxMTYuMTEzMjAzIDE1NS4zMTM3NDYsMTE4LjQwODg0NSBDMTU4LjA0NjY1MywxMTkuNzIwNjQxIDE2MC44NjE1MDYsMTIxLjg3OTYwNSAxNjMuNzU4Mzg3LDEyNC44ODU4MDMgTDE2My43NTgzODcsMTE3LjQyNTAwNCBMMTkwLjY1MDA2LDExNy40MjUwMDQgTDE5MC42NTAwNiwxOTMuNTA4NzYxIFogTTE2NC41NzgyNTUsMTU1LjQ2Njg4MiBDMTY0LjU3ODI1NSwxNTAuNjU2OTY1IDE2Mi44ODM4NzgsMTQ2LjU3MTMzIDE1OS40OTUwNzMsMTQzLjIwOTg1NSBDMTU2LjEwNjI2OCwxMzkuODQ4Mzc5IDE1Mi4wMDY5NjksMTM4LjE2NzY2NiAxNDcuMTk3MDUyLDEzOC4xNjc2NjYgQzE0MS44NDA1NTQsMTM4LjE2NzY2NiAxMzcuNDQwNjM5LDE0MC4xODk5ODcgMTMzLjk5NzE3NiwxNDQuMjM0NjkgQzEzMS4yMDk2MTEsMTQ3LjUxNDE3OCAxMjkuODE1ODQ5LDE1MS4yNTgyMDUgMTI5LjgxNTg0OSwxNTUuNDY2ODgyIEMxMjkuODE1ODQ5LDE1OS42NzU1NTkgMTMxLjIwOTYxMSwxNjMuNDE5NTg2IDEzMy45OTcxNzYsMTY2LjY5OTA3NSBDMTM3LjM4NTk4MSwxNzAuNzQzNzc3IDE0MS43ODU4OTYsMTcyLjc2NjA5OCAxNDcuMTk3MDUyLDE3Mi43NjYwOTggQzE1Mi4wNjE2MjcsMTcyLjc2NjA5OCAxNTYuMTc0NTkxLDE3MS4wOTkwNSAxNTkuNTM2MDY3LDE2Ny43NjQ5MDMgQzE2Mi44OTc1NDMsMTY0LjQzMDc1NiAxNjQuNTc4MjU1LDE2MC4zMzE0NTcgMTY0LjU3ODI1NSwxNTUuNDY2ODgyIFogTTI5NC41NDE5MiwxNTUuNTQ4ODY5IEMyOTQuNTQxOTIsMTY4LjU1NzUwNyAyOTAuMDMyNjksMTc4Ljk0MjM5OSAyODEuMDE0MDk3LDE4Ni43MDM4NTYgQzI3My44NTM4OCwxOTIuODgwMjI2IDI2NS42Mjc5NTIsMTk1Ljk2ODM2NSAyNTYuMzM2MDY4LDE5NS45NjgzNjUgQzI1MC45MjQ5MTEsMTk1Ljk2ODM2NSAyNDUuODQxNzgsMTk0LjgyMDU2MSAyNDEuMDg2NTIyLDE5Mi41MjQ5MTkgQzIzOC4zNTM2MTQsMTkxLjIxMzEyMyAyMzUuNTM4NzYyLDE4OS4wNTQxNTkgMjMyLjY0MTg4LDE4Ni4wNDc5NjEgTDIzMi42NDE4OCwyMzEuNTUwNjM5IEwyMDUuNzUwMjA4LDIzMS41NTA2MzkgTDIwNS43NTAyMDgsMTE3LjQyNTAwNCBMMjMyLjY0MTg4LDExNy40MjUwMDQgTDIzMi42NDE4OCwxMjUuODY5NjQ1IEMyMzUuMDQ2ODM5LDEyMi42OTk0NzMgMjM3LjY0MzA2MiwxMjAuMzQ5MjA4IDI0MC40MzA2MjcsMTE4LjgxODc4IEMyNDUuMDIxOTExLDExNi4yNDk4NDcgMjUwLjI0MTY4NiwxMTQuOTY1NCAyNTYuMDkwMTA3LDExNC45NjU0IEMyNjUuNTQ1OTY2LDExNC45NjU0IDI3My45NjMxOTQsMTE4LjIxNzUxIDI4MS4zNDIwNDQsMTI0LjcyMTgzIEMyOTAuMTQyMDA1LDEzMi40ODMyODYgMjk0LjU0MTkyLDE0Mi43NTg4NjMgMjk0LjU0MTkyLDE1NS41NDg4NjkgWiBNMjY2LjU4NDQxOCwxNTUuNDY2ODgyIEMyNjYuNTg0NDE4LDE1MS4xNDg4ODkgMjY1LjIxNzk4NSwxNDcuNDA0ODYyIDI2Mi40ODUwNzgsMTQ0LjIzNDY5IEMyNTkuMDQxNjE1LDE0MC4xODk5ODcgMjU0LjYxNDM3MiwxMzguMTY3NjY2IDI0OS4yMDMyMTUsMTM4LjE2NzY2NiBDMjQ0LjMzODY0MSwxMzguMTY3NjY2IDI0MC4yMjU2NzcsMTM5LjgzNDcxNCAyMzYuODY0MjAxLDE0My4xNjg4NjEgQzIzMy41MDI3MjUsMTQ2LjUwMzAwOCAyMzEuODIyMDEyLDE1MC42MDIzMDcgMjMxLjgyMjAxMiwxNTUuNDY2ODgyIEMyMzEuODIyMDEyLDE2MC4yNzY3OTkgMjMzLjUxNjM4OSwxNjQuMzYyNDM0IDIzNi45MDUxOTQsMTY3LjcyMzkxIEMyNDAuMjkzOTk5LDE3MS4wODUzODYgMjQ0LjM5MzI5OSwxNzIuNzY2MDk4IDI0OS4yMDMyMTUsMTcyLjc2NjA5OCBDMjU0LjYxNDM3MiwxNzIuNzY2MDk4IDI1OS4wMTQyODYsMTcwLjc0Mzc3NyAyNjIuNDAzMDkxLDE2Ni42OTkwNzUgQzI2NS4xOTA2NTcsMTYzLjQxOTU4NiAyNjYuNTg0NDE4LDE1OS42NzU1NTkgMjY2LjU4NDQxOCwxNTUuNDY2ODgyIFogTTM2My42NzEzNzMsMTQyLjI2NzAwNiBDMzU5Ljg5OTk2MSwxNDAuNDYzMjg4IDM1Ni4wNzM5NDksMTM5LjU2MTQ0MiAzNTIuMTkzMjIsMTM5LjU2MTQ0MiBDMzQzLjMzODYwMSwxMzkuNTYxNDQyIDMzNy41OTk1ODIsMTQzLjE2ODgyNSAzMzQuOTc1OTkxLDE1MC4zODM3IEMzMzMuOTkyMTQ0LDE1My4wMDcyOTEgMzMzLjUwMDIyOCwxNTYuNTMyNjg5IDMzMy41MDAyMjgsMTYwLjk1OTk5OCBMMzMzLjUwMDIyOCwxOTMuNTA4NzYxIEwzMDYuNjA4NTU2LDE5My41MDg3NjEgTDMwNi42MDg1NTYsMTE3LjQyNTAwNCBMMzMzLjUwMDIyOCwxMTcuNDI1MDA0IEwzMzMuNTAwMjI4LDEyOS44ODY5OTggQzMzNi4zNDI0NTIsMTI1LjQ1OTY4OSAzMzkuNDAzMjYyLDEyMi4yNjIyMzUgMzQyLjY4Mjc1MSwxMjAuMjk0NTQyIEMzNDcuMTEwMDYsMTE3LjY3MDk1MSAzNTIuMzU3MTY0LDExNi4zNTkxNzUgMzU4LjQyNDIxOCwxMTYuMzU5MTc1IEMzNTkuODQ1MzI5LDExNi4zNTkxNzUgMzYxLjU5NDM2NCwxMTYuNDQxMTYxIDM2My42NzEzNzMsMTE2LjYwNTEzNiBMMzYzLjY3MTM3MywxNDIuMjY3MDA2IFoiIGlkPSJkYXByIiBmaWxsPSIjMEQyMTkyIj48L3BhdGg+CiAgICAgICAgPHBvbHlnb24gaWQ9InRpZSIgZmlsbD0iIzBEMjE5MiIgZmlsbC1ydWxlPSJub256ZXJvIiBwb2ludHM9IjIwNS41Mzg0MDkgMTk0LjA2MjE3MiAyMzIuNjE0NTUxIDE5NC4wNjIxNzIgMjM0Ljk0NjYyMSAyNTcuNjMzODMxIDIxOS4wNzY0OCAyNjguNzU0NDMgMjAzLjIwNjMzOSAyNTcuNjMzODMxIj48L3BvbHlnb24+CiAgICAgICAgPHJlY3QgaWQ9IlJlY3RhbmdsZS00IiBmaWxsPSIjMEQyMTkyIiBmaWxsLXJ1bGU9Im5vbnplcm8iIHg9IjE0NC44Mjk0OTciIHk9IjIuMjc5MDg4MjkiIHdpZHRoPSIxMDIuNzIyNjQzIiBoZWlnaHQ9IjcyLjI5NDE0NDQiIHJ4PSIyIj48L3JlY3Q+CiAgICAgICAgPHJlY3QgaWQ9IlJlY3RhbmdsZS00IiBmaWxsPSIjRkZGRkZGIiBmaWxsLXJ1bGU9Im5vbnplcm8iIG9wYWNpdHk9IjAuMDc5OTk5OTk4MiIgeD0iMTQ0LjgyOTQ5NyIgeT0iMi4yNzkwODgyOSIgd2lkdGg9IjM3Ljk5NzYzNjkiIGhlaWdodD0iNzIuMjk0MTQ0NCI+PC9yZWN0PgogICAgICAgIDxyZWN0IGlkPSJSZWN0YW5nbGUtMyIgZmlsbD0iIzBEMjE5MiIgZmlsbC1ydWxlPSJub256ZXJvIiB4PSIxMTIuMzkwNzY4IiB5PSI2OS45MDkwOTQ0IiB3aWR0aD0iMTY2LjI0ODQ4OCIgaGVpZ2h0PSIxNy4zNTEzNDEyIiByeD0iMy43MjAxNiI+PC9yZWN0PgogICAgICAgIDxyZWN0IGlkPSJSZWN0YW5nbGUtNCIgZmlsbD0iI0ZGRkZGRiIgZmlsbC1ydWxlPSJub256ZXJvIiBvcGFjaXR5PSIwLjA3OTk5OTk5ODIiIHg9IjExMi4zOTA3NjgiIHk9IjY5LjkwOTA5NDQiIHdpZHRoPSI1MS40Mzc1NDc4IiBoZWlnaHQ9IjIxLjM1NTQ5NjkiPjwvcmVjdD4KICAgIDwvZz4KPC9zdmc+
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - events
+                - secrets
+                - serviceaccounts
+                - services
+              verbs:
+                - "*"
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - mutatingwebhookconfigurations
+              verbs:
+                - "*"
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - update
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - statefulsets
+              verbs:
+                - "*"
+            - apiGroups:
+                - dapr.io
+              resources:
+                - components
+                - components/finalizers
+                - components/status
+                - configurations
+                - configurations/finalizers
+                - configurations/status
+                - resiliencies
+                - resiliencies/finalizers
+                - resiliencies/status
+                - subscriptions
+                - subscriptions/finalizers
+                - subscriptions/status
+              verbs:
+                - "*"
+            - apiGroups:
+                - operator.dapr.io
+              resources:
+                - daprcontrolplanes
+                - daprinstances
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.dapr.io
+              resources:
+                - daprcontrolplanes/finalizers
+                - daprinstances/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - operator.dapr.io
+              resources:
+                - daprcontrolplanes/status
+                - daprinstances/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - "*"
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterrolebindings
+                - clusterroles
+                - rolebindings
+                - roles
+              verbs:
+                - "*"
+          serviceAccountName: dapr-control-plane-sa
+      deployments:
+        - label:
+            app.kubernetes.io/component: deployment
+            app.kubernetes.io/instance: dapr-control-plane-deployment
+            app.kubernetes.io/managed-by: kustomize
+            app.kubernetes.io/name: dapr-control-plane
+            app.kubernetes.io/part-of: dapr-control-plane
+            control-plane: dapr-control-plane
+          name: dapr-control-plane
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                control-plane: dapr-control-plane
+            strategy: {}
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: dapr-control-plane
+                labels:
+                  control-plane: dapr-control-plane
+              spec:
+                containers:
+                  - args:
+                      - run
+                      - --leader-election=true
+                    command:
+                      - /dapr-control-plane
+                    env:
+                      - name: HELM_CACHE_HOME
+                        value: /tmp/helm
+                      - name: DAPR_KUBERNETES_OPERATOR_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    image: docker.io/daprio/kubernetes-operator:0.0.13
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: dapr-control-plane
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                securityContext:
+                  runAsNonRoot: true
+                serviceAccountName: dapr-control-plane-sa
+                terminationGracePeriodSeconds: 10
+      permissions:
+        - rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+          serviceAccountName: dapr-control-plane-sa
+    strategy: deployment
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - dapr
+  links:
+    - name: Dapr
+      url: https://dapr.io
+    - name: Dapr Kubernetes Operator
+      url: https://github.com/dapr/kubernetes-operator
+  maintainers:
+    - email: lburgazzoli@gmail.com
+      name: Luca Burgazzoli
+    - email: salaboy@gmail.com
+      name: Mauricio Salatino
+  maturity: alpha
+  minKubeVersion: 1.22.0
+  provider:
+    name: dapr.io
+    url: https://dapr.io
+  relatedImages:
+    - image: docker.io/daprio/kubernetes-operator:0.0.13
+      name: dapr-control-plane
+  version: 0.0.13
+  replaces: dapr-kubernetes-operator.v0.0.12

--- a/operators/dapr-kubernetes-operator/0.0.13/manifests/operator.dapr.io_daprcontrolplanes.yaml
+++ b/operators/dapr-kubernetes-operator/0.0.13/manifests/operator.dapr.io_daprcontrolplanes.yaml
@@ -1,0 +1,159 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  creationTimestamp: null
+  name: daprcontrolplanes.operator.dapr.io
+spec:
+  group: operator.dapr.io
+  names:
+    categories:
+    - dapr
+    kind: DaprControlPlane
+    listKind: DaprControlPlaneList
+    plural: daprcontrolplanes
+    shortNames:
+    - dcp
+    singular: daprcontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - description: Chart Name
+      jsonPath: .status.chart.name
+      name: Chart Name
+      type: string
+    - description: Chart Repo
+      jsonPath: .status.chart.repo
+      name: Chart Repo
+      type: string
+    - description: Chart Version
+      jsonPath: .status.chart.version
+      name: Chart Version
+      type: string
+    deprecated: true
+    deprecationWarning: v1alpha1.DaprControlPlane is deprecated, please, use v1alpha1.DaprInstance
+      instead
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              values:
+                description: |-
+                  JSON represents any valid JSON value.
+                  These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            properties:
+              chart:
+                properties:
+                  name:
+                    type: string
+                  repo:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/dapr-kubernetes-operator/0.0.13/manifests/operator.dapr.io_daprcruiscontrols.yaml
+++ b/operators/dapr-kubernetes-operator/0.0.13/manifests/operator.dapr.io_daprcruiscontrols.yaml
@@ -1,0 +1,153 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  creationTimestamp: null
+  name: daprcruiscontrols.operator.dapr.io
+spec:
+  group: operator.dapr.io
+  names:
+    categories:
+    - dapr
+    kind: DaprCruiseControl
+    listKind: DaprCruiseControlList
+    plural: daprcruiscontrols
+    shortNames:
+    - dcc
+    singular: daprcruisecontrol
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - description: Chart Name
+      jsonPath: .status.chart.name
+      name: Chart Name
+      type: string
+    - description: Chart Repo
+      jsonPath: .status.chart.repo
+      name: Chart Repo
+      type: string
+    - description: Chart Version
+      jsonPath: .status.chart.version
+      name: Chart Version
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DaprCruiseControl is the Schema for the daprcruisecontrols API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DaprCruiseControlSpec defines the desired state of DaprCruiseControl.
+            type: object
+          status:
+            description: DaprCruiseControlStatus defines the observed state of DaprCruiseControl.
+            properties:
+              chart:
+                properties:
+                  name:
+                    type: string
+                  repo:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/dapr-kubernetes-operator/0.0.13/manifests/operator.dapr.io_daprinstances.yaml
+++ b/operators/dapr-kubernetes-operator/0.0.13/manifests/operator.dapr.io_daprinstances.yaml
@@ -1,0 +1,172 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  creationTimestamp: null
+  name: daprinstances.operator.dapr.io
+spec:
+  group: operator.dapr.io
+  names:
+    categories:
+    - dapr
+    kind: DaprInstance
+    listKind: DaprInstanceList
+    plural: daprinstances
+    shortNames:
+    - di
+    singular: daprinstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Ready
+      jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - description: Reason
+      jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - description: Chart Name
+      jsonPath: .status.chart.name
+      name: Chart Name
+      type: string
+    - description: Chart Repo
+      jsonPath: .status.chart.repo
+      name: Chart Repo
+      type: string
+    - description: Chart Version
+      jsonPath: .status.chart.version
+      name: Chart Version
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DaprInstance is the Schema for the daprinstances API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DaprInstanceSpec defines the desired state of DaprInstance.
+            properties:
+              chart:
+                properties:
+                  name:
+                    default: dapr
+                    type: string
+                  repo:
+                    default: https://dapr.github.io/helm-charts
+                    type: string
+                  secret:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              values:
+                description: |-
+                  JSON represents any valid JSON value.
+                  These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            description: DaprInstanceStatus defines the observed state of DaprInstance.
+            properties:
+              chart:
+                properties:
+                  name:
+                    type: string
+                  repo:
+                    type: string
+                  version:
+                    type: string
+                type: object
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                type: string
+            required:
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/dapr-kubernetes-operator/0.0.13/metadata/annotations.yaml
+++ b/operators/dapr-kubernetes-operator/0.0.13/metadata/annotations.yaml
@@ -1,0 +1,15 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: dapr-kubernetes-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.41.1
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: unknown
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/
+  com.redhat.openshift.versions: v4.12

--- a/operators/dapr-kubernetes-operator/0.0.13/tests/scorecard/config.yaml
+++ b/operators/dapr-kubernetes-operator/0.0.13/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.30.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.30.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.30.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.30.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.30.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.30.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
Updates Dapr Kubernetes Operator to v0.0.13, which targets Dapr v1.17.3.

Part of Dapr v1.17 post-release checklist (dapr/dapr#9281).

## Changes

- Adds `operators/dapr-kubernetes-operator/0.0.13/` bundle
- Updates operator version from `0.0.12` → `0.0.13`
- Sets `replaces: dapr-kubernetes-operator.v0.0.12`
- Bumps container image to `docker.io/daprio/kubernetes-operator:0.0.13`

> **Note:** The `0.0.13` release of [dapr/kubernetes-operator](https://github.com/dapr/kubernetes-operator) is pending (tracked in dapr/kubernetes-operator#380). Once the operator team cuts that release and publishes the image to Docker Hub, the image reference in the CSV should be updated from the tag to the immutable `@sha256:...` digest before this PR is merged.

## Checklist

- [x] New bundle directory added: `operators/dapr-kubernetes-operator/0.0.13/`
- [x] CSV name updated: `dapr-kubernetes-operator.v0.0.13`
- [x] `replaces` points to previous version: `dapr-kubernetes-operator.v0.0.12`
- [ ] Container image digest updated to immutable `@sha256:...` (pending operator release)