### PR TITLE
operator gravitee-kubernetes-operator (4.11.1)

### DIFF
--- a/operators/gravitee-kubernetes-operator/4.11.1/manifests/gko.clusterserviceversion.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/manifests/gko.clusterserviceversion.yaml
@@ -1,0 +1,1713 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: gko.v4.11.1
+  namespace: placeholder
+  annotations:
+    capabilities: Full Lifecycle
+    categories: Integration & Delivery, Networking
+    containerImage: docker.io/graviteeio/kubernetes-operator:4.11.1
+    repository: https://github.com/gravitee-io/gravitee-kubernetes-operator
+    support: Gravitee.io
+    description: Manage Gravitee.io API Management resources natively in Kubernetes
+      using declarative custom resources.
+    alm-examples: >-
+      [
+        {
+          "apiVersion": "gravitee.io/v1alpha1",
+          "kind": "ManagementContext",
+          "metadata": {
+            "name": "dev-ctx"
+          },
+          "spec": {
+            "baseUrl": "http://apim-apim3-api.default.svc:83",
+            "environmentId": "DEFAULT",
+            "organizationId": "DEFAULT",
+            "auth": {
+              "credentials": {
+                "username": "admin",
+                "password": "admin"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "gravitee.io/v1alpha1",
+          "kind": "ApiDefinition",
+          "metadata": {
+            "name": "basic-api-example"
+          },
+          "spec": {
+            "name": "K8s Basic Example",
+            "version": "1.0",
+            "description": "Basic api managed by Gravitee Kubernetes Operator",
+            "plans": [
+              {
+                "name": "KEY_LESS",
+                "description": "FREE",
+                "security": "KEY_LESS"
+              }
+            ],
+            "proxy": {
+              "virtual_hosts": [
+                {
+                  "path": "/k8s-basic"
+                }
+              ],
+              "groups": [
+                {
+                  "endpoints": [
+                    {
+                      "name": "Default",
+                      "target": "https://api.gravitee.io/echo"
+                    }
+                  ]
+                }
+              ]
+            },
+            "local": true
+          }
+        },
+        {
+          "apiVersion": "gravitee.io/v1alpha1",
+          "kind": "ApiV4Definition",
+          "metadata": {
+            "name": "api-v4"
+          },
+          "spec": {
+            "contextRef": {
+              "name": "dev-ctx"
+            },
+            "name": "api-v4",
+            "description": "API v4 managed by Gravitee Kubernetes Operator",
+            "version": "1.0",
+            "type": "PROXY",
+            "listeners": [
+              {
+                "type": "HTTP",
+                "paths": [
+                  {
+                    "path": "/echo-v4"
+                  }
+                ],
+                "entrypoints": [
+                  {
+                    "type": "http-proxy",
+                    "qos": "AUTO"
+                  }
+                ]
+              }
+            ],
+            "endpointGroups": [
+              {
+                "name": "Default HTTP proxy group",
+                "type": "http-proxy",
+                "endpoints": [
+                  {
+                    "name": "Default HTTP proxy",
+                    "type": "http-proxy",
+                    "inheritConfiguration": false,
+                    "configuration": {
+                      "target": "https://api.gravitee.io/echo"
+                    },
+                    "secondary": false
+                  }
+                ]
+              }
+            ],
+            "flowExecution": {
+              "mode": "DEFAULT",
+              "matchRequired": false
+            },
+            "plans": {
+              "KeyLess": {
+                "name": "Free plan",
+                "description": "This plan does not require any authentication",
+                "security": {
+                  "type": "KEY_LESS"
+                }
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "gravitee.io/v1alpha1",
+          "kind": "Application",
+          "metadata": {
+            "name": "simple-application"
+          },
+          "spec": {
+            "contextRef": {
+              "name": "dev-ctx"
+            },
+            "name": "simple-app",
+            "domain": "https://example.com",
+            "description": "A hands-free application.\nUsing this type, you will be able to define the client_id by your own.\n",
+            "settings": {
+              "app": {
+                "type": "WEB"
+              }
+            },
+            "metadata": [
+              {
+                "name": "test metadata 1",
+                "format": "STRING"
+              },
+              {
+                "name": "test metadata 2",
+                "format": "STRING"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "gravitee.io/v1alpha1",
+          "kind": "Subscription",
+          "metadata": {
+            "name": "echo-subscription"
+          },
+          "spec": {
+            "api": {
+              "name": "api-v4-with-jwt-plan"
+            },
+            "application": {
+              "name": "simple-application-with-client-id"
+            },
+            "plan": "JWT",
+            "endingAt": "2040-12-25T09:12:28Z"
+          }
+        },
+        {
+          "apiVersion": "gravitee.io/v1alpha1",
+          "kind": "ApiResource",
+          "metadata": {
+            "name": "reusable-resource-cache"
+          },
+          "spec": {
+            "name": "cache-resource",
+            "type": "cache",
+            "enabled": true,
+            "configuration": {
+              "timeToIdleSeconds": 0,
+              "timeToLiveSeconds": 0,
+              "maxEntriesLocalHeap": 1000
+            }
+          }
+        },
+        {
+          "apiVersion": "gravitee.io/v1alpha1",
+          "kind": "SharedPolicyGroup",
+          "metadata": {
+            "name": "simple-shared-policy-groups"
+          },
+          "spec": {
+            "contextRef": {
+              "name": "dev-ctx"
+            },
+            "name": "simple-shared-policy-groups",
+            "description": "Simple shared policy groups",
+            "apiType": "PROXY",
+            "phase": "REQUEST",
+            "steps": [
+              {
+                "name": "Rate Limit",
+                "description": "k8s rate limit",
+                "enabled": true,
+                "policy": "rate-limit",
+                "configuration": {
+                  "async": false,
+                  "addHeaders": true,
+                  "rate": {
+                    "useKeyOnly": false,
+                    "periodTime": 1,
+                    "limit": 10,
+                    "periodTimeUnit": "MINUTES",
+                    "key": ""
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "gravitee.io/v1alpha1",
+          "kind": "Group",
+          "metadata": {
+            "name": "developers"
+          },
+          "spec": {
+            "contextRef": {
+              "name": "dev-ctx"
+            },
+            "name": "developers",
+            "notifyMembers": false,
+            "members": [
+              {
+                "source": "memory",
+                "sourceId": "api1",
+                "roles": {
+                  "API": "OWNER",
+                  "APPLICATION": "OWNER",
+                  "INTEGRATION": "USER"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "gravitee.io/v1alpha1",
+          "kind": "Notification",
+          "metadata": {
+            "name": "api-notification"
+          },
+          "spec": {
+            "target": "console",
+            "eventType": "api",
+            "console": {
+              "apiEvents": [
+                "API_STARTED",
+                "API_STOPPED"
+              ]
+            }
+          }
+        },
+        {
+          "apiVersion": "gravitee.io/v1alpha1",
+          "kind": "KafkaRoute",
+          "metadata": {
+            "name": "kafka-route-demo"
+          },
+          "spec": {
+            "parentRefs": [
+              {
+                "name": "gravitee-gateway",
+                "kind": "Gateway",
+                "group": "gateway.networking.k8s.io",
+                "namespace": "default"
+              }
+            ],
+            "hostname": "demo.kafka.example.dev",
+            "backendRefs": [
+              {
+                "group": "",
+                "kind": "Service",
+                "name": "my-cluster-kafka-bootstrap",
+                "namespace": "default",
+                "port": 9092
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "gravitee.io/v1alpha1",
+          "kind": "GatewayClassParameters",
+          "metadata": {
+            "name": "gravitee-gateway"
+          },
+          "spec": {
+            "kubernetes": {
+              "deployment": {
+                "template": {
+                  "spec": {
+                    "containers": [
+                      {
+                        "name": "gateway",
+                        "image": "graviteeio/apim-gateway"
+                      }
+                    ],
+                    "securityContext": {
+                      "runAsNonRoot": true,
+                      "runAsUser": 1001
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+spec:
+  displayName: Gravitee Kubernetes Operator
+  description: >-
+    The **Gravitee Kubernetes Operator** (GKO) brings [Gravitee API
+    Management](https://gravitee.io)
+
+    into the Kubernetes ecosystem, enabling teams to manage API configurations
+    as
+
+    Kubernetes custom resources.
+
+
+    ### Multi-generation API support
+
+
+    Define and manage APIs across all Gravitee API definition formats:
+
+
+    - **v2 APIs** – proxy-based APIs with traditional policies and plans
+
+    - **v4 APIs** – next-generation APIs supporting HTTP proxy, message
+    (event-driven),
+      and native protocols (TCP, Kafka)
+
+    ### Declarative GitOps workflow
+
+
+    Store API definitions, applications, and subscriptions as YAML manifests in
+    Git.
+
+    The operator reconciles the desired state with your Gravitee API Management
+    instance,
+
+    enabling version-controlled, auditable API management.
+
+
+    ### Management Context
+
+
+    Connect to one or more Gravitee API Management consoles or Cloud
+    environments.
+
+    The operator syncs custom resources with the target management API,
+    supporting
+
+    multi-environment and multi-organization topologies.
+
+
+    ### Reusable resources and policies
+
+
+    Share API resources (caches, OAuth2 providers) and policy groups across APIs
+    using
+
+    dedicated CRDs, reducing duplication and promoting consistency.
+
+
+    ### Kubernetes Gateway API integration
+
+
+    Optionally use the standard [Kubernetes Gateway
+    API](https://gateway-api.sigs.k8s.io/)
+
+    to expose APIs through the Gravitee Gateway, with support for HTTPRoute and
+    custom
+
+    KafkaRoute resources.
+
+
+    > **Note:** On OpenShift 4.19+ the platform ships its own Gateway API CRDs.
+
+    > GKO does **not** bundle Gateway API CRDs; it uses whatever version is
+    already
+
+    > installed on the cluster.
+
+
+    ### Templating support
+
+
+    Reference Kubernetes ConfigMaps and Secrets in your API definitions using
+    Go-style
+
+    template syntax, keeping sensitive data out of manifests.
+
+
+    ### Prerequisites
+
+
+    - Kubernetes 1.18+
+
+    - A running Gravitee API Management instance (for synced resources)
+  maturity: alpha
+  version: 4.11.1
+  minKubeVersion: 1.18.0
+  keywords:
+    - api
+    - api-management
+    - api-gateway
+    - gateway
+    - gravitee
+    - kubernetes-operator
+    - api-lifecycle
+  provider:
+    name: Gravitee.io
+    url: https://gravitee.io
+  maintainers:
+    - name: Gravitee.io
+      email: team-devex@graviteesource.com
+  links:
+    - name: Documentation
+      url: https://documentation.gravitee.io/gravitee-kubernetes-operator-gko
+    - name: Gravitee.io
+      url: https://gravitee.io
+    - name: GitHub
+      url: https://github.com/gravitee-io/gravitee-kubernetes-operator
+    - name: Blog
+      url: https://www.gravitee.io/blog
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAPoAAADvCAYAAADb98kVAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAhGVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAJAAAAABAAAAkAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAA+qADAAQAAAABAAAA7wAAAAAXTBRUAAAACXBIWXMAABYlAAAWJQFJUiTwAAACzGlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNi4wLjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyIKICAgICAgICAgICAgeG1sbnM6ZXhpZj0iaHR0cDovL25zLmFkb2JlLmNvbS9leGlmLzEuMC8iPgogICAgICAgICA8dGlmZjpZUmVzb2x1dGlvbj4xNDQ8L3RpZmY6WVJlc29sdXRpb24+CiAgICAgICAgIDx0aWZmOlJlc29sdXRpb25Vbml0PjI8L3RpZmY6UmVzb2x1dGlvblVuaXQ+CiAgICAgICAgIDx0aWZmOlhSZXNvbHV0aW9uPjE0NDwvdGlmZjpYUmVzb2x1dGlvbj4KICAgICAgICAgPHRpZmY6T3JpZW50YXRpb24+MTwvdGlmZjpPcmllbnRhdGlvbj4KICAgICAgICAgPGV4aWY6UGl4ZWxYRGltZW5zaW9uPjk4MjwvZXhpZjpQaXhlbFhEaW1lbnNpb24+CiAgICAgICAgIDxleGlmOkNvbG9yU3BhY2U+MTwvZXhpZjpDb2xvclNwYWNlPgogICAgICAgICA8ZXhpZjpQaXhlbFlEaW1lbnNpb24+OTM4PC9leGlmOlBpeGVsWURpbWVuc2lvbj4KICAgICAgPC9yZGY6RGVzY3JpcHRpb24+CiAgIDwvcmRmOlJERj4KPC94OnhtcG1ldGE+Cugde2kAAEAASURBVHgB7L0JuGTJVd95b758S1V3S0JGbANjsCVgRhiQG1sLAprVbJKFRBuzbyOW+fwZvOABDLgReLxgD8t4RgsSYBAIJBaDAQNCUtvYI5gPYRuDAMkDxggECKGlu6remnf+v/85J25kVrUW6G5VvcqoyhsR5/zPEifi3D3zjcO2PKgRmIZhHO4cFsPrVFPuHs7UEPnqMj1puHh428EjDnbO3u14Wr37cly822oY330cpneRxMOHcXr4NIwPk6aHiHaraBfGcdiXpl0p3FUttu2cyMbxNA5H4zRcFuVe8d8s/hvHcXz9MKz0GV83TdNrxXvtamfx2t3jk98fHjr80fh/DkdXeybFd2kMgz+wV8Ndg9RfexzXkt/SHtwIxGJ7cG3eVNbWEvsRSoYXDWebAZg+b3jYcLj7Psc74/+0nFbvP43j+07T8D7Km/dUIj58Z2c4aGnFjNVuoa8lQFkljYoPyafk13+1vQmi9fV92iUkD1er6ZKE/0h7it8V4/8bp/E3pmH6jbPlzq/t7R7/9vh/D/dKYq1Mdw47w6Ml9avS9KJhJZXpzRps23kHRIDp3Zb7OQI+2t2tVLpGYk+fPdxycrz7fotxuF0pcbvy84OUgI9cLIZ3HpdypGZkpbbShMQVhp5zeBx13FXq6giemasDaRy1axSloXSR37EbCI6PvJmBUenYnBjUglrsLFTXMZsaqrxYnWB3eK18eNW4GP6jkv8VZ+PZf9x74/Bq7cSOywnq6Y5hOdxhymq8y2NwZ7t58CMQU//g2z13Fn0043R841ScxD49Wn7wMC4+TInzYTp1/uCdxfQew1KhVydSeBhOVz76nZHBykoyGYJTjHZfSO1gK83iOK1t5DJpmHDlYmsjTgqbFbLWT9/0otkOHSkSmrOB2MFAQX4adrRTGu0/3om8UnoL91sC/pL8+HdnZzv/fvfek1/pE7871d8mvYP84G6Y6G35E0agjtzj3cNpr+LwafuPWu6s7lCWfLzoj1vuDEpstfK4vJbUlcyR9jEf2pJr6CRxqZVI6/3id8nrY7tgCBiMnJpkftNDM/tU0N3tMNgLq25Vt3YcEnHSazTsqThBGJaLHbb60FPiK+l/S62f077gp4bh7OfG5w6vUd/F0l+v03zBtkf6DMoDXDEt2/J2RKCSe/PIffy03ceMO+OTdYz9JK32v7i754WsNc7ReiLFuTYnLX2Udjs2Shani+dCGycfNJKGvtvZb+1qWKo61PJAVkrO7A4jZXneP8uYht1+pxG+rtmfZcMl+mjBlmR99A8HlPhLkUl8gVYnwxVhfn4ap399ulr+1P5zj38NOUo70t913zclA7nd/mki0C2BP42a8y9bp+b90fv403Y/aFyNT1VmPkVH7Q/0NbZS+vTMKXHiYyeJHSe9GetID23JeCoXSyhZgpvEbnbUNLZPxkR1ic2p/Jx8zkD1e1ls2hb6gmErPaa1kd04k7BNAXBVCmDbr9AVppB34rNz085DNpdO+h1dBxx5f/IL07j6wcXO6kfGZw6/2cZxl1C6kXetG5aF2dZ/sghoTrblviLgpLlj2OmTe/rrF9/j5PTsaboW/Qwt4McteIil5D45I9+GU8mIPCwyu7KKXNAhj8QQm7Bbu2r3AjB3Uk6ojaMsSVRC1NYiok6iu8TNZoAxZouRjM2ebWzqT2ynq4ThzCUHYvuV9DhR/tXojMPjhZI+fNzV0X7gfEfX9qcSedlqMTx/Zzr70fE5w5uwsD3KE4X7t3gR3L8qb3xtdXreJ/jJpx589DStvlAr+cm7u+Mtkdw6Oo26Pp8iuXOVO4EchbVE4wgohGiQlRI60nEDnW5LPidOUK6mhbqIb+mKXm6tKdpxpIWwdiqvp2RNb4cWLQVEJC2jJKJswXN7Zldm55iDy9hCnYCzFVqlW68D+PHb7rgXmOl40HP84YcWi8Xzxmef/GKaIOmXwz/Qab0UFm1bv/0RmKfh7Zc9dxIv1HPgO3XnvBJ8esrwsJOd/c/SQJ++q1Nz0nml2266Qc5DpjhyZxS8xBVN/feCdB/eVRHO3IgEN1YYJwoyyFv2Groye9YwaT4qZJTX884DVVK4tjNJ8aSVPHbL1/IjByNWlMIUf91PH64NAd35GgERpykKdWXPLwxpr7c7kPQnDsDP6STpmTt/fPZDdefeCa/Qb2/eRfDe3u1G7N9e8fOB9/W3hlLXhlfuPHif5en0pVqZn7/cG96Z22gnK049fQQnwZVPmZRdwrDKK6mIjPtUarQ2DJZ+0KqjQ2AmpfnrCQ+pyaeuJpgJWv6YLovgZ0zoNlVkYwVwM/1v+Ld1PP0OZT59sFKpUBw4dwi/qTUAW0w/TdKGZK8dF/5y5N4Zd7UTxaGT6b+petYwrZ6n0/o/Qmib8ETh7S+ejLdf7HxIaNEsdPd8UUfwo7+69xeUcV+mRfY5umu+O+norYtuHWPi6K06FmUmQzs9FaMSnPVJdOjTzoW9tgOAr71F0jIJpRtBCUWGAFJBnkVfxTo7yqa9wlGHD3HTLDShyLlFbfvIB7WzIgJ0dFDekg9rOPvlA7Vl857EHIMcC/YoyNpHnwykHaqRXatitBM38abj6U1S8uzFYvVt47OG34X3i1807N7+Htox3OWHlpC25S1EoGL+FiDnj7WZ4MdP2f3gadz56p1hunNnVxfdOjHXAiTBedbLEdylFjWLE0L0Wz5IxrmddK1Y4ZqM4dqsHf3QonVtbV7o0cZ8CHYpXfaMq4vgdf2pB61VsFftStjcQcWOJZjOTjWtwabTPtUsd7UuxAMafoWGopHBogiQmLKJPZG6st4LfLyss9ILOj6t1x37K1L47Yvl6p/pFdzfQXpSwg/P0U09m+/0bZtrEdgI7xrv3HW86G7XO12vcBIPh0/ef6Qy5q7lYvrMhd5UOznRmo6bazwFdmxYQMj1CePAZOSs08s5CCRR0CJ8lu8WdfVdoxf95ktKRf3c0JhL4dbkQIoADWSzKwKlsB2mzhrEDT8NZRNH1fAH4dQdjYwBqNQNHXvEpdlNcNjVqLK4L0+DHrVY+B6xtSr3SwQzGRePg7fzzhbjtMtXdlaHw6EA/+LK2eqf3frc4Q8Q4gj/Ic+JeW1Kto0WgTYZjXJOG9MdSvC74w226VNufZeT1cnXaahfojvoOyd+4s2Jup/2EhMfcXJhEhEvUlZfX7zQtR7XTlF9sb2+yL1qU0dLitSFDeuMZKfdEgK5xhejzhDCbsiZpiSlbr5tyNkEGXmVbvKslZDvZI23WGBaH6m0ZpoM9L4Vr2l2ODcwMFOHKjTSx1ofeyO8PyAqxHoYM+H9TP4eEf/p4uLqn4/fPFy5665h8Q9+VfG7xheHUH8zlwz1+Q2BT9Nz8rnpdnq093e0WP7+7t74EB3BWVxKc151cap4CceqE2te5BGnjJaqgtAA5mQnim5TbUTWMiFoDs1KDsRs2LQ4aweE7vvSgy3zaVgjDTfnI+wmXdpsN2DuSCSPqraIG2tWwUPa3JEELHmSMC7A0W4ASWbZ1EW/dpKCFA57Hrf5nTfVl4GVIn7mU3od4aej4XdWq/Frl885+5eY0pzzpH57h55gZKngVv/c1E6C7jT96EkX/+owrr5pb2941Jmuvv2IbNKC4OTTRemvpq8q1Y8Mi16tXN9AK1YfqdRAkhfZ9hs9komlrP8NA7bHlWyk/YwlyZrtBOEqsugrHaW70WMQtmkMsgKtl+BAVquxSc816FpnBooc9lGaGGh0QzNbO5I4s4i1+rFTM05CKY4oxTtCxu1OsTuQ1MYp/Y5O6ZXaZ8fjz+9M498en336csvodF5367nXctOXLmznJxZ+XJbfh77ypIP30bXdt+zpPXSWzPFq4EcYdtT0TTYfgb0OCYXXVC5MThMjkbQCi1nx8mGKBBQhhdQIXAaSM1DxUqLpgrtB6+VCn9HRnPU37cUoPags/b2uNNXOHApjfNNGD5fqrCRdlhHslEx6pCpshUwkY/MH3lV6KwY+Jxc0bDlyYm3op2+7roxufWNrzGXTO4u4S7/SY7ld7sGvVrpht1p9BW/aeS08Wm7ddXPfnc9QEv4bv7Bo9C3v+WbbJ1/4Ch04vnFP92x1Hc7rqSxD7qSzXtTNxadOfzSGf40FCw05s7WpJQ3Zi1B1S6rQPe8ISp8xqUZ7iTzKWVv6IGLq1jGv7SgC0ba2qd6an003Dm2WpPUY2uHnvL/CJ0TxwfyQiy2MbJkHTlHQdYfHnWzLFw49jR5CHnajdzEwWxsElK/Yp/iw70azbmbYkacKkrzw9lQRWyz2hwVv2un1u7+1fNbZ91r2Jj+6ZywJxY1d+qP48ZN3HzOtdp69tzv+pVOlt1YEV+N6cEYzFjGrib4IjgGrr3ix9jIe5qaMSMiwAksOFLLVD1YCk8USDEyJhnzJlUztDNBJsVrOcWXNK5m0CkZV4XPucpoe7G74VLp7DIPp+61tfdjsYiJ9NmqRcAh+G/eGvc5BwdJOKOxcS5WNHvoE6AsgewSs7BkgQplVjBpGvBNd6+zp+K7r9+knxrPpS/ia7M18dF8PaR/eG6g93a4kzkdmR5908LXLxfAM3agZjk91fRZflvTCZ0hXL5RcXGYJkBHxwqkYeEG1hZ7LzsxYhIjlihMUmkufXBsLcfYjdZdflg8l2kax6sCV8raokSuZwlNbX8i05Chc2Sp8+U7fmPQuddsmmGDH3uZa+it2sx75YU9Dby8DpmK86VffV9ulaNkND0WEnn6q0n+VtKmTgmGlo/tSR/fLelHvb47PPnue+bpZp1N5nrLcNKXieEMOWNO60A8t+nHK4SfvP0pfGf3uvf3xccfHnvBTrQLuvrp4QXSLDqJQazuAWjSsHpLLJ4NC9YkQ2hCMVUUArUdVv6hLP7qMUMM6K0XRiwymjAFHJ/SWrqABC6br2FxTLhVYo3WFwtYve0G2MQ1ltkk7dkrhb2fVvgLui2VDgfVcS//m+NbHljGoKGZcbCNHyODrZqT9Sx+osMdcuHYV3uncyV5pw9HdL9xMh+MPjxfOvnD8luGNN9uLNhmyCM6NtO2fix9/0sEXaqafqVN1/XjpNB/FWbRdOjDz1XfbeRXJVXQvHVZmiwzLLDCbSYQMepLvRTfLWaztJGLHMeN7HIu0+qWvp4UmQNwwK2S4OC/yXOXwEW6LP/zr5WZ9G/FouhlSxcA7pBKBYVaYsE2n1LX8htZw0l2YUla6CCG4+B87QHhBUyM4TZe6ddQGBrvFxW2TtPFNDtj+ptzZuK/Xmo+HP9RPBHzO+KzTn0aW0/mb4bk7QbjhSp2qa5L2ji8dfKcS/DO4FtezFr/0wiJnUP0iu2qQmyPPviovKOPVif58bS0CSOtPTPW9kL04Uw5++VCPzHpan3zYSX1NpnRBh99OdXN8SW+LPjBdQoXSNb9so98IU3Imb/ZFJJ7YDnUpnHEQLfztdiz2O+VAtxjQQUClaH0MoNpGGEpk4GFATjmrwKEqtrmGAaqCULM6nOj9eb4yw6/e/JOdZ6++EghH9/P+GK4LFUO+vosnLH8I4ujjb/nAaTz7of298ZE6ipPgPC7Tj6vWamGKu8WRC7Fo1Cwy8G0hqNP3aYeWWDNwjeUOLzwRvFGnL0VLTMgAMDps0A1dtGYa7Vr8JV+0simEHMAXJx9sK4hG6NrUTR/5Td1XxSBU1QAtY70StsexjaO4HCh9M8atFke7mTI9psa26WezMZ96C5Jl3smGX6HEnhUEw5DbeOnmfCWNX70ZxgM9Yj0cf248PbtTN+r+4LwnO8lxQxS/4SZPeY31+BMPPlsvv/yn/Z3xkUfHOlXnxRclOSvCq6I15qGRGtVjwvkAdi0Gi0PEdmFei8UKtZoDp61a4NDFBhz/Wls0ridh6r/tGGMBtWyWdTrbpL1WUKZS8tRlU9TgVhW4AHtr0fIrOrlFD0p739zO2OAnH3B8qh0CHpL9trocM+rAWStC0TaEDaQgJykItgEFPGPjE7g0QS/+W948XFCDratop+KoZj0dmfnLMUpE313SWrkyHI9704dNy8Urpy8Z7uCIzml84Trpc9HMqF7fY+mvxw8//sL/sb87/K0THcM13z5VZw5jgWkaY0TeQmMtUOIQEMDAeh21I0Og5i1HqpRPUVnTUcZLRjDZjHYoS4yt55LKNirjSGTl1tn66R3SaAx/6URRq2jUEOt73g0AOXCFbWMtmcBqKwLFEiFDfMr3xg9U4GKQhXGeBT6Ut7Zk0I6PprHHqDaNsmmiusSXNgVV1SdRTShvSHOXUG8svJTOCqMeC1Aw1KUzaG0pFAAdJ36NVgL6QZEv16n8t1ruHF63V5wY33VZuuvxC0dvPvhRnap/7LFeftEkcQSPU3VNHTNb+221WWye8Hzxok++GGeOXFUs9m6hADC9LacQYf0ovXNBZWImBnyhLBw+FO0qTcam101UXuMG/gdfjasWfrMSPoar+JUMckYlHIIa47PzAen1FxRaiAjYeWt592soobowlil8+po6rSfte0C9zKYP4Zm2EmDMsUNTxyQNIZt4QTMGGWdP3RwbpU0bc9lseqLBZIXG+LGLhW7Ujauj4bk7z1o9HQjvy5+nR3A1WMZ23ZVK8iufePBnx7Phxfu746P0bJy/BsLfFmuLuKaMCfZ/AWC2BcCkro/U60WYllSWDQUzUi1I86JIq+g3WUxl2MYbbMTRv6/CKXzKslDR6/WZWuajWOmSHPZstNrWxmYuLN7yy3iJxILGiLSjQyWUzVj09nJX+5HCnf7UMydOpRjKBQ/75Q5G/R9FADDeyaZL60KOTJDseLjdYXI4qEut94WTTVs1zDFAJOJVV2Xw4ukFJhwDvTMv2Jmu23d13X73eOvZJ4//bLh0nq7bMyyE4/oqleTHn3DhcdNq+mm9q/4Qvad+rJnZ8wR1i5F+TTBL3n0NpxJCTcZZyUbHi6DjzwtTvEiaLh5IqyDnheFKHR9Ga7FH34tIUNtIH5GtVdecS4x9yCNh73s6acvWhY62jMMXj8q6GbNPD8RAWdrHcBcnuiXTdHbY0p++t5hYLmXhhZ/Yo2VbcGOI+DgPhB7/a/ihSgQKfkbLThhTtJIpn0BDm/shqYGXboeWDkrTr6bT+kJpbANXk1fTcqJk39MjuP86jquP4sctzkuyX5c343xNrjfdjj7u4lOms+Hlu6OS/Ew3SyrJmUtNof4zpy7iua2V1Sa3LQFDxTAnOpbVpuRKD3XkSlBYFdVHJlYJpryiSw1Gg5UY+vrYx+DZP3wI4eShO7BammYhg5lZYeq6miZg6DYLEbyVFpsOogAUddxyDJIWnPCx2q3uMMhaXjT9l3PWbz/xH+1sqoEDvR7GXHzX9PVpGDX6vm0l02dLbhfc1qUmSqe7oWDiF7YSlmATUjZZ2QOrz950qJt0O8MjV2eLX9ZNusf4Jp0ev63puQE711WiO9jcCOHO+sdd/IK9nelHWPL6YUa+kOJ31cGIpGoujaYGbf/3HDOZ3LB2pxarl+YsrZYAlNILnjYf2pZPTPVdc0jvtUkCAXj8Nw9+YEQuSzZne4HFCGYozhKfZxYvqLHDKVr5VxqhF89Kyg11iocMlxPUEDs8JoogcjZDcO4nI8gRI+Urgw6d8FXmGETXvspi2rW+4DDapFsQ4fxEpTExFVGwS0yL1mRThks1PqDBWlcnWzRmJmYqcYlBnzB7eo5zot+ef5huzv/C9MXLjz0PyX7dJLonQX83nLeUDj/uwlfsLofnHfl3Vwf+7smSCY7Zi+nzJLN4+MQEqVkLwavDk0nGpJwr28mJrarJzVDLhKVCqRa/p2HXXDyI9eVuUMNddPuj1UltGVjqVL/8RxhaKKkjVyR+0BJg6UJlDGaaE0+pl3o207CzIWNVypfyC7p9VV0+VR9C4YKGydkesoXJZotBOVW6yNo0wEyZrXAWzD5IGItuh2K1oSW1dBUuoN0OpITEaDY8FZgp6eDRE2Z3dabfoePV2Z3Vz0xfuvPkGz3Zr4tEd/AzyY8+5uDv6/n4Pz0+1Ul7BF1/yMfBZ1Y8G+DnCZsXRbJzrw+dFQM0FczJgB7T4XX6nYhdPxYUIBXo0YotPvCBHjxWbWHm1Vr8WojqU+xB6UhKSMfq98Ln1NVdC6A+CjRk6VWdbfXtkhjimOndXeqOKrTAjYKPQANuxTMPT9WDB65kqKEFXakuFLYTEziHxBIZo1m6dJWOxkEyiPYJOrod5QZqEKmJgghys7jaoafNi20mAKnwARWer2ZPSpZKdv66DL9e8KM6jf/sGznZ3+GJzjzoiyk+kh997MWv3dtdfONRJDmTxt8tc2FCwBqftOCYEUcFL8ekgtEHfMnGdJZU8AVY15ZyoJDl0yPQlQwv3NIt54QDijl2L07QaEHIotd0Q2fQ0NXuAaCLT5gkYQranMG7AGQjO7FAw2Fj7IF9AW9dhgJhSUcdytTxmFDZigBg6mO6OiZ6m238Vx8bHjsYty3LwNv4UpelS2+NWcINFzEwTM0o4N3Cmsrcbx2RoqCr2uDoeH6KmHXRsOd7AZZqJkHt6M9jnvltjd3Fd59+yc7TSXZ+iHJD1XXfXRvVg+0tk9CS/KOV5HvDM/w6a/eM3Bgcu5anGzR1uVhsiZ1ijYaWtgZiuXtqpbtkLGI9gGn0ljt7wWKFbHiWGPisXdez/uSGbngYTBtul83gwYmkBBW6EoGgStBmH6ovKSffjAlfwjJUL3PBGUL6oIblXUXbhOwj5YKAClhq+580+i7qhw8VRnU9FMS6YhzOBF1d6+xRfYzhRz9gpYkwhQ6bcTtCN+uFb/1hRFsVbb0oOpr97uZVLF6bXegXbMbV6fjFO888e86Ndjf+HXpEv5v31nVNfuWjL361fgXmGUe8s66AxpqOKYz4q828rs+t+3PmRrcwJReTH7pKnDksvjjamUs2DkkADROfBlXDbtoy3+gZU/ZTOHSxd0lc06c+pI5sY+rbJji7pGXNwpPHdhGBznd3yy/oZqM0s2GmlVozUR83EulWSRb6ygZGYRfN9JRRJfLsb/lhddaF122I0er7qTfVXTUu6ynb6ZPtseH4b9O4V97S8mWKfbblQPF3q01TN0MY2jv/gpBb6P5ETPnpsUl/FHJaLKdnTzfgkT0CsjbEB6dTr7UefsyFv6tr8m86OtM1OafqzkHcqiNY7IWZL1GZp1zDMb3QoTkbsl196k250OHVtrZ3Rwk88sO1VTpxyjCQKGqBoVP2IUCLPr5rmRiUR3WzExM2UtlsMwmcZ6eeNbxpwZrtrmE7OevqfLIrEY1ohv9qxzhwuByiLr0FLl7sPwCEb43ubi8XZxSWt27cd8FOxTlJmtIw5KqPKQBY0DZ9KlzQ2TclthuLibO98KH4LIP0DZw67mEPXVRyrFRA4MWacbGn35w+Gb9IP1P17XwHQ2/QQb+uSw7iwfWxXoa58jEXv+BgZ3je4em0cjgn3ed0lGs+0i8tYBytiYXK5CY36N1IUFHYTZzVezc+T2DQUJk6o6HtXNBTOqGmjAGNviaxuejSXZuNfQByiDA49LlNk8ZGgR9Gi5vdxL4lH2aJaHkoVhj20xQKrS1Ydii1BwK6nGy0whXFPjRuJ8PQctxQLRd6IoEDWvSYz6SV7k5ujd+mxUozkvZhjnEvC4ujOzUiV40HYvBVRRsgdjLGXqv8fTi9H//3dp65+qYbIdkf9FP3SvKjj774lINRj9D4VXWHfPS3z3xThAjPxSdpdGMOgqGoK13jY0p0mGlPUNXwcoJC0H3Pc+rTFIaexk+Bpse6QknTDxgfqJutUGRM0bxPASRU6BHImr3YaMX4UpeRHGnMoRf61S1H1YTJNm6AmWeKiQSlP+20XGHwgbZWuIKgXimDpk75DaN836T1/dAVipDBtbLvPl6GamqAtp+6mYgWU0RDpvMDp1RKjphbf/pNF37IpjigjCFy8CmQN07hg6Htmv5OZpYv3VI96ZqdzJmGhzUF13kjvX9wvKwkP/7IC4/VbvHn+UaKAs9jNK6BHOy58gq5yjGvDENzcnK11oRo1ayNCXpPcx9RNdhLhyqvBWgmgMEPVqD+X12CXsIstbndLZKyiz5yL5ShUSsOmnItRG2i7GUoTAvHEOkLws4P+xe2RTNZOAnl+ObxFK3UJJbKziS9HHKYLQNDqKzaOKGFcHHXcSERtPC1lIQ5BqZc8bUzQYDb7NGcowXUPOx11vqIthiANS5lch9jWtMvAPYC4j2F9cYxmxAwN0EPGbbWKpz+cMSBvhZ9NHzD+KzV1xE9/A911+/2QTui12utV+44eG/F5qd5Yd2/CDP5+8E+ArWJINCeC3beNScOovsOecxS3FDq40vI+agUru+jD7r3+G4G1mJxlEtp3XjhqLBeWJApGwzbSBRtNe0jtbFr3ojSSqBZJ0mKGIhQ/ax9Fy5M2CH3uRmltZjrTH6mD8igmX75kHqC0PwxNZZp+oAKFFLBRU/poo8+aorjZ1SHg24VcwxCyPuwpmseolWFutAVGNSkbpi9XTr0TQuGY15+xrxGnKw9MTZi0VAocg2mzVlRSnfJEGf0arGdLvbHpf7227c6yXV9XkrAXs/lQUl0X8PotVYl+4HWlL6gMjyUP6SgwPCDEYprTgzRVydXXxI95zGx5oKPUouq+lXXpNNn0qqfi7hgzsrAANH/7KzhmrViW2d0+i04jGlbH9iQ+BRNqWk+68biMhZi7sXGpFzMM1l62k4hRK23XTs2x8oeivlUHx88NtPZ2DnRMNjpVsfP+wNinHWBlw4+QdzYior+whQOWhuvNDgGItRpdGrzRJdiy6LPJpsL3ruVVTDwUV404x1aGS1xEcOH8M3YoLlpPRYsLVEjY81gB70ptz/urg6nZ+p761/Omh7ueguxWFf1Du9pjA9sqfgRzCsfectPHSyHv6IXYvid1j0sa1WoGQWsg56nTcGu07uAsS2nSxY5a0gGOkKjGrMuk8DCh16YriVSiorrBRSownr1tE6nu/Sis7dpeo6RNnxtYum7CUndDhN8Y3HG/iK35jMElVlXg5VWZF1sV0BjRSk/zCy6xhJZAz9ExaJ4zKqz65ZciYIutY1pbbGuisGsB+3prNNf4kxGqEAO69bpygybg4YszNaesSXUsIDm4lHpNBv10S4ezqikWbU6OTWxearT9V392eZn7zxn9SX2gU23dq3hOt488Ed0npUrWIcfccs/75McGh+HlxA7ejmR9INU0Q+cZqDkqEOk5jd1hWjJCxZlA1vkmZkW0MZa4x+LToCmgzYddFmfNnRoi77mDzQ+QhgAiFI4Upu21spaHBofvD4pZtnqhFzET3ypwNHUAxI58ibkBWdEs39A0EFNQQfOR0GQlxk4eBqjCvhcGBgFuappJ9507NEoTAms45x2jgHqxEMgTpMtsGbAbJNpoUhbPjSjGzQwpq3HQP4xTESilL/YFKWGRYO+9atRSf6cluR3efKMCU3X/7YN+oFwtW6+Xbnjls9Skn+PjuT66adRN94i2Iq8J6ls06+2GuGbtjEhjSUCLPdpxQJhdQYxaNGvyYKHmO0hQ19emE67ygbGCOa9KUd2Xc6DuZYuhLDVj6XsVF32om87YUyEkmNA6AHDRu3cBKbx5FcMcZYtHxBBH1h8bTJoskIQUVCilqEWMd/mC7IWg6brKk2hpRSV8Ka95pnhMZ0d1tbp204ag3it8QQox2mRECx51h4q+hjAk5wTHb1VBDzWL8/s6Zr8X+489+zzoN8Ij9LK/7723yHrCfdX2zffXj6c3nPHrR+gm1o/Hdd8CiMHCxe3+7gyRy6bSRMXYRwBvQLVYK4MFzSLGtk20/ykFb2nsUgsmczUEsRYsOJk4gkrpV78TZcaBsALYWNoV59G31fbq6ynGQ7BZc6UzRh07BIHbMkSj06xWzJHtKQATo0bp6sdWmwhzcCzB4IxcIYed8nV9XhtK8ZeSWM1pgfG8UIOWk+vfgZOXSjhTapHzJTEuO9NAjrfU3UHMSXQatoP6aG+ylLqCTMpl9WxTtf3zg6HH14+9+wzkL1Rk7zGTX2/FgXPT844oh/eesuv6KWY9z3Ud8plZKl4O+AZ4FwBs/mcmE26zyMbD65nw6rWhKsDtpLFbckUjbpw9kMETtcKb55oc1HCe6WEmFnBrzMEoDANs046aWdNb9GDGVpEi/HQoJkxmhMmyPPWtnoZWC6zRutpvoRSx2ATZ4zkwiXSel738t1mwqAk4yS/WUGml6dtWs4QtnqMbZsWYmk09LFdIydadLOi8lb9RFpZArsKAZUe5/ZaTO15ALW178hNg5J83Ds7mn5cSf4kADdykuP/A3ONrj+ThHIl+fMOluP76nvlektYd9gVSX9UEXQ+0TccEbrRUYN2fpyIsf5FSaCPt4YEqbRlzwpQgo6eljrXaI1fDYPIfR/afGcaRVEyFVMxGNFjgYdTBQzbgWvSZiYt9AvWcVuisfMJ331aaQjIwlIDmCkZpzAfemKYwMopi4hpWjBCg9plG6y6AuHCpB+scK2mhgljozAOkSMG2EpM0Q1fk0t3JAWGDzLeP6h2s2yUr9lnvBhrBbBo1iGi9aEt9RTdOi3njW1ohtl1CWI5DB/r77Xp56SmnzgvSd7GRuP+KnVdfunDL37BxeWC11vzSK7J8d6UOdKBz7kS10u9bTCtr5YXcVJCPhYUGMjMLqo8iUErpV504OAJlvZTPnXCr1IY+m5TqRHtsBTaRGMZzb727VKHUftVulw7Bh09dcArwTkG4bmTTQCKx5ntrEy3vDe4mz6nLaQcc5sNJhjropt+QmtFWlAXHogaR3IaYSWAbdzGzvGY1VwrBqhO/QA9r7Es7JPnkxXiIg8M907X820Cmw2/yzHr8/BSd7V75zWBFOJC7Zvx+rucek6uI/nwU8vnnX6C+efkp58zmAzpT1/q71gdPvHgz+me268phHt6VrqSEdvpJ4AQV78tOBGhlSdqeDZ6WuN1k6wmFgSzQMinFnTApS7NrQ++JUNpjrpsWr5h7I6ticSxICyHXY8Ss2WTRmsXvelKO/jmAYTvxgtTXPpum5IWg8mg4AWnwzG+hLhVOog47c0xgy8fmpwacwwUwtg1txim3bZT7eWwbjvpB7rLp006crZPBRNfVBmvxkymrdJiU90YT7Acj5mxoav0um7zIEvhZyX5S5ffcfrREGs9077Ry/126u6JeVF8i2c1Lr9nfzmS5BzNeYed/adXabW9cvwghRB6RmOSWY3OnwhtyTE5idT6i4VAHZKhPiQCWDqQh+4aDUHwQqJpHPRkQQtI0NgGBhCZxTqkyEmRoPKh5Jt07uIbDP1PfLTRBa0+Fuxw0MH4Y5gRYSRPWNHNR4rQLRFvQmfQLATGPoiGXv6X/l7GYLToA78+lm+a7HYAQk+IIbdR8B1SyaefRqHbjWCmX6YQGPPAwEaP8nHdgmhFAFNYNNCuT3gQer0VA17h0B0Yz+fxYs9H8l/Yuef044w5J0fyisD9lujD7dxo00sxH37LV17YHZ6gU/b4U0kZzjJY4a2Aa24d/JiDbCaYiUGnJ69bwGYzcbGAPYGA0KUqV5IadGQfHdlTtdaK/jW2XggBtVM6dHkRhS6TxPUyRLeLGt4T2FrS0ONP+ABrbecCLOVSoqvEiPhgL5KUui8Vg/ArOZLrC7z+0+wlrmRN7wWTH3ShZLxiPPtjxyrGljY+ZS2E/YyDAaFobWWEjeJGHXpQVGsk6NJFYJhyF2IQQWSbtHRwptj5iENaFhg5J7m+a/5LSvIP5/cRztORvOLh2avOn7SuwBx96K2PXo3Tf1H40DsHXX3tUZiYsKet/s99gRVxnVI6r+0G/GpQl6wQlpv5zFoshGAJnPaFaU6kZkjNtnWEIrO1CqI2BKSKJaJ5rT7i8sCSzX7IlWTFIU5+O40y1sbC+EJXeE+7WbUmuhIwjlgFHkzKOpuJ87pc9EJa7fLKcnnmHcaafbrob3porPcy4oVgGEIIY9lAb9Ksxfy3oBs+wHl87lq9WQLMnWypEgr/XYhrNoPe9QPQ8EpyXV6eDP9xcc/phyrJr/ix8N0+Ey0V56Ku2PyJB0OAEdZmuvLEW1+uR2mPO+RXtsY4wreIB2jdniagCDFR6wu4OYXymEgnBsaC1NG7xSO15D4HkcKFmZQrXeivBY0+6KW7x9iPMBh6RGAxGW9m2klMVKELNn1ho9k0BAG6nkUmu9G8U4hebptun7HbfCUDfrQdaepPm2vj2dQXQ1iPARj09eML02KEbh9QQ5eRbgYrh9nNRTGbDhEq5qEjtuaHEhPQTCPmMjBs+zEjIz8juGnT3c5+stfGgx7RfXddR/L/vLj39PHnOckZ75/+1D1P2S8/8Za/rbffSPIT6eVRWi1uL5yaOIxWqRu5xfORWTM59+OaCwKl6DRoV79qMExsLg+6FJGyiJNK7BtA7w2SbFkwWaxIbddJD/0zrdlz6od98IazpxEUY82JaJuNGR+B1YNcH3RKxoEomjXZFy9tdVm7c6z6L4iUj+hHDh1u54bkCQzypLSNY7Lh3An/LWUdoQtlalGaFveNEXHmG5RRcDt8AdjpLnyQ130NqfAz/EufBTNeRBwhxhRowWCfQCuK41kd/amAxa6O5MfDKxcXTp943pOcYf+p3ozzSwQvGM7e8ISDP6sf3PiR1TQuHXyC3X/Ug0DxsiL83ut6YUVrnhT1LV4LJkElY11NAzopkmBitaGyiE14pqHAAwgz+7Tdh5VWi6Y6uOCbaKfYAGO0s3BaCIc6aGHfraalmIHQNs+bw4eiOgFCDerKtmq7CMxU9WNoagjOkw36K3HP6KtDW/mf9K4vBc70VCm4/tfGzSAUTb3yw7hAO84piXtOJXBVJOVmwNWURMcOncWUvw3tPd7cC532oV1RWJMgBCGQabXOjiCalzbBikTvZGepL6icTv9tsTp7vP42+pu0jpfjd52/0/UMiSu+JvonL78aQb4wLr95fzkc+AbcqB/ZcUw9A56IDLLteDkUoCxrCtYWAVOSxUuo1hkzx4pXQSe6gh9HQ9tBkRoqhUO5iLHrRzLWZOhCJR/QKWo5K2i5ZWWobQurtS2XFqUEXSS+TNqd9MNnDtJfxQJgi+Daujoa/cDo1/S8O2EkSl7b4ctCC/25qljKaOo/pRialEQJhbQZCH/+Rq0zqVjlvFhDingAgmTEBYXRis1GPKzHA0axs9GXEnP8jGs7MeFrvq2/6VSj4xUZTMjaFXvhvgByUmwX043Fi/QWHHHPvpP87HT63Z1BSf7dw+ud5Hed7yQnOmtTF/F627Z10+LwCRc/aX+5+HGuyzWv2nFkqFv8Qx8TUhxRYiJkPR0Qy/lZ2dg5oZly7mqhGxMLCUDMX1qc9aMrimY5LCTJxliQ0gEjjBvUdBW1VOCr7Tf/Q1kIhIbCpg/2CFpyU7cTJ5122z4kDkz13ZYusfh9Muod/T2qhc+/uNgyJ/5UlXqvF+ENMvZ6ReqNqu9R3l5WrfskkiZs07ir7S2LxXSrrLyT9hbvLBuqh4fv7khvXcBJ76S/iyNBnSH4D2gQQc76BNemGx+KodV43Kab0ySjNXxjanzUYPuYWlaMTUwpkIDjVTj6qDFeYwy3rFik1CMHfVmkvvF5JHeST2ePVZL/Lr/P/iH6nXbrPecbB+btHWMFXvXi8Am3vvJgMbzflYmFoT9Pp0Lg44hGLybELQWfmgmKSvOdHngyYFJES0z0tY2FQS5k6eTAIj8vxBkzw6ChJbEBwTlDSkdKelFX276lInBFp+4XrHVs6rPcHAOJGGGsh5mxMM6JfabBLHaV1o4mQL2NcDINv6/xvVI9PdUYf0Xn5/9VNz7/u2bg9brGfFPv01trc8k1/OrwsKOj/Ufs7Az/o8bwKJ3yfsBqmD5Isu+/uzM+3OmtkZL45D6Dln3eifBuAbfCjlM6R+1wyv2ISiZg8jzYmkCPtp+v0ucZwpb0y4AgshPMaIu3GXP84JKtZOjTTgE1dbq+O+yenQ6v3ZlO/xJJfqP9Ljtj+tMUgvB2l3rN9fLjb/m7F3YX33SFZ+b6e1VElwB7omlR1nb8QSqW2dp4xWg5hGxyUxeYmvzAx1qpRbDOi0UBjgLGjVkXJqBiEl7UgSqoF5g78HOZhmBIoYG+NanR2gipExVnDcCybMYhOHjCgjzVOBZ7HLM5IdcVtv6w5B+K9XLZeOnZsPPyy+PlX3/Ejw33lLrNOpM3tL6uvOhQj5ClR+tzF+FUfR9Fj0offjotH618foIG81Ea5WOXu8NDPRQyPr6cxDj5nb+NOMjjMi0jXGwwP+GUDGZjzX5jhkMV0969wvdzjS7oEb44jUiaRJkalZi7E+3Mdler4XWL8fQv61r8v91sSR6hcETe9o0i6G+mvfn22955b396lTrvdLbS0syvn3pSYmY0wS3grCxPODNQmLSqbhCzH5NU05REdKWOtoc3S9LKoUYL05rqbsdhWZ/i4UZ6oLpfhMihPxcLoECGdzZlvlo5MMYTuFhQxrAxPeViIQYORrCNUdoMK8Vvd+m/EzsM+r7+b4vzEyL/2P7qlpeP/+aP32yJ3DiZ784T7S5xU6l96fH31a5xKOlHHdnHoXYMd+iM4i7fwGui0523PuJ4Ov4wZfVTtEf6K8vd6V1gnvLOo0802gWFB2VqbiLuMWrHBPp6rOxzBjIjZgxCzKrnKNVZf+lhDDUPxe/XW2jRkTyS/J7FYqEkP/71mzHJic8c3IrWW6l/UV89/RD97fLLj7/1Wy4sxy+7Eo/Tcql65a9PpWaLyVlPvLWkmi0KWBNZRORoB90ZLYrXhyGF7/WXbEhGr+SdpamOBRYhsD42prAFz2JKivugi9b4ECkhaZwxV9GUJjYYfzxyb6H7GbrQ0R+TvCLRf6UXjZ6/f3b0kvHf6PdFs/AikpOQpNbrxdgs3gNV23f9LTzsvkh2/5reFCtb02cODzm+svcJi8XwucJ9/O6eBqSTev3XlYXOReLUfi0GEWM0EE4XSP16gNjiHJDYClgyJqjj5C5M9amheccChPUht3Z2xuXZarpyNi4et//dx798syZ5xKai9jbUHFHY4x8+9iGPWi1Wr1R0eZxGJnvyUOHgu9LG9PkUNm7UBKbMlSAz5QVA5WnzJEdLW3hr+rtkb/RcGPhg/bGtphcXndCFulhzV6EFAHMtPVbWdMQYi0bN4kSubJDepsfNrWlPi49jshL8t0T/9r3l4l+OP3b598BQuMk5PIiJHVbve+sY3OGj9sDfrS/kdOf++x1P0xcsxvHzdZR/BLsDEl58Tum763gfmPsEjej6bDsjX0odqeqozr6qFlOvKamsHXtDz7LAW5LvTOMTx+ef/NLNnOTEaA5Pi9h9N1iETPalx93yHfoK6uf3R3MviE4b0YbGwp81miKCpknFmEzrhhfdAiJw1xQJy8dWndxxqB/XgDbRcCK3hC45aG7HBovqxwJEvflZAaSvT502hrPZ39BVGMvYVwS7ovHrHtd0pgTX39pWgp9M7CD/ye4fHr5g1JkRUCc3jbv9DLz3Fep1Uzw+kl47It0AVGrL9zuHh54M+5+n1t/Z3Rvei12BE36alp59MYxTWL0PzPhQmZHzD8ZlI37Qag1hX+y2ruxPSEX8pUtrIpJ8mg51Pfmhe9skv6+wZuQ2qnY0/8u3ve9qMf2aIssfQ/TRHKgngEB3E2sVItTkNJUbR2PxI7NUk9y85eUk7xaBdXR9dHnhWLaZtS02lFoIJeva7oipTr+jsEDojyQHkXp6OdrQS3fKVbW2wxHxdGcx7OqO76A/IMn9jG/c+8nD7zFYGy6Dbn+Sknvjurj413PNehh+T6fr+Xhq+rzh4OTS/hdrv/ZVy73xXU+9C/MpvS/rWpIqqt7P9oPLODdS149QK95tNhoqGgKASf3Ee3mqZF+OOpJ/z8kv/Oqdw96jX6QfPrnJSxfStxyJOppfefxtz9NjnS+4+k57pEVNTCVJP8FrFpTsMUEkqSfLmUdTMhaHrwtTZzEgdKmqreXp1iIg8a+FKR9SuulBf3+9b8VeUKhxua/l1XxIXFu9aZ+30wb9hdid45PhjRrAM/7VbVe+ra53fQS/zo/eNa63Vnu8X6QzvUp4XcefHu99lehfsavxn5zwWN43cDmdF9kSnn1+tcY9z0PNjkO7dlbmeQrhOH3bjH6sijM9sPDjXV2Xf9Tu952+TGcbezrzuOmTnDmMENF6C0WT4TvthxzNxzyae8bmIziamLSaFKtL7Y2+Zk1UFZJU/zXhPpCGmllXqIlDt3WXrjm5MUtBAxAGFYkKFoWoKzkjbTNoxYfuEXg7jryIZlJRrSko1rfZz7FL6HRfd3rRq2vY7zwelv/bbf/m3tch6SP4K/SHAMpQqDsXW8e6S/jDT9t/351p+ublcvhEbj/q5QAd43lrkvkCXdNJpDyHXUQjJJtxNlVE010FToQzZfgOp4E6mn/C7vNPf2qb5BmbFqL1/jV7dTS/9NjbnndxqaN5d6fdU8ZEMV0q1a/as9JNiqa3S7q4TtacCx5tdDCRrtXgNL6pjoZXCPw52TOxpShkZ10og4Y/1onuABnb+wlLTONCznqvkkNPFaFDt85ZNYrV3t641Gn6b+9Mq6fv/szRi8Hx3sFwThO84lC149wl/PGn7n6OYvSteoT4MD2SO1GwdO0ecxGXZ97BM98V99aOaQpOm6c0VHOv7pmOQjscic6m1ZOW33v24zf7jbcM0VoVwV0jrXcUYB/NL/+lC+81LHZeJYED0Tw7TA0TUBK16IMc1G5CCkYqSSxkwQbGJGOavBYEVBYEDCe9mMUX8aqjwOxN5XP62Ml1RuRK50slbZCkvdRHwhsbAtqGHzk+XRMOSz2z5Vn4c157fPhl73P3cOhT9DuufjZt++d840eDxEg37e799Fvedff05Hl7e8Mn6VSewqUNp9me13irjZC668ACUvE6q3mO0BsV8Y8v8Ozocd9wdLZ68sELzv71NskjcJtbB2yT2PfraH75sbf9ows7w1f2R3PjIvqznrnlhPQkARQ9oDlR7sfBsDDcMqWdOFWa+eiYBsGlo1U/OSwVYaWmgcMeIiRliBZaxKR1dkXTRYAUcHyPow6nHNku0dwHCHisvyW3p1+6vSzdn7v/M1d+EEjFreA3a90n3vGn7X65DuffzCToDTtSfldxJ9JUzFxNDydW1Q4W0ygKhblSxfcAFrr5NpytVk9bft/ZD/e2DNxuWgQydK2/1qjFPz324Q+5PB2/WrdP30WPTvj6I3KeCQe906JmZK8arV1aEwe9SAY1XXl8tAGffhsmQ4VPDfOklx8AZ+lwod5/tpLalIbse4yx0syxb97M44sl19ZZjQsNp/t7464emf2n1e70lAs/efjbPorffX0/JqtQPFj1xB16vYHH0X3667uPPT0bf0Sv1b77afsbfN6tsncmvVWzo83SGrGeoGqeWQ+jrv/Hs5Phc5bff/I92yTPeN1Hpf3hWyg8M1W5vDr+zIs7I0nOXnjBjKxJEXYyRjNEZV7R+qSGptIwc8ccTTdzzK059MyFzkyIVmxta2aVSLoXK0JKOSLH2hFW7fCx6k53KEiF8NFkb5IGIBfaan933D08mV6w/+Irj3GS61qc9wwk06FD5c285fGhk1zfFhu//+QXLu0eP/rkZPoPegynv549nkS88hAei6uWmPbVcyyZD32gjNpRjPqSytO3Sf62ray3nOg6MqFGE/H0DDd4rXMHe+LPLLW+aOQoEwOfDxOT8m3hX2Pi2vG68Jsy9LOgt0qTE4EFEP1myca9TPClCUFpvaKqtoKZ43EkUoP2eBKtF2CGUb9yy6Ozb7zw4ivx53r41dB8AabTum12EeARHEfeh33f8Ia9F5088eR4+N7lnm5U6gtygrX1ooU0H9GRn+eL0/WBJNevw3zp8gUnz9XZQnu015naNjcicJ+Jzs0UEuSe22/9yAuL8TFXVnpI4svUDQ3qRo5EksOlnzRmr7U3JfsErF14yacST/GGrrK3qW7uI8WycQkrbOWKqijrbTPWdgCdTa5Vakeim0jjYl/vfeqa/G/s/+zlr+W0VNgFR6zSva3vOwJOdt7hV9l74fFnnR4N36Rk51VqdqCEPc6iaEbcgdLRvVjdwdMLxEry/3Xn+0+exWWSzhbaa7nwt+XaEbjPRK9vNOm5xRdwXFaWkDp1FPXCN5lEZhoitSohLNJMBj9AqYOssz4EmVFVIhjJyXvCbC/Mo5KWtuEL+lIiOMEtSIgWzXLBsh++72drpTXl5BcA5OyE0e6T5Ds61xx0Q/LTD158+f9ioeXXPr0IE7qt3koEfBrPDlKf3Rcd/73j4+EZvFyjRcAv3SjsOqbrH5dMbQ7U1CO6xcnZ8OU7P3DyTCe5LpPeiqktOyPgRb0ZDYLLQr/3sbe862K1eLX2Brdpd8tiNp4zKycKoKTR9K5YoKSpEl4MeIXr+yGOINQoM42z5SKjSj3lLnoK09gBjNP6FClcrzuUAGYJ+cjBUrJE6bYdhtDpUZtvjulI7pdgPm3/Z6+8sL6Tb53bzZ8oAl4T+qYciX/0qXtfs7c/fINendWZEft8vbPEPPBfN9aX++Py9Hj4mt0fOP6H2yR/+8N97SN63oTTDwo9TY/UbtNuVl9D5L0jZ4APlZFb3pIpzIZTg0zM4oTMo695iQMcWNVuzzIlK42GtD6yJQex5ApVNRnc47CPLDLU4Q+uQfS+yTzkCmPe3OdFmJEk1+XLp2+TnOjcP8Xzoq/fcpm4/4PH36gj+9fo+lun9d7z11lSJPnR8A1Ock77897R/ePFzaHl2oleN+Gm8TPiykiRdzpEslRouGlCUikPnCSJAet8RyTFSiQI12IkUJV1ehHQsYTNaxNmQmnQbCjsjFoZBqRxqvAvk7b6ItpDdON72DC4ydhhCaBaP3w5Hq2Gv3HxJVe+f3skd0zut41jX8n+ouN/uDqZvkyPzWpdnurO/FLX8f9o94XHX8ep/oP1vfz7bYDXiSInRu+L1rbfhLvnQ279AK3v/6K+8yaArHy1SB8VbYOcWlQlIGABaZiZh7CKMsyKSg/9apsf+tT0sdcJ6ZYIXD4Exg+/2sk/RPyw4lQSpLBX+jHlJLcPZH74adnUpvaJH6GdTv/wwksvf832lJGAPjDF8deZJI8nj//a7t/cXY7fSrrrdJ0k/2on+V3z2dkD48X51Vp7znmEd8TeVLdBn3LAfXfFWp84MvrIrSnRkbWOhCQGWUJhsrIZGVudxGQW91TLIOsEQymZbFVNH++p2ZHCzXWXoLNWTkLsL2pTMLhsE4cp9CjdhY2jOnbFduoLd6JHaHoZZniBk5yjyfaUkZA9IIXYk+TsTPdeePJtOo3/6rOj6V9sk/z+CXfmwayMhU7QL91+6ysuLsa/eJlnnJOuizaQYJQiqoqhdBEtNo3I6UHmd9i4FqbQ5qUr0lyKrdJ+bejCXKFKFrlse6eDEqFMhN4k1Fnvg2rl9GA5LnV3/T9dfNnlx0AV12c6DbFtPGAR4Ojdf0efOWOuHjCDN4HitSN6Lubp3r94ywcuBiV5PNmMu59dmCtBeAQSEwAzjvJqeVKgm5dygXOisVH32gV5PpnD1uG+4CVXunv9aCu51FGJ7Dr5rQ0YXPoldrqkV3z1owVLfTnlkn4f/SnIvYzntfkcl/62PLARIMlJdn/W5uiBtXuetS/XBneHT091l3nnyfo7asNl/lhifvGgcCSGE0oEJwpnzyJysFXDp97GtrwJoLDOpUwusllnBJldZlqq5Rt2MAA+UQYgRyNkMRKgYHobQlbgRIbIjqOTS1cQTe2hVzA9N1xq97daTZ9z8NLD3/bNt7vjJ59S+7Z6ECLQH9EfBHPn3sTaEb1HBKbfAABAAElEQVSuQZWtn5R32/X7C5EgjgSp4nSJuJBL6pIdIpAxdCnklTZzgR7ESrjqO9cyCddlLI0NPqUKvXxmv2YzhaO2Y2GryaLDvFRmRnLRqY9O2Rc7+qszz95/2ZUf5ocitq+1VuS39Y0cgZYlWuS+Bn3j7Q/983vT6tc0KL5C6BRmgBz5MkmiXjvORgjEQEQdGiEKTRTbQb7TNSfdNXSFROpNOQts6OpxhoWR3l7dSQjbkmcAWeyk/dN3m/UXZ3b0GO3V+/deejQJDr18LoFtvY3AjRiB+YjOabuK/qTFHRf0i6Va5L7bDs2J0NXQ6ojaJ4IyOlNIElW6JmLOnaSlXu8eYhfQHb0Tg/7EhSOxB1mjxYkEAuxVIo3LL6tJXejBQXxP/+lSOPa7reqLneRxXZ6SAdputxG4USMwJzq/JU7RX+PIVhsTSePE6Ja9k4b0oOEUTLiOkVyrm0riqe3EQoc+mVEp2QtKHv2djav6sHX0D5OGZtseAldDG2mfdzpQhG2JHCZsRpuU4S774vBs+I4L//bel22fl0fMttvzEwEnBovdSfj497xw+cqbXqW/IvKe+mFDXkHU97Qi9ZwYicvMjqQihzitJ7moI48coblf0pFYtlVJqU72naXI9OE1L2mJCxuJykQNHbZfB3v2JexlyPFOp+QQxaNUsdLNt4X+PtIb9ncXjxpfco/+Kun2UVo/B9v2jR+BOKLzJ3hUrhy9+YOc5PpbauoqR0hftfi0vHC7bcTyroBaieOkMg0h9WhzVDctOtrOBQE+hqMDkUAkNXiNnzaqP2tKXKavzyTQal3eU/RatT8JjqTOlvFi0Nc7ybkBt32UthbWbefGj0Akev6RPT1SeqKeIWtU/EAv+dtyIxKwxpspSLJUwlArYZ3sAUNPcUvQ2ZXnCDPXSG1ASzVdgCZXH17xq26paniTs3iqaDuYcC0SvnQKoxtw/ErM8Bv7/+7St1lQv9baFGwb2wickwhEouf1ubLiwyMVla8+zLac9HB9tFWLRCHZaFTS9LSKjTF0xMxKJHR2z9uTjTleXQ1kblOu9LAjKV0NB0YfMGs4kYvmwWBAH6DQrQtJddR7hmnbG3AtrNvG+YqAj3gs8t95/HDh4Zcf8hv6G93vdbTSH0jh6lZJQWq4FeMmmXxDrA+Dk8TXx+QR2ZM7gjXppDZBoJLEg2hFAyJGogRo7gcVMdLTVZJyF7BGA2O/gIZfMRjn95ne5dfjtOmXDn7u0u3IoTO0bbfbCJyvCCxepBtPDOnhlx/2/rpUfa9jvfZKkmfCkCf8ywSAbmY7ekrUPDGceMhVEhpbfOkAgy0fYUlVdYuGHDwDouMmJGMkW4loWyiHVyLqI9zT0GesoeKYi0Y4GNdmGr7FvfwOvtvbzTYC5ywCizvvYLlTzh6j30JzQ4u/O4g7GUgiHxYjSZ0lKWdh51iftORQJmill4HxA0E+XYi0FHXeBcyp6B+ezFTPSqLla9jEKEpsy26KX+DqA00cTfyXwNm+3mfXtfl/PXj3S98Hvd4KdHu72UbgnEUgrtEZ1DTenmNzqjirg1Cp4xtydPSJfA+O8jkSkLpPdsSh1Sf6SjMRjHWV+gpMnQUMQBXvVEho+nUt3/HX9KVMarFwO5vwPkxfXBn1OyZS9mx+xsivuqYvTWjb2EbgHEVg8fV3x1vt+lG0D9Z3hsgRJz9JxRGUZNKHTCP31eYAqv9ZRLAQ3cJUu2owfJCHRnHf+uvoHnSSGBy6AFsmLLR9j352VeS54Cf6oBhPLVrfpw1GpwUrfTOPO+33rHaH50O//RXbX3AlDttyfiOwuEsHyOn2d3qokuBRx2RJZLKTpjKF4ZOAJF+lGNft9COxjGxJ5qQTI3hzbXrGEh7y0Hodkd4BEn0uc8etknWdfqCHftVljz6KqPVZ6U8oqT3+6K13X/p9vwXn4c2mtq1tBM5bBHz0vrSa3ltr/xH6SyzKgzzq0lI+kDjOENUkiolq0Il9Ahj1YIZ8NoUVzZ+oLAvGOpOGWGFooguMNLajNDZVmj6bEh+i5WlQ0h76i26foGeRBetZDKvvNqle/S3Att5G4BxGwIm+OJneTy+OMDy9KOMsUX746OcaWmaUU6YS1eno/ONASv5Q03LKrdXQSmfpglZYaPDLFGcM1Yemou5c6Jigjf5bDl1uB0Hb4Jkezp3p11x3rpwNv7l/eOlu+PzYoOvtZhuBcxwBJ7oOoe+fY3SikBh8+tQid8TkKNuKc0ebICAa/68lh2wJosuYgPt02zZ1HEcnSY4u+yAh8GsfdXoba+3CS7xsIpu6Vvlr4T+2/YZazca2vhkiEIk+DE50JwZJpEJyUCvD5qNu0DlsmgdfxafakUuQI4elwDsKEoxPIEOf27UxJ41KFnuBtp44fTd7NlktkWmGsLbZhzjbLDtR64ydPwc7/bi729P29ehse+c2Ak50JcZ7Z7r4yBdH1TlZ+h2ABFpiERWSy4RMUNpKVwcMnhu5UUeq1mkBjKSG13/iyI420p9DdNgWxkqC2vQFV0x0oBd76SCnCpO+rcJp++/dcunWn7fd7Wm7w7DdnP8ILCZ9NVUp9F78nIqSIhKTtruReNELAiwnEPWceMjF6bEA+s/pt0hqOz+zY0rIgcmuq9LVaKlHJmwuk76XEUIlcLZ5tWw7Zcfaij/upfIfxl/+g0v1RySbzLaxjcA5jsDiDW++9Agl0Z/RHXdKJpLSixdhM8vItPqQuAAFd50Y+v4kkwNoqgtJcCVDvdlHp0VCCuEyUmIQQm1jAZKyDoE1kRoOPmzs0dYz+JdS1x+RdHu72UbgnEdgsTOcvetymC4ohfTODGlaHxJE+dEdkSufoBGXru9OxEpceCEHUE1nWV68B4ptJR9tdIGlUe3qexcRaq0PgD8IVgkaKHzjY7HEQV8e69clThdTnLZvr88rctv6JojAQkn+7ntxShuPmTKJnGSZJT76kvXKnfrAMj2TCrqySSQOnmDnN9jFyxItYy1uMBYjgQuVe4YwEc7BCt3V134jfUox62HjhmruJyRx0p87HpXnr7lluvQbxm+vzzNs2+pmiIDeBl28BwPNBHEmkoiRLXTz7nejRViMiaa3ko8dgSTh0ecTqYYeNM4vw0AoHewwzDXJwJAFpNInuE4x4qI9WKFVbVsIsGnFTtZKf+cdB185vny48kL9Rc6y3eG2zW0Ezm0EFqthfDdGVwvfyenhKr0y3SONMpUEoF+4wpR8inb6zEGTGj7aB4+0977BErEJpWkBE7NfBqRMyaHZItrwiq7bKVN+9Tr0Lfv/TP/O/EUd2tuyjcDNEIHlYpoe4cR1ImrIkbEkZYxf2RNNGlF8UG04sTONi0/NaXWpCLoFfI+Pvg/1kabBNk1ivVya1JG4IUNLiPiL8z5+C8j/ziKi6PJpRo5gnFa/0oxtG9sI3EQRUJ4P7xzHzhy1MiRyuIsCaUZqakPuFIcEB2u6GCQWvFBhcPDcREMwqTgCu4tctumjDwVFc82mswXOCNFdU1Hom+YqHEXbpF951QW6qlcbt70R5zBsNzdPBPjbaw+v4ZJkzikS1mkYHHV8pDW/OJlQm7JOtE62+siCtQ7p51AbuSuiOHk0ZsdxzYJfTvZ2dLcjZK+VIhQ2AIS2YsmUXucfDsez09+18heFL26fs43GvBjuiK8an7OhPWDD4c81P2DKrxPFuuk+PIzsVlk7spIKTkqyPFOJ/Ay/STJyP5KvMsz4xEbSpQ6O2pGXVpU8VfrvIlXsXChBjQQ2oe0E3BPSmuiEXxJQo6mKpuVtU61d7VWOhun1F08e8nr9qHWKUp2v4vngZOluTpi25W2NQKyjWKtvq8yNhltOi+E2ndWSLC3RchBO5BoQ6eSAgA2kG9B8vFcvkpmGPlSZkpYl2QX1gdzMVG9M7UB4bX4OOLqB9olcusoH9xMXO596vJdeiMgt9nE1/JHfiFMTGes9RxsNiO8fro4/5uJjVqvhsfqTuG/U0PnDsPwlDrG6IiJFAhM/2bVZBze28NzS95gpm/iiUTds4TiMZJu6L4UtfebpGVDtoXCRnw3w1ylD0GPwTwmoDx2XVOt8LQCa50lruRvrSo9X9IoUON2JlYcB9IXjQstz2Jl2VveOP3j8wzAEPJdrg7Etx9V4q35yZS4xWgeHjTLPGVlJC5DEnpOWg2fGxwKzKk+zohkq5x0FujSnXoC6SVA36MJmTFQ7aoe4dL413ZILn8I323QT9+yTjuYu9Gwr++eqOtOZi4L3jy/sLx468LpjP7c10ogHKRJlM7ZFrzB5P7wRsoYppao3aZt9oD2tbzfeuh3vX66BM10ym/yih5158Pn6syRqsGlHu8KjTz34xv0fPPza4Q6pO6en8bpGny6slHkadtubkcUOhwLc6CZEv82WgNz5juAxU+Z4x9C31wBgvG8AkZIYKUtFDcNYLcradKMTP2vhSD60xK14d6yiaRgi0e+UhH769rwVxWPl9/dfdOW/X/mogw86Olr8ssb4EB3KjlSz/jmCxQR521Z89BoLUBaC3ElEN3iOLXPgGZiDzHxgBwp19r1Tp68Pc0OjLZzSxU6JORUjJhNcFmg0wRaNno4YsQ5ELEwaQT9o5LhRPCy49Zwl9UyjdoZ7u8PXnH7qwW+OP3j4ndMX6S/1PGc4Kdx5qRXacV9f26zotSDS0IfAzMFpsOAxJzM3Z5wI1lkAMPWZPD4EDTY1p2yh312dTI2cttFh7fjDtIS6kClbIWcwu4zQb3Vojn7pFttFOu9x4xw/Q+eHLif9SakLLz387Z3V6sn8bSlFaV8f5nlX8d1VZi4VC53ljtyIjc+kMztOY7OvelcRb3x4mtMdxbrRStZ060Jf6FbN1RI7lx3N4RK74NFvH+Y+f7W36RTWOOyg1x9sowvb0EOvZRiHFo7Hg23krSNx1p1yjEdrbo0vn7C/c3JsA99x8tSDjyTJSXbxzlVhH7qv4DijFEhKJmBLGMiK+ZxswiveECwpoLvCxfVxQDUNwUmtVgISIQuUXgCNoDb9wHhHQte6XJPaosAPTPKSBsZFfQr2qFfT5LtwtM9z8Q9qKNl3X3b4b49X4+fvK91iv+uQaej08jMHwjGlWzGtOV6jaUqLP4t6IjLaktci8KfteJkBC3ruWRU51yXTT73VbtpY66dUzavXnNdjbhgDPnjqw0uLBEEsjzE2jFrPXEWKX1YaVj9++LT9RznZ7/AOKBScgy2DZO9IAAiOGy0Y0e+O2iJkAd/F0oEj+FJiXZuKZnppUI2huXh34ZlAMatRAFZBk00stqHRxSZ9t0WjnzDLVU/nCJzC3hSFZOcnrC+89NJ36U9Bf4P+JDTpnqejjqjjlcFwvDibUkxdKoYKbMM5xvD1cTuaiDQMwiXb7uOYFrMa2DZd3UwhqQIg5zCaUqdGb7NwrrXBnm1qK3ebL7U+0DNjfMsCjTZlHe4NO6er4WR3Z7wouRdPnzk8hEduXAoZcw42usLxPw/FAVOrm2AHMQI5j7b6BBEqfT4hZ1JQU6SCTtcyEVxzPbHyIXXBaUmMZwUtnIVyAw05bEOijQ/2hbY+hpqbQjdJpZ+wPp3uGhYXXnL56w5PphfsL0d9r2fSSapjEmEiLhkbAuXm3I+WtsSzPg5fYtwOOSck81G0kCr1aI+jOoiA5X7F/ZDChludFvq2jVDS6TOAkFrflg6WgdcMWKsIXMohi7bQIc3q7J6cDSe6Xv+zJ1f2fxK0L4UUQ9o3etEgyIuYBAJSgSJLKOzpo6VGhrpw7qtDvzCCaNI9C6kh+D3GWAht6iSvPmIIlU0mK1TVOhLfqjudyHX27X8QUJVFvzrRYYp6nmvH4a4Y4YWXXvmM45Ph/9nfGfeUITqy644lmwidKroU1y2Jgi8yMc64GwVlLbrRi7A70ILHmuDIjkyUNGMK9/GsOtaBNCJTn14/sqZ7mQbGtFgvlqEPiDWD6d73ZJXuMCosJXF1cNk9PRmOd/fGDz1+6sH3BiJsV/tGrflbCJ54D8CBignKvhcEMamPGg6RNg5cC6gw0dZWreB7ry3CjKJVH2ykHiMKpVr0up3v/Yb4NZ+xU0K2lVCSCzeo/cKEshjHvYa/SRqKo+/EM9xLi/1PPDwd/rv+sCQ3pHgTTGzPU02uyApkFuJHWOlWnZNlkBgNDt99sJJDpvXFMi20S2ckomtpAGeBtIWsSsylFDfbpgrUrKYNe2MZb9ixeOdieqzD1JagHHPoa9LYQbfqvZPj6WR3b/qMo6fufcN417B6xe03/vW63lsYT7z/08AddIKfwXQUtCEIOvTTZU5q70eozDM+cSYWI/fmOZlNb2OjD629LG19cvLtkxAy4Q8CaroTdfhlP0pPEzci9U/TReRutuLTT91YevjPvuFN43j2sUdn0xW9Kch9Gd6T6nbknOo66sQ64r6ZVKJXbEsWAqXozDWd6sODRmKzTmh7Dju5wnpmOzqy1hV7B8samxjY1tf5Oe9IakfF6vbZQ66/JixRO4YNEzvdS92JP9vbHb/m9KkHn/chuudxo9+JJ38PPWKPmXlXwwfNmqC2p4NHQCJSsQUOIVTM3KRLH9NqfkI0Ew1vVNhJrTFxvZ3EzEbq1N5OYtFF2mP/EMq9KEyTPdTJi9sMvAm/0OIbS7o5d/CSo1dN0+JJ2rsTEh5b6Yomkt2xIYSRjA43MBp8IqwNZVb0EtM6gSWpLRvs2qGkXCfu9eE1Yg2Yk5zxtIQ0iW3vg/UbGmuvt4cKCrTCBWWmobTzgqb3M+Ak4+pE57o7i+k7Tz714I4b/bGbbsaNl323gZAqlARzM0DQNva2BKJNJJ23VBxsr6HYkVTw2ySmsCBrM04f22nJ9vzKpOc8hMCgx7hOT/V9tqKOdMSXd87xF1py+Nes6rHbhZddesnR6fC/7OuYrqD5X8WqBAkmBXrOkROux8WcsjCABThb1WVBWUlWoUvoNT1ixul2JHUI2TcnIsrz43WQ/qAS/8s/94M468eOP7olEdAZhp6mN0ygixLDr8duAuk94Z84vHP/kTfyYzeu0S/zDIFBKy4EN+MXjaDGJBA0QABoWyYWS5s85FMZoi4ph8DaHjqFrKZh42zC+tGFjITcF8ZNCKiqycMf5I03JnxIH73zUPvPpI01e0m7KSonu07jL9x9+Xn6I5P/+8EuL8lMp54HNRTBjKlCRpSIfUTGc85cVIwBw7JQxhxezQU8+tS5rWZ3IPHUmF7M6qA3dfmyMXXVOjDMNAGNTX9g9H72PoBr+lkzIlTJ8dIFw4eI7JyshtPdneHieKrHbk8ebrtRH7txjf4mH9GZUweNm2AeNqNtpz4EiT4Y09XurtsJUCsNt7YwmF8mDzWxQ0GAfqgMcU+SrWDMAY8sF636RpLyM4TW2iILDAYG3nKkvPP0ge96CzJresy6iTZ369qcx24vu/z39djt+/WMXS/Q5WM3z1fNfU5LxI6tGdoohLEGiGPFkzYfR9Jot9qGea1Ow4aAt0UL66FfeEsFLKUDCMy2qL1mwKrgj5Fs9dH/8AmiDxDA40YvvN6vlKs1jxxalqenw7Eeu733yfLGfezGc/Q3cc1WAfLAu4DMnAgaIydATHj/yCrkGsbBLRwBLP20WTLmxTqxkENqZmzQhww4JKDWpISsmeyT4PFZW3Tgs1Si/5k/3n9zfffe/hXgZqo9D3fFiPXY7dOPT4eX84xdAdQVqWJN1K8qToxGZe6ZA3RRb85dAc2rDnUQPK+NLFqQsRs779yXFITF0nbi9h8ktM4HfCraLBg0+iVnY14zYQ8dlu2GIVoryKm/R7Lv7g1PPH7q3vOLiWy1r/eag7K+7MFchc8euAgbSbU2mQzenz4iGim0CGTwc/CeJPSaLyJzYjTgrtREgTU52fQbLfWgK9gsDuDpopeFFaS0dkii6ZduDy6cLt/Tevliy01cNPj22O3yau8TdRr/OwcLv/cdj90UOeLdPop0ztla3JgAEbRVia2bRWM++ZiYG8lYLxjE+fSI6Gsb/4NfCqTLfPUDV41uvYnRlzV8Y9hkupk7l3DM0qWbmoOZfdV3X3QnXo/dFp958rSDr+ex23ADPXbj+zx/3MavBoOqSdCuLhLacRWTkTNxDkcQiTwfAgK7dEGjQLDOlKJtBmDTQkThRmRt0gtHjVzyy74nAGn2JGEPUhT1W1uUs6VYq3H88+ae4y+25PDfalWP3d7p7jfqe+t67LYa9NjNz4vjK+Cenwg5sXeQM8pWLkrEvjMlGWbX8xRNzwHzXDR01Rqy3hSPtUDHO+7Ao2+9sD7Msx7pst4OB13E9XWU/KtlsAWctaL/KtF2HZ3Zd7WG5cnRdLbcmb7u9GkHn+t7HjfIF2D0tfDxDxmgg8BQNNIabFCTKwQYerqs1rxkZELWSWtmYZJfONfaVN962FmKEG3WTdiYJz14hQnc+g4ldjCR4DljKTSbst/a6DrlLxRzWyvavM/NY7eXHf2G9oJP5l6NpoOvbvMrDeSLKkpWnqtuHQTDTPCJzBk1c2NK5vkXKJXaQExWSsJDnz9ekak8oJYDUzrczjOFogU0fHBbDIwUH93uM0i16MPr117REO3KeKLzHn2d7rtOPuXgI26Ux258Rfe1NeAKAn0KfX/YQ7qfCU5IEgMjm23m6HNNQNBoF191S2yRwQfLxwabECFsSDAIhSslCKqU4tIBmHbKW4/PSGKh+B1Y8T4Y2Rfd3Vyie1OXeux2cPelnz2ahqfr5hxBdLQd24i7ppLc09yoHzdU5/kBrf9MQRQ66Aiitipssx8VekLGdgxKnKtca57VWE+hKPSWLsSQ9yf9huaSAsW33TCeHFAsSe9X0lL6HhpCd6Brr8d9rfi226jHbk/Z//M3wmO3xdk0OtEVjDZQjzEDQpCqn2M30vTkFIZFkBNgIbo8v2NvAQdc+4gusrpZAhOBvYZNsF48hVdt+ZSjW32OOSxXJhCaGotTuNP0P//e7e9x8a/lW2Gdqpu62R67vfTycw+PV//4YMn3yCceVsT8eA6JpyhZCCeln89+fhqyw1lAfWSaLEob2IjkMnG1RrSf9k7Bxwnm1EU+uB0qLWZ/0Q/NdgDr0/pIJo1m+IIL3pFBcrFt20wCvoQeCPXY7ZbFYviZ6bOHW673x26LabF67VGMgD2VA8JIHCwCGRFwgkaAxFFpgSNoWSzD/HQ0mmBVMSkWRiciBNO1IMjSUzSDR9PBh5GTBpiOkMZn13qsyWwktXOxGiFC3bF+XUNPF97zIWeX3xc1w53n41tJHsv9seGxm/bLF+6+8lXHJ+MPHOzqsds48G03F+ZCu09FdU545rnmCBBTwyaaV883/A5TwJgo5MzsNEhdzTOqa55dJw+FSCAKFl6tLxtoaqMHBiwfKCVnHV6XkM1ia2zAAgtOH7Z+7La7HP7c6aX9n1A/vu1WwhCuo7I4O935A+26r2hQ/hW9CGIOqhxlWCoM3A1tA8e8+nSuBc58NrNMkOjrwySUHtSYZnUZ3dlKk9Pysjbjg9r004VeuqRb/fy1mpgQZCGf6Qsd4pw+Tu3tX1N1EOZNzQmU/Zdd+uu6E/8L+4thTxMWj91yotjFOuUcUqQoMQfIenqJuErpDJQFTK+56jFmaGNedailvKdZl+c7JjdEgIRsj6XNx36A0Ic+WGhixo4hIdatAcBnHDEWdm3zjgEMfBWGvafXZI+Xu+NHHH/K3neZep0eQBaXjm95nRx+Pb/Ro4Lz0VKnBmWaNpSi0SJOhME08UuW2m1t6lm7mi5gi0+7ZGG6HTC0Nt2lK1muTEuZkqPOAZQ5O2XNSEEdFx9Fc7gJ33n3uN/CRvFrj90Opr2P17fdXsO33SRySnpXzN1QpIVvxaF1hB36xioZ5qaB1aCvuYp1kn3zEcgcjibLYKZZEiDa9IGl1hrGtpJfdm1POHRXGzWUsCeqiwCR5aEdvsz0crYZ+tnmt90Wn3v0KQdfVz/nFbqun+3ivV7zmiuastfwI2EKqfJShZFksMvVNrgk0J+PtJKkMGw+KhB6GfoEDN5VyQjP8bWYQJ0+yyGh4m2YQpdlBIZF3/YSt9Fnehf6FRHZmZ4w6TrdE2IxBLalIlCP3UY9dltMO/q223CoV6T9bTcwxDji7NwShfD7GJ/5YUqsHs9XJ5N99FTp5xAa81a8+67DpvFpqQmpXwcX+CwKHFPFooo10sCdBWiADLVk1w6c2SnS2tjnsdvxdLa3nL7+6CkHn3U9PnbjiQq/x/2bFYUch8dMgKpP7cFpQ6MKR95os8+PvSXhAlJ9B1t95PlYoNMBzjo6Gn0S3vobnWmQtta3VEhfizazMbk4nqazC4vxf7i0uvQEs67T06x0+x1W1WO3/bvv+XUtjidztqeo17fd7JfC7Ul2LQpzxbx0c8u0B00ztjbHYhQUZeYFQdsstOZe4L2QOmJhOxE3E4Je+yMibZGry0Js/aIL3PjpVarjREA8j8K7AlsouVCvV6312G13MX3PyadceOL19tjNia7cebWDmhNCUDxCRnB1WjloFThqMIqCAhc5TDL2gbQ+aUylTTcC6ogdpXCui9hqZqHNjZWVLHW1G1yN3gfTJ73ohIvj9Mnub1+c6cO11m6P3V5y6cWH0/BFPHbTBOrvQsQ00vNHfeYxhVkJXge5Foyp+SkZsKWHdvGtWZ2ay9IPJgr7Db+Om3rzmNEONtJbUPToQ0FP52PTX/bgG5djqX7RfHBJPUB7/8C46MmOziTOwqPVT05POXjv6+mxmxNdzr8y3WWWXGqwDKqflMRlaKIHZg5kTIaDoY3rElInQtpV0IIsMzFP6MLm7IPCJ2IuHut0O2VDQyhp7WqEUpB8dvhji0r3J/GiiI9cabPg23qOQPfY7duPzlb/ZH/XP9nMa7JXlXmNsI93UF1p434375rWucCveYZKv7jVLt2Fndca+EgtBOHXabvaVkQtfBQAztPZjhYZ/jWbBoqwTgPk1DDO/grQFZuQIh67nSx3httOFtOLpyfpW2/XyY9MOtFPx/FVl/WgUoVvrHqU/UDd7gZGnw9BM89CcUoTkwC4Ykfit46RCEErumWYgJwEBzLc8CKg3xJ7NoBSqaBwtM8dA7oFhoN+Yxpq4Kdgzy4uhj93dPbQOyy6PX13GO5zk4/dDl565Sv12O2Ffuw2DLoKivlrMZYC2oS+9srCeII0BypQMynd14Z5qU/RVLOuui6dWkSoDHXhgHEx96QitttaaHJBmjUGPmxgq7cHDxvQylbVKTErsvWIA3Ji8OFHJo93l+MjT5fXz2O3OHU/G39LB7rX6Yac/J0DQCsHEIOroajX6ElrfSNzsmnXhICjSxDLhrlBz23jgQNM7bYAIaetWk1HLQqBKND5MOeuUx43/NIFeHH0O++fbYHt6bvDcF+bijN8PXb7NH219f/lRybV1U+Q1ZzAVWEOPA9wYpacRJ4jM2O21NT/NtfGilM01+r3CQiGObRgiEPqSqgWKBvNmyaDAXSjh7oTdtO8pJuvjbUkkFjgEwtIywsu/DU/sSGaHrtNx8u98Q592+07jXsHH1B4dj4+/Df1e2LD8Gr9HjCj59ieo/A4PSEepLrw7HhuNun0CQ7RAEp/U0Z0Bx9cFTDGIltEajowmcBsopH40seGLdBMQeBNrlETqdMr/W4a0p9y7wfc8q55+p6XMCjZls0IKMLtsdvRye7HH51Or/G33fQjkzHPIcFMzLKeL9iRVF4VbgdESM+TelXTaO1SJMJVpcfRzrUWuFwWnRxNvNEkNyoJW/ZE9BHc3IZoKyvWpbrg+JSWGFsbXznvgQsTj912F5939NSDr31HP3bjb2n7dF3f7PrPjIiYeFsbeh3Fk6m+/reB0zYm6THh3uc5mKXKwbU6AV3HKojIxDP3nCYHF0zowl4GFCLFx+1E002+fTEgffQiCAI8SYx6Ufnk4s5462K58FFdv/IZlywpt62ujkA9dnvYv3/TG8azxccdroYj3Z/jFt0ZieaPp0uyrANO02OaNYcsFZg+0aIZ/VwdzLEIMZkpk6A1Grhr0aGVLbVkLNZK+mV20KsZtfWlPeyXfnTRjsqN2BGkeMnVwQdys2k9cYATMR677QzP0DP2z3xHPnZrRzKd1/4iA/TgtFHReOhG6YPGQJ20jVso1aLpP7Iu0e6O7E7Q4KGnqVCDPa7x2mBPiswHh0TtKELaxFxMmDMEFMZrNxD1+oJCfHHmexLjF/PXOPwrn53PALbl6gi0x27/7t5f08mrH7sJpV/SzvcvNkQ8l6Ip/EwQp4rO+JnuOc5JzznOuStVYD2fzGFNMcxswwuslbf1xCqIf7lWCyc0IP3Hl0huNTaL198m8Rp9kl129EFreBOueshs9NhNGT9Ozz956oUPfUc9dlvUN7l0Dv+Ky7plqQhwdAtf0/WoPIzIPAOuDlLhxO4KYXBckybURnE0ZNPX0J6D3AgHr/RSWxehnXGZ7KlUIE8SZvhU6dri7+j716d6pv7Iw1c/5NMMyTObgm/ra0egPXZ76aWfUQy/WL9OQ/z9tdaY53m+rMHzkDMsQszf+tTA7eeK+eOzNsdWNm+KV3LAZaqtBZsVM9Ss60e299W6JIC8eeUNSlTKVi8DNrghFziS3kbZ4I96+gPt+rabj6ir1U9eeQc9dlvc6TPmYbjl5NZX/f/tnQuwZdlZ1885995+9+2egRQQQgKUqRAiM0kQhCqQljciZjIQHmKBViKoZawCygRLkBQoJQ9BEUoQkOKVggQIY6I8LJ0B5VFATAxJhJBiIOlEEjLdM/2cvo9z/P/+3/etvfbp29P3DjOTeZx1795rfd/3/x5rrW/tvc/e56F1flbfxEIHiNEd2aNDHlA6hKw6Rp9oN1rCXtcWc4HW0mcy0RPO2KYbLESjCbccrsrItjks/hhbcMh19ehYGxZHQ8G2zjLTb4TF2YpqEK9aNxqBeux25O4r//Hazvw7tdh559y2xzkGO/LABmLQSXyGN2pdBkSDKfBchlq0mT82BFWQF8ayFBSvcNQCWrPyIRd75YKhfgxnVKcpmpxctlm0a+0oxIBdNvzxUiX8SIJc6xy+YXqapQ9V7ayvTzb1E7G/qqvIo4/1Yze+Lo7BXpv6rbCTN2mhEyfn9ih0bDTkMZDuJRIVbLhLFsVigUdH076adVDwQddO7MAW3CrSi5vLeDG84WvZPnQMZOjS9lVUKNm+DHUJN+BoSX3t6nyxc2xt8glXbtv8CvNWZ/UYpP3s67Hb3VdfeXV78XPx227xabeaL8yw2CIXSAHT5pmQhD+3EbaGm86ZmmdsAGGPfVUhF0sN5x/iEc5k8YwCYpM3xhnSdmUbf8WE19O0sddspo8uRmTrfuy2MX329s7hN2DrsXwbdrxGPxOd0IutX8/O0BEPCLVKNxuwo3hC1aRD5pSSWQWKuh+EYQGGmoco4VRwHQB12YYf09n8i1U8mirlBQtxQCFG9Epie+zClm5N6LpzMvlmWHkHHuVVuckI1HgCO3bPlZfosdvv+rHbwl8y6XnLMR7mUIOsf5Vhr2OxZy04KRJR9qu2WrerOUUO3DiMaAv1tBWV4Jj0Ob5OQJJwmBFcf6kqUlzyJfJjbAuQim2xSxw2iodwyOfwZx6YuBO/tbEx/Ux9YcWP2Nhj9NgtFvo9Ecru7uR/bXGTaqEfsqerWRw77eSo8oDAqTadrQ1c8VFjQIqm9ta9eUJL0gPbYVArI+i6WK6dGJ5Y6OIBwL/rnKSKx3AkIQXiIjtrunu8fXx9+tyrt22+3Mwn0Bf+ZTc+aJXGtz12O7Kz8XkP7izeU592q6CYnzYvzIDnARYHYicBPDFy0Xl6Na9e/zllGMPQEmmM57TE4ZV8o2W8/dmbeZE6wotKkZVGOmHGeStQO0kku1XSl4vwXbHBox0bXpDrXBOOoTf0jH378KHpS7fvPPTPfFZ/DL53bhTo4hnPOHrp0OV36EsCn7G94ENAMfoRbHTAnZOWFRFUCZ47Bks9NUQ7etvapQgPmf/VivGUopFlNGqLJcF4iZNnQLMVBguCg853DrrvQWDJtmgs9GmNmR65nd89vHj25u9cvE9MXtIML1+MXu1uNAKLM7qprHsc1z7rxMcv5vP/rfE8rBvNGtLhseV4Lph3lVhdEjG1wdIEt/kzxrhoMb1CjRDwLI2Gdd1cpgUiJ4ONBhlHMsRRIfm2TRujqjEeIFSy9DzaZsceYpxzMNKtZY7B/Z3r3XNru/Ppl6//wtWf5bfduCNfPh7p2mf0DM6v0xXVbx5mOOLbe3QkqpsM0WkC8PzE+AzxqMet03BFeBsQloMpHEPto10OlscEvRy7bPnqDpnlWWs0RUZJ/sgfvB6DzfLb7EYsLHKeq98yuzb7DmSr5+oxrvvd+yWPPjtw+L9f0mcmpi9a11hrYscHS89rWMx58NwP88J0kmsuNddBIWE+ATD/kTgNY3thdOCRH8nDSGFaG1NiYrQrzuo+byqPwlTakQKY4lVMnR03yW18VIEmdsIXb8rnLvSs6We27jz6KY/2Y7e4dCeSM4wlHZn+KnUFSCdoe+ossMhYJMiN6XRqAMySQeoe44nqzCA3IvYeivJvkXaekBy0st8PNiLzQwgZPt2CohFR4B8OxRw95ry8s5gfnU5eevW2U5/l5+o6SwVitd/PCLTHbndf/pVr88U/9GM3XRXVvGvAlxdeTFjOBXLPUGYTbdNURSwFIjY6Xvxuk2tq0C4oOUK74kih0wmk89rrrjRAqEjU20mu7fS2mpYazqvQ7tgVStQy68UuwEyvknf57O9kPv+lxYuOftSj+Wm3YaHfE5eq893duy/N+fogPzJx2Bo9L76ZjqV0kq0GgQZteO5dCNwurAdAwoYB2ONkPTDME6ayCBOwoZYEeYsjvZZG+Eg9dO0TursnAF9x24/b4KKTfA7zhxfPmxxa3ZhrQ7rvRnvsds+VH9QXVnxXPXbDAPPAxrj3+eA5ysUejiK14EP3NXo9nUKxri/lr3yi57bqmntcNHvOB19RyI3LKCo41pOwycWrvpQdcMWjTYHGt9s2Y8eo+NNuuoQ/vT2d/7fF350ccd7pTVxWfAR3baErEG7DTU+/64E/VofeeMxTo8Wf4TE/etGqkRESmQp4NhrUdKboakMXrzBNNxebjWEPJzaF0VzM3XCnHXPUts+yhZNRAdzp2m5iynZ2wFz55k00XMJ/zJX1zX+HLV3Cr87qo0HdBxGP3aZH7r78Cj12+/nusZvzgLFnavq5gc7JzBlSIijPEgMvDhKBC/3iAYXfFfSKV3XxxnMfN4FRdVx4inbl1vLLRvh2mDDgTsSsHIt9huMhDnJdPNj0LDBUk42tncW27sQ/Z/v+w6/HzqPx2K0tdBzo8t1HEnX6DbzA0n+7IcVAGMNO8SlY5MORisEVG150AlzTiA6y8DqebS7RNj1YtV7shsnGfm5hTgT04C1axhBqV2LCCXNciEX4DV3C62Os039w5fbTd/oSXq89x8gV9VAjwDhK7vHVY7cv0WO33+OxmwbXn3ZjThIzyg+Pf85VpBFeBMWaysATt1vIKWy2sM9WepZbP3gltz+vuUCUfdu2AecbQvLaJeNWpZK8bMaBapTdKMY4YC51rRfmbQWabOdOvH7bbfrZWy8+8sOWPMKP3cYLPS/f5fj1l3V+V0BxRus6FR3zBDRuNdyZJFSJ9KiXGHueBGpj3SPtQGiDP7DiMgpWsxuAOAykTuo1DJPS27HljmeZdoAoTDCPEpmU9DPVa0xm9yeufuItz/Tl6KNwKRXen5x7jePw2O3w+uc9uDt575HZdENj3L60gnlgY2F5cdFmOjS71DFF5KAg+RTO05W71BkPIAZzZm2j5lQoaMvCMfZFqoQjN5OsPOAsZ4xVtHNQURnTx23baYV2bbYfbmzLOBvi2ED36Z8BG/reOZ3ZJy/bfvGhb3ykH7vZecbnik4RzMWPvuWNei/4C/WFFLvqbp3pFVegwblFqMKrDU1Na2gnBaZsey5LwwpWtm7MczCtE7bECNOWSFD2oAk4aZM9xu3c9bZtT4ro9bbBiLets/qG+v6m42+58ELUBRrfRe4Nr9p7jkB77PbXTzxvvpi/SR9129ATDj7ttuYM6bU06JSYD8Y7Z8K8OA4zMf1cAQavubEE6Y14KWpJNM6F9NusNNjIcnEjjkhIVHpbxIOvikgE8MaDTrGOXx0qVFhMC71m19ewT79s/RevvuaReuw2PqMTQb0NdLp4HXcEFWW7fEfcBwrNUS27QWdEEqr/6JA7hbz0qK2DsogqJS9aipaC5XwLrXFpPPDBE05EHX2lb6y1jbahFgf2w7atOYOwxb9r7fTPIt/S6/UXXLpt86crpsAVtapvNgLtsdvdl96mybrDn3/Rhzwqp2Ie0ooGlxJjDFGzZHZQzJZnO0+uRTV0GBBqyA3UMSpsVJgaeDQrDvTCPxDSVHTjgTTW9gIXeGyHtNuLkxgzafd0MQfNOMPD59Nuer/mz2696OhffaQeu12/0PPyfXtn+ouX/JzPl++KMQOnpW0IOseNY5HZIWPwGADXsGgnja0qyzzToF2ykukYcMzhRmVAwLBt1RaWSHWCDXcb++iK8MRTmxfKVoWW8NCV3cX28bXp3758++a3CjdvB0FhV2V/IzA8drvyX6/O5y/Xzz2xePwlk/38tHmIGfD85Bx58nLnqSMX8mQoiOay5UvMqyOznY6GmbyRX+basMQOGMUgy03PHlM62CJGYwKHrUyvAYOo+kesfbwhCz/uL18yqcdu675JtvilxZ1Hn/FIPHa7bqHL2fxVuky99d3n36qof+M4x9+cGAerfqgzPv0RJMU0LE+AOlKYJjNM7GAEPgcWVhwkLK4dvDA32I+35XpWZSv8Fd41k1ZKKRDtQkw0ynfVJYVOXePM5/n6rm/OffPl2zb/UZ2hQme13+8I1GO3Y/dc/f6r25Pv1ffOrWuQdzwjw2g3c8xDESwKprSmleXmuZQeqtpYJaO5q7k2oAypLr1iobdnOxxiXqU8ViYFVwuHRIRp/+mLdWGbZTvizxjTnxaIdSpOdzC64xgl1mM3vV5fm9yyvdBjty+YHCb3XvMXuFd03UKnG99yhu+AsOdXEzWXWg5cO+oKMDsHAjhDooUWk5L99XD4svr6QbFOs6cGBbrxksZf7zPag4IVu11OSQRFvExJlJEdWPiyqBCBK5Y7o8W+0P2KH7hy+6kvqzNUB1s19zMC+djt2K9d/vpr24tf1NdHt992q8VQZmqu29wgEJGL3TPFbpjXnGow3UIT2U5ItNmwjZ5rWw3buLiuSIGSlW3TbnTYL9LYir3sS+gYetr+cz2ghIy4vVW6Lqb6kkndiV+fftz24Xjs9qWv9e/jCX7wsudCn2hSMLU22/j5C/PFRb1RRm9/Hy925BUgbYo7FU16134xY5iQFKoyLxRYlxG8GqMCvcTLg6EUujfvMEg2OToIYdfFsgQUrgTYh0dfoj9xoGq0fsNJgMVVHa30nXo/c/Evn/rS1WLPgT1AxXhOXhXzfPieK198dWfypsOz+JJJjz8HYzUo0H3buuJXzrDgyS+DPfWsE+uZZX3wydor/6QgcfrKRvHQw4btuGFSCs1ihddiRVJ6MLFl/Yyjt938ClDt0udUGVxZyS+Z1GO3z9m64/APmf8wH7vtudAz4PUT977/fYr2Ln09MsWL3y3tqlMOMCeJtuXa0zEPjBgi3WntEhk8sDUAbgsHxjgxRvZMglLBiz3FwdK4pFM8+GtIN1AYzuqAs0SMrHeCZbDdLLFGYLHLY7eja5OfvXjb5pfX5egysBRW9fUjMH1VPHbTyOoNmFMeu/0Zj92E1O2nYWGgCd1yQcSNivMnJ6HNGPjUSRHG+RsXhMtc8UoHsGz2ZOQOGOe3cwnYyEroDLbLADq02cB4S82GQSRJ0kjzsdv0a7ZfdOiVD/exm3ztXeSIm+67Fz/69Jkjk9ndD+rnjNRrf2ssGgTpgBVTBTleG2AQJTg6B9V4KYpOZSRlF1vV7mszLQr7eqWAGFOB19GlMcTTmDlhJDQ/Y60nsw0LrmxQG2cOtt3AEAe7NV3GT67uLv7x8d+/8AOS+jAoxOjpBDZWZe8R8I9nvHGyfenTj9+2trZ449p0us4NKGV1e+unJoaB9zxobJVIzDRrpOO1OWt5FhNliCfN81w61NiKXUxqT4ef4LMf0ehmrldeKxhBen7YDjdIVIxw5diDqSBa7NFP+M5VVb3dwPtosDikx25b8+mXHn7d1dce9LHbnmd0jCs+7rlPT/7J/fdokb/p6HS6pgiczAxABOBGdJZmcgc5s8XseIpyNtx1TyOK2Sl01c+uk6JTZkzJxEQtC1yajFokATQYdK1vuXVsD9Iyggp/psNOyqRry9Ytdw7IY6BvplkcW59+v+7Gf5ukfHCjvUEkA1tVDzEC9dLnxP+8/BYN9B28LtTo+iUSTZM5T7SZL/6jDsNue37KUWom2WxkLhTKdadXdpQsHVcoUcjSqmXQ6FOTPhBc6sGjWI6/AAafdmc7RAEuneKBI3ebTwlCPfzu6DQzXcxfs3XHxicf9LHbDRc6QUzaM/XJD7dn6unccu3ciZ5HW8FG92lo4hR+nHlrnFJb2FER3TqJAHliQhTyngceGnmMUdrIwbU8baUpjxr8nBCkLtUX18UMw+zF8caX/S3ybvw36Tn7zwD1JdXq7bI1ajeta7Hre+f+y9Xd6T/RzTmO1u3loRN+aQ5rfkbGNTM17/B5xwV0z0Ov8iAnspkovnVjgpllwURIjzjYik4JpJv+MT+jzfIOcOdH6tLXzn1yNdhzn1K16ahBgXbsMQ7Ku8UOdzB14fPLi5cc/ciDPHZ76IWeN+W21qc/fXE+eb8egfJ6Kj/o4lgiGGLK4OASCptbhhVVa0u0ilUGPfUpB0Q17bJTgwFtjLVtvdGFSbt2wFk+8arCaB9nYqlcyidE+cEn/4N9m+LsM8vn7F926fZTb776gtPPWr1uj3Hc777G69ivXfr3ujn3b7XY1zVher3us6UHejwPMS/MRcxLeKq5QcF8Nci00gUlMk8+mUOAwVkFhErHK/tVB2CwD11XkY53WAFhJW0BwwZ+ylbV2IBPTbkRP160+Hiz7sdu63rstj08dlu8Kl4+hpW99w+50HG80OeyP+Sd5y6o9Z+OEKou6R1QREh3WrDdgKs5HAlbZ0CHhvepWwZCQn/VwlZUORAioGsw7EuMKsjCNhyagjK7TEDiqDL2/olAW8TIbKeMZo2tZp8UkxX2sruuxb51fDq5fb67ePuV2059Cc87bWf1efYcvZtUOpkwtsfuufx113amd/m33RaLrRhz5tDjTOUhx1qbC7UZ6/oPWXtZnrPkt3Yyf4GlkcW6S3TPkyjmXXjyqKfTq/MxYhBIgBEGUowqyApTOtTYXuaXXumUDdUb2zt+7PbcnUNH7oLvm5zYfojykAvdevfE6/LdtcUPXpzPr810Vm+xE0XXFQeVzqojrDVY0EweLRrZtsziZtQGPKh0Fr3Sr8E2Ine9f+M0bLxUyDEu+0aXLeNCX+r5C5z20vnLfiFHr3QdvUMK0/Lkd9Dp/tyxo7PJay9+wskfar/UqsUu/ZuPccTylNx7XF8VOXL4zKU79YaaN/PRVg25vhMhJoU5oOlao4TOmBdzEXBDhXG2aBa5mPefVFwAV9sMGXMeYNN24UajzXsADbCu46ZlKuDhk/giBkkdmIPt88lRjX06yObW3loMUA7H/nxmz992m3ze1osO/6DRN3nsdtMkVKRzzuq33Hv/n8rbj+udckR/3eMQnNF5htdDnJ2E58HIAXFQQuZiZCAt5k016IXcgxDN4gwCo8RGFYV+VI3mIGK/IYrJk+Q6neXI0LaFwW71BV1s+gBlnJWTpw9r6FMb+sTf7on12ddc3dp8+6VPOPXZeXafs/DRzy6sqqURaI/dXjWZH51PP1eP3d6nq0fdo5v6026MuzcNOXVOZMxU7NvcumFEwGq+UPXraXyLCS5VmZiWt4ihJSuMyIcuJEVNL7oYzlzGhd2Q32XFDIjWSHzSqozFlm0n37alZtv12O3Q9Guv3XHoFTd77NacVxB71fLDO2/nF5956/Pk+62EyIiXMoEp42Nw0oBk7j5kBV4KyMwLG26HusBxOGxDl7q+Hmt20kfZg7Q/1YpLzSjEhPfQg91a6dM4MVVSD0KdLXnEibjrX/gideqAYi+x6KeTHZKUm5dXFpMfO7Y+f8X0jRc/gAsOmCx+2qty/Qi0x25njj9/TV9+ojGc6YYQl/bDpydTbTTPGtqiY24Eiob2UZg+MDHNNeVKiA5XutfZkollXtgiocivzIPOFvxWMgqqPo+QWyX1ogpftGVBVXVl4IdtJ7ftbaxPZls705ccvuvqz93osdtNz+jpiLfArp9817m3Kf5Xn5jxBvjxWV1RhecusKW+tqNm6wBjBOFLbYfPdUm69FndHYVh+xYNHbdu9DolAIcmbc1us6GG/S3rOYTBtkc4kc0Y/jmS2oa5Shni5t9su2YMNnjPAR/v1RuN/t7l7ek7L92++XXyMWOR21dc0re4mpOneKPuxJ+45/Kb57PFnRtkJ/NH5nSFMaw5ZD6g8wzaUMwXGGal5iysNFPRaGSoitxzXsp+k6Nn3Q5u2sE1GFbLP23HRUNN+ADh9Rh8dbgAd3FFKsqsj1q6Fa9Th+5EvHbrzmOf5Dvxezz92ddCx9Nrq1uLyb++rCj0v66OtsQnUG/iOTLt3NvosnnRpGdopjzB0Vf3xthAlCXGSiUkVKbxVwMCr/G7GFDjVbuxHs8wlf5tC44HF7BK2aERpB2akr9WImYWfLh2C3U+b62FzV15fQb7lF7ufM+V2zf/8OrzN7+SOOqG3e/FJf2+56A5fhI3arEfv/vKXXrb8dfp9TrjoxvAsR7a3IhJm40x9ZBoTz7Ag/ZY50EiFoeRgfWxwdgwZNUuz7CVdmy728HvfSIaY2MFot57FCagkf8SJa0K/bENM6wCv+yMMCJ0ItPFz2Rng2vu3fkvX/mbeuymNyNx9Zj2XZWznnfDtgzyM7k7Dzzzlh/fnM2+6tJirt/b4rVUn/6hrpVl29pJTTvRtEUMfLc6dwEGhwZ6NEeX7YYEAFArttvxjZO090uccbnN8UHxROBNi4adJicDiCp5qqBtlxpaDEuxBy8h5Zs3Ge0e1pcurGkydKZ/s+b5+46vX/wpJsRoTco9apzRHeiyD/+pXOplzpXPOPZ9RzdmL7+2Pd/S3OkmXRTPJXPI+Gdulczz4RmJ+TE/BtZcT3vmJxOW0K5RPsI2FOp72pWs+IWhHoyGB825o4yUs33cgqO2/cZ1I3bVN/tI3LI/kLqk2dYHYLgj//aNQ9deoNfsWzx24/6H5ez2W+TAr9Xvf+apj50tZn+olaK7yoyzIu4C7oPKHrTO9Dj7tWSIIE6+QUvUbNOGi+3W7nxa9hD0oFfRhS17kkFslgQHKiJjEkyxW8L1dNM3xhcasMKu4hKxKwt8Cs7nKJ3t9SWc0x85vrbx49M3feC95cNH4qdJ8bXDVyWX7KlUt7nQmF39a8ffcGRj8oXXdpS8Uz5bxFzV8Z9R1jB73D1nQWuw2gSoqTYMz/FI3xJPtc6omi8Dh5E2NvNq4Npgy5cb8ce6+BjrIY/ILXKuu2VgtGoc9urfmMcpbMLPPR3a2V788sZd174AC+jj50CXjVLwHXi+KVZWf+AEyz5fq3uUoJZKBYozO2U0VWgvb3Btx0cDbNc3z0rXInHSjm2pDV321DJddtNJegRlD5puK+EgSkfbfker6WI/wU+OKujIjegbnE53ABrKJdb6VV6/65Je2fqxx9cn335lvvWOK8/ffPXl52/+jcVfis8dcwfVcejz86yIJQAAKqJJREFUxyx8fsNdukO8veEnadvj/aro82/PLt+hRf6Ww2uTQxpw/2orecLQ17hE3sRgoOvx05iVXJLIAzEotk+DmUtSPE9UYwRpNrxRSTs9r3yWbXw7LoF0rIiYMl8wymb3YcuxosOWuTXECTZUGg/bxbPKYpqP3aafr8du/0Eqk0k+dsPXgYoM+6x+4eknP3Syvv5H+vKv07v6uQk5Ep9LY8ffgsH4Q/GQMzBg8oDrDkEgc/eqgwUIQdsXtjrd09g2MBoSBW2siCjpqtHBNZkKOiIOg5o4RNhZ9qfxb6MQIdupewidOpzh57K7od8rM+DKYvGn4r1BgNcfP3HoN6e/8YGLEUnspTebnMnn8nHWJ3C20XgH+smx5yDHge/SmeMfrqPdWw7PJk/jt+3VO70G9UhmRz0MLZeq956jNhs591pzYuW4ef0PiICEupRHZZlGKJ59uMq2Zzp9wTKGaSdiUlBFe729MpiJMX+8q8uWIW8z0hEsLDaWL+M3phvXtqavOPKfr36X78Q36QEa3ETiq5AvfNSt33ByNv3ui3qtrlj92QSGnjGUbyc0Zt3OAGk3V0Fo3xVRhcGWj9kSo1R8NXqdEKUeOlhj8bV2xoJ+HFAqBpZkDHwtwN6y8Y4Biy7NF1TJq126za9jkMfC2leMDTxwEurxrl9HTXWWX1uvRb+7eJ/G8bek8j+k8VvHtg79wfRtf34Jvb2KbM109LavyZ9XJHshn4C8a/pdst+aXL38Gcc+SW+J/x3uMum3Aa9pXPTBt2EuW89iFBpJY3neLfTUM6VZIq/MKBN5yB5Awkg20KVLXUrFu44e1BQ7oQ+Mwnb2B6FM3+jau/TsUxptQBaLQ/q8/9Zkfsfh123dNYJVfDerw1wsJD1bf/uR6eTj9Kuk+hgrHzNktNQBWQZXtiBrsHv97K1xxoQBq4c+Q3LdwMaUlPEY+BEPW4hzopq93h/yiivhsMxs+qLc1g6J8UbIfnpsvMAYaLC67L7GjDZd46VLDc79FKHjI4veHwfWUXPNd1Il5xdu9b1L/0+Q/yvAW3X/+ff1fPmdu2tr755PZh+49Y3nH8DOU6FcPXPy0/QTRr+m1+xK/Ri0Ub/Fuq4s8+JkHrBlGdz98JYxjfaU7t920wuV/fnufKTannocHAS9trX4gmU3pXbTWvpxB/5Zt3zhycXsDZcX8x2dHeFFcmeSk8515JJOJHd6Ldp1LmbaFTS2/E+85tqWV4dNhB2JoiwvarjYgE+dMFeFLYyZfQKIkXqB9167dJb2rIHxVro2mKE/ceyDtm7iGo0BC8KDmnWmVxg60+vNI36unM74XfcH5wsuYe+Txjn17pzq8+rqJV2nXJnNJjs6PqSXFt3Q4JsF9hTDV1k6g0By+7bVDhBglBF8RBSiq28m3yNqdVs91g/fThdXNDCfrn6+TofRy+oCjzIz6MGH+n/DMndPsotrAH1j+oZ4Cx7C3khxv7hSuhn+ZvKyQ91h/Q4jfb+Hxuq4xu7sHkPaaz50W6PLheauLuF/QZfwL/YlvN4wolSWiPykqFpaQOJ48aW0WwxW8I6JLUqNsJUWmVdsSM7Kz0Y4rAUMGz3XRtmIbZofRx+JO37DxZkY2+hXHK0OXPFTK6SFrzg6HTVLZbALDh1iMlb7spG68Okwr9e0vgXFI79WOp3OOLKyYQRFl6oh+vZetHlDXJAuN9O7mRwje2LKF8Js97i+7UA6O8B13f7gtcW7jv765WeVeFXffAT2GtabayVC4+4bc+c/5vSz1ndmfyBjR8Tj8MgtRttmPfWvg1EVJvzu4V0JK/GAgQZvO6qkokQ3JM6mwhYGvSrFM17MsIFuIKBphb2Ol/LwJ7FoMFJMkyJycYaW99nbwhKSdNoYZJ+aXt4AQrXZpxUFR9Vejlv8wtU4cABgjDLOtEGXC1nGMGteCdJNkYUb01ABbPGb4T6OfIz1ukBiPMp8HfgrGmzoP4NJ1NgWFHJ+y/6Q7mLee2T7ludNnnF2a/LHOo+dXNJtjlYNj4Bu3I6H82GMS70/WWf1r9dZ/d/oE26+MecE8BpnhpQT9uTc88JtrpYiENkWCBjozAIjLefk5uRuiy8WvYQh7xLLWs1bJjpGr8dE4kW+lX0jZZWLlJCkicEubFOhE3ZtS1zUcpSbhg8iecyyqqPvYsTgsNjRy6DCD7TMCoLtYQzKQsVRNFpgiya2whQ/3r8gyqVBozPJxeF1RbzsY0gTo6rNM2306sBH2/LMCmgX68bxaYiAYC2lw3NuWOou3L1HLl9+jt8BFuIensZWVT8C3VV9z95/W4Pt929vvvvc9+gbY3/n+HTGl1P4O7tjHtkrH7nk1HR40QtQk0+S0K5NEK+p4jsSmImJyELba91pECuFzLK+KupQC16j1Sg+ttzWjgZF0QYr1tHg19EHxnDtmkqycQoz+a2haF0iarG9yMuXRoQx6MbB4LQlY82c243GKtG6qyI82sZqx9poetjGJvySSQsDQ2EV2haWmA+g6IRd25Md93HQslHAxbIvaxZnXNuOWMQxlhAceeJYbQGs8RV/2a162cCKvuEI/IUXuiwz7LazNp9/jd4QgjOegLgVpE9PmjOmLWZJ+5aMYjkB4aFcBbptYBIXch0PTAvB0pGqlSGzWCKMIywmdRglEscQ5NAmSmCy6DrI4JYMuVEkfzTtPvlDO3EkMH4gaaML7XaE2PrX+wBDPwczDqrsE6Dk2qvQ5j/ee2/CgsCEDQNzVzGFHvo+AuHOIbj/2I5/+/TO0XeWsj/FQbliLh519dttrMouGx2wjocDMvqBCCzFvOQHZ7U/yAg8Egud2djlEv7Ee+7/P3o29M26hCcG7gi7ERNWcxbpEwke8wwY2pvnFLIWgY3EkR2giiyRftmyDbXNgu28p1Ee1XQpn+gXT412wCkuPOQkF0nP1lRCWBADy65UCtiWQgGrtt3ElR5dT5ceh8KgMzg2QiwVBM2DQ41OW0L3BeDfC8MasUPPkqEuafE9BlaPCyvNlliE0YqkKnJCgw0h+kkbC42QOKkESXJogzEuWEBU8DjwSxcJ9lfl4Y3AI7LQ7Tov4U+9+75/eXF38Zsn9ZlsTbEXu5PS0x4TyIQxgf0kVvg9j3afKMaIaeU275kWZcAqyhVwUaKlvf5HPh2XMPCBug7QcGAx7RNUYhQS195xFhpsCocJ3iKo2lhzYIoWIw5kMQ4WhSuJ8CYUGAT9Ai1deNW2soGBx50XpF9uIGDYMoZoaB+l7BS95xhI6P7FIjXUOFkpu9TwIvKMDWb2r8dhwHhVNQ42Kmao4C7jDW8xBhLSjU7XCoasdgcagUdsoWeS2p7e3vHVPGrT8x8u4fksO/ngSYoJJe895W3iasIrUUZSCcsG/L4NbdNKcvjkWdMlES2NBIsIQIc98FYIjPVCaicyE0UWhQu3Sjuj0aUFEctMTZilotpIALSbKAgz+52WAJiGs16c3RpMPOStz7TlVYMeQQnod1RTRwsrFVcssqTLpu2BAKlStt2q3ogPLuQRJ20Kjj2GQRYvxrV42NZWNgK0RMMc4SCCR1/cTJb5q92BRuARW+h4VSb4Ev7U2QvvFPW1PKnX5PXvRohkybSqRVOJYjR2MvE0r4GXlcLAM45J19Zj+kQpPnElzsawo+QcLRYgZT/hg19rs5NK+iRuYnAcNu8OWSd9lT7m0kJULS5sqZQN11hMnheqIiVWdJAHRo2OB96LLeVcUaCkTXqoSWAerSjYwYb7I1bF5DHIuKxDeNEwxE2cmQpt2wKXRSKXgCRRVQpLhi6i5bp8wmeLvqgzLeIyuKr3OwKP6ELHKY887tbNON2F/7EL8/lP6fW63s+x2EKkLad6aMUkx5SSALUJ0RZf8UhENmjkrrWrdljhVhRmkHNiGbKdNptlITSu9BPr5MIWDrwgAKiYp32/gMAQE7JoCqhG7aOZmI4/IMquOdJta0tm4+YY9tPgsOALbtMOCo7l+gJPWWG9owZL/+xE6n8YA4Rpu4vf4FQgmjbeYDATtmPZmQG//gBUSdtFWj8UtM9Ca5lnVswdIvSIs83FoF1WVvVNRuARX+j4O5PvKdw8df6lF+eLd+gnnfTxwnZzzuknmDOoFqNn2+k5WjROTmwy2Uy6J55JzwRARgk5OUGRVLao1eKSAgJbkEi8qd0KvJDSGBaDsZJQw7cCVlSso7rHN76YpQC8w4SN0g9cW3zWT39ooQeP+wKuMzYnvtp9DIZrQNOXFEsasdpWGByPgXiwG1pE+AqfLHb8FddoO+MlTesm8bX5Cixxq5Wa8NTkJU/DlU94yEoPfvkkR4LfxAVb1fscgUdloWs6eF2+Pn3bZEuZ8MV65DbXjXi+eorL+Jot1ZrAlgTFFiJmvC0uT/gSDwwsaUVCpDyqtCUiSudGPF/eStfYhgkkPPxhF44x2ehpFp4TFiZdqqUjCp3Sw0jaCpswstAsHKzyWfY4c8ILjFeC+9p4EiCDbjxYuSgli6Yaes+zcfjBIHq1wYPRF4+BLTF2qKrghapoU7FDvUxgP0sq2pm5FavliVMVhsXEbylTm26aYoykPXLVfqgReFQWOg41czs8cjv57vNv1eduv8qv18m3pYl0cJ48pY+mUU3NrfKjm9DgRTLQbsmyhEGnbFAHpdZyCb1Bm9ZAWVGBKI7BJ+0+CRVgiDP5y0Vhwr+UsMsWVQQjOpTDfgnxWTjLcaF/wsBe6pSueWXbNrodWHSsaQvNZ/Cwa9tjpeKhXxuI1m79xXJe1qedzlfMsvbEkPpulZ3qD3SLQIRp7VLHMTQ/FVxTWDX2OwKP2kIngHyL4vqJs+d/+uJi8T0nZzP9qpO/J835L0hOKVnFCbImfZjp6ogTgyNAHijAOomADvA4QIhGXrosEWOt0ukJAJ/N+LRTPBsZJ6vtpy3poqaSetHkICWECrE2UWtYFL2AN+Zbp3h0N9FicUaOMcIuMUh1NAbpr9PBXLhwIFwPSCX0mmg8BnYYO3zQErItWEuaUcmqB+Kx7FNk41YVozDIqm80zS+FTgJfplRVKQtZ21DJVvV+RuBRXegZgH9yRzfnvuHSfP4rer7Od35tkQn9ZIrMRRSXqy34pUkFd51eAw8NkrMoLxBe4+YJqPhCyFQkVEul1Cu+sUHYnnFqwWoLEZAxmAvCl/ZyDN6iZONTzVigxo53YNGpeCI8cdFyiWGKMRBKBZ2+NlO78RiEX+1tSVUpY4rpaDGhx1Z2bS8I6xIbm4ZUMNR8LjcCvQwnQ/J80bY/9PjrQQZ2CxsZOMcBvismbKljrpo3HYFHfaF7YnOS758ce7HeD/+OoxN9m6fO7HvNF1kXyeMZNiSSZ+iLbeb00yYxnF6ZQJYLXokitu04DC92J13w0JGBNGczjZANbNdGBK1dCjCrpBsOLBxVHLdx6T5wJrBTar0/eOVDgFwQQMW1LRC5sJCaKpyIgDXbHoMcl6YuOtz7dbuizVhtzSas7/jD5I3HII3WnKUJOlfuPCoZ6iCWNIMo3qDR+WxWBtQI17NX7RuPwKO+0HGtSffNuY86e/aqfrroc/TdaA9opbcPv3ThkRReej5dxBqzBSWKkw9sS5BKJSOGZC85deiVKgo+JthMj8uEAsCG56hFR0wlQRrFGKPcR3K5GS8MNQupo7EM3W9NjC9vHoXhLGsPoNJULSz3r7duTJgTe1igSxibUVxgUsVjVf7DQuwbDxtLdipWkLRjr6rD0UzcED4KNRIjNIIo6Nigd0aXaFUfcAQek4VOTJo035y79b3n36XZ+/wt7eScd87tMptMI/NJE3SbZIuGS7mSgUp8e90OL5lhxgwbTVpWKVpKcubLQyp8WZIHk2W70KiBs3178a5dYpYcDLZTJeFg4/IYnIoJ283IbHkYg5E/K2AXPbtVw5HYlm1D97zraOmJ536nHYeBX2JrPogdnF04zs6TmIgk9BZV6NoO4sBYv7MFH16IoYJwA3tZ3IeeTk+pW7BVfcAReMwWOnH55pzuxJ96z7nf1reW33E48stfXoGYTIgJzdxiwouRzUoEJ5x4pRMwGFFisRWlGltZ0OXy2hmuPdmX+rlIB3TZKX/Uyzx04Y1iwB9bFQGg9Q/OIvcl2/DVjCuCwFnTfBRU7FtV6VWNNXC1YAMdvuwoGWnGdsSCJGyOejEeapePskFt22HcJsCUvNpg4LrGg7aSNRthy05zOFKUgqhQDg94YaP0NQ9pV+VAI/CYLnQiq8W++d777tLz9Zfp5lxMrC7v3fDkulV8ckJtSHIpT75KvOqpGk6DqgMvNGBt0JaBMrLTtM1gl54wts3zdvTKRqfllVU0ddlvNsRjbaAbOJu0o7IHlg06pUADrz0yGGWbNlTxY+0BGRYVTy9AFQbd8uc2IglL3rDBEz8WO4CSlR5HheAuxZRYcOjpP3ERq/tnSVMHkPMaYyC7RmDfdsqRBTEPHWvVPOAIPOYLnfjqsdvm2XM/enGy+Kd6myxxkC5e7EOimOcFS1ZQOBNHzeIY7tA7mUnEUGbhVCJZH51m1xactcIIakEslpZkaQeom9oJLHFXktf7AtwXqfhsH7xhQRau/GX/WszC21fJrZ+2i0c9LCIUUI9/802kZ3VUEtuEgxyobaCpP/FgebMP5EaZZ10ZaTawUzT4MJcGEKYlj0G4srJtpziVcOtS/iDsXkPW8wL1QUnbcP0E3X/QRkyTvXN3vCf+uy/tTr5JZ3Z+jYQJ99mNBNA/ucfmVIQBHWMd6VKJNhp/FJYKemhQ20at7yH1MGXbqLMBNDZpTO7lr+fhQ3r2Az6ijL31nbfhx05gqhiBU5Ws3MA2MYx4hgc28T5YRTttpwDd6zE5BhKkfbXagc6tGAurdgFhqelYSNyOTwohtUONASVi4QAEjo4By5iavvT6tmMqW6GT8UoRmvddrcrBRuCDttAJ8ww34vRNsiffc9+/ujRf/IvN2ZRvqWUWPZMtc8xw0pAsmSeec0H078kXqCuAkFBbAYwbHRpeFkQs0MKg60v30OuQUgCctlF3BB2PJrZsL+Uke3l223xO9sOis62G8gFPYpWw7QpfFWcnUtMSWKMCNtXNF+FxKZBjT4L+yokWqBgs02jKhPml4hq7y7YzTrTVjJcAYEqxxik55ovnAFGAwdbh4gCBgWYFYlUOOgIf1IWeScajNy32c992YWfxLZzZ1QkmmLfLeoJVVXKSF43ntkkuj30gKBZZ01IMP2zYYQNUNQ3ayEN53Cpmn7DGodR0QpNFRAs+Ym+RwGJZFBo2ukyHDatLji3D0kfatl2QZbu0TOMklYrvGqFU2KDTFs0YD3E7nm3bFBqClMl+DMJk2LWhtI8dZM2XDRHWeH6GOONKAh94o5RtNd2fsmXhavewRuCDutCJOCfRi/3Ue89968X55J97sccy9Wt2EqybfE73zok+8Wwrl3ZhXWtHoY0v6yQvJBKgZ14JOJdxUo7kLG5lPLQ2VkBL6JGtIroafJBoZ1NWiMl87RMTNMyBZ0oBuVD1esGNvflaoF3sdiYd16ACU44HPcYBHPIGNg3lNYeSowAD1mMwjJ7VajzLp2vtKqbwqL14Opo3VxjEHj7UbEXthjHzYL8N2uw8lRsf9IXO4JM0qrzYN99z37fr22leoRt0nNmZYH6MsC6rPf8K2qkFkbqqIzdIMniVHG5HhpnX+JmcMoFz/EgJN9FGzwkrfm/PngXKUnFYv3By1Gh4dtD8ecG4P33i47cWCDplC90qdWlNkFWMTdv2JUHxBvs6azb/BJTx7cFDiLww9u8OefhkWrpgtFHKp3HB8r70mZfCVP/CRN7dHyzYL1h0Uye8sK/NTY3EqhxoBB4XC52Ic2JjsZ89/10P7C5eprfKcjueBd++aFIT3ud5lwCykCXystk017yUt2RSoqffUl2qlV3+jzN7qYvVnJF/JDAbfOx5g45YzbMO4CyNFrpiMK8Aqhs/9Cr5vSD6/lgFTOAGCxh0H/2y22ffwmAbcciDC93ZKmt2VQcNDhkZl6oBjh62yjkYj0kePKGb/QTZppjwS7dh1KBkFcSejEG0at14BB43C50QnRxxg2799HvP/ejVyeROVv6heAedfhjCmeV0IgFIM9VUrkmcSsiBF3LoBLfcsS47FqUq+6ctI5ZZFS7KbUGagqOC7+YfBnqhC2Wix48WQyDQwXUUt6Ux2EhRxgUqDdY4dLrhG93QB6Ix0WITqJmkv+kumKFgHji2YEXf7BMpMZSimbAcu/2hk+yHMQaDr3LBPFS7r6erS/d+OPbVflwt9IpYs+u3y26eve91Sp5P1fdQXdDn2fXe+PaVVM7kTKzIPfbRUnbkWSd5JG7ZdvI0XCR0yagliuRSg3bpxuIIkXlK+lowvY55qVt2+4Q1VrshIq9KrOE4F5ncqgV2dOk7CjCt48tG0yK2VcIW6y0LllXg18HEDlI9TIgwJHTQDnDaRh9eiIlQY4D3rojaawzKV0OilZotVvc+YoxojWEgjC5P468hbBZXjYcYgcflQifeegcdb5edb+8+X4/f/ujkVF9JpY+4IneOaKf/ls09j3SJBFI25pkBOnV9qYguPNdxtmoLG5wTljoxtmMLSP0M0EmYLFfYCumwt98QJHSQjVrd4naooDuNJCvxHVfqMwaDXxF9n+2/c8QCBb8cV1ugcZoGEz7CuEk3c0EyrEGrGjDZHByGKGLCZ9FGiIjQ3bA/Yq8brsEVBCX3nG4+btOWzjwuy+N6xGqxn37fA/dubmzedmmx+BV9eQXfP7er6Y47MiRADq06E3mRi5Z8jfzIs29IjTY/cTCW6eIhQGYl41gfg93Sk8gY7WIZSFC6xkDBywLOcgWJHLZxsQZhGG0ZK0qFXfGRshgMQpiNJheHBYM+GxBjRDAuSV5Xl37ptDpjQC+M2QY7ILDkL+zC80YPJaUkKOjkhW4oDjENz9+bPFyyzMValYczAo/rhU6H6u2y0z/5kwdPnj33+Rd3598b3yzrw/oOM+9Tj1KIZELHNckkHpfxJBE8tkqewokJ0gV5UT0OIbjipT/7gZd6tkS7DBa+MMjKjtsOVcZLwVEoBK6IiQW/Ia1Fa5+pa0D5MJYI0paV0c+4yx5jAS/NRwOd1BsLiot1QQIT/TWti+h8/e/rJ+Dxb/fYIr4+hsYLczkffS/w5GmIm4emHEe6R74qBx2Bx/1Cp0NKA37IcUaSbL7n3NdfmO9+tWZ9cTR+IMKX8uAqE5xlMIQXL5KNhAPis0Jc1gdEexmmtHSDTh4+R20jA0sCI+dgAjtVaGYCJzMFvX3HsoxDUwVZfDhFLagqnZ10yJIF4K7D02aFvvYYCClBjIGr8FOmXYcSZqLQGijzsFVs+s1VVPGwHyAaDEEUMdsYFs+BtvEb9EojbJXFMBWjLMRSTM3mqnHDEXhCLHSi11T7Ul1zvH7qPff/xM508fwri8k7dXY/pATg8RtJXKVSwbV2glSuZfIEs3AA3EaaiMbDKPBKMOSRyHF2DFMTHgX67CUcyR86rhw/LKlGsYFMdDj2mzS2wTomNUItVU032wghmt2kR7FjG3ts0Qc46PkQFXuR5hrUjQG6e9kPC0MfhQnV0OUmHfHDS28tpsRZtzDEDS5ouh4HiohJGvEPbFUexgg8YRY6fXMi5B35W8+ef8vmqfued2E+efXJNX4kYqJfgNIXTyoh+qSIRJEufBXTqkWqOdS0rbvEI/HQKT0SuBI/XOWjKxF1A8m2hp1vLJVOscteBuLoHJNbgYL25qxnzSTfC8/ht/5U7EIYh15vG0364rrHwCgu7Szo24Zo9z/HATF09QfVwnmUcoHCr1Jy1+yW4oCu8ShM6BoocRz4zBNgVQ4+Ak+ohV7da6/b9b3xp87e95X6kYiXKfF2jvP1VPEts85SMtCJk4rcLCrayaoEqqSDb1kAtA9d872wIsG9L6Eh2iHPK9XRYrcV3yOOlvZgbbP8pS14NImrYoKmOFa/Fo7HhtDVt/QXCyW8GF96hbMh7cp3yVlElikw2qYNiih6PO2yQ01fKlbJsO0d3yEPtOhoIIyCneUNDDwQ2uWVEaRZ5oX2av9wRuAJudDpqKa/Xrev8bn2xXTtufpK6d/WIzi+i47sGN5NJ0JJFCkTGVY5Ja74XjZuOtm8cIP0XsZ8BgvVMGNBWIkzPjZoWUwdRbZGCWxupwcdZODbXkwEVYiBlTXwok3sanUO2yKyameiTIVD4u2K7SeNPTrT8yxCQxvyTjXAYoMHwipeLhJYp9lMTNHLNku/n5vireqDj8ATdqHTVSUJH3rJH3b883eeOnvuUy/tLr4Jmd5gw/fRcSlfr+0FdZJGomaiRYJVuoGw3XZpCg0GhLM/TODbC6wStGrArS1dDXCQuSBtB564lPLc2w5J7tMeRny2lQZ12BFrgInViLbo0LM3NfqrDdvLxWdMRSKiiv0lDaZiJ1bir9jdTFzjWZmQdLHjpR/3A8oOPpbt2GYbmYiibFdtbvoKxGq/nxF4Qi/06mBeyvPFFVM+274zWdx+ebH4Xd2o21Cq0cd47a4GqafSUoX0cxIll0QtmkSEtkbuODONeJLCQ6wVFXhrmGVbvK4Pcdgqg+iVrs2nLVXDopL5Pg7LaplVaBhkG6qiHURIZLRbRPSBDT34VANOHBd37LqXEj22dMwb+lN34zFq24wNmD4GdOHVGDieZBqbMXpciSJlrle7A43Ak2Kh02MlCZ9ym/AzUL5Rd/bcJz8wn79SOXxNH3tlwWv9BwacC6kT6eOEhEfSkXB90l2XnOR/6qFjrGhU5c/6kbySiN2dSX1UMZNdFesGMdjC7FAEaXHRxn/4KxwsIPCDx8qqQrOE8ApjfwkatbWw+n737YTbSG+n3NH37HP0V2s8cA47FrYPMc2SbRVlrHahA9eRuxZvVR7GCDxpFjp9J1Hr7A59+uz575yvzfXaffL6E/r55iP+UosFH47JxMtkyuyJRLcVJ9mQaFaobLMf7HtV2wRU0ENShg6LD4u4yA073uAnG1suqpBZQrs2LzQwAaAV2m4EoRXk5ZN2I87USTi2R0sMczaZuNI1Txa4gekoUVRnqg0ODHE5NhyolH7HE4sh0H9ffB/UAh9UrbcUA77wiR/7ssveyKq93xF4Ui306rSSxj8Dxdn99J/q7bPvvu9vXVpM7nhwoffLz2Yb+tyr+h0LPnW0REhq0pE92RVnNLMaKBK7/CCrRCRRoZ3galDgQYMJTvAAUsCrsoy2DZhtsXe2l1hjwOWGfXlIDdZgHFQwPMLghOVNLGrasBqJg9GswKN0VgnfPuGjXzGBKXvmJ126CENFrfhTxWt2UyEUA93aSsN17vAXvuKKpZet2vsbgSflQqfrJEae3XlH3ZoW+116C+1zH9idf6Nux19gwQfMP/poFVKwkprcoi0G/zI3lEpKJ6zYJGKCnPjGa0cJXUcjyuYiW1PHoGHnxd7ItFGJXv7KF7iw7AiamvmOaMQy0WwoNGIrOuIMPO1hy8XFUsthGGShb13t+rjMw5waNaaQWGn7PWJsesZ1u7SPvVU5+Ag8aRd6DYUSK+7M6x11au/qcv47Zltbz76wO/9+Jc2c1++J3XYOOdPI8yjSGaWjF79E1y8tMa3bpWJa0fL2GYlLa/SCXQvIerASHbbxa98SuDRbiROtf0GiVJwVH1z7EoM2WG9Jw1MhHgvZ03QJcCOLPdR4i7vowcuzNMRgb4BjzxqSagwGRw7NOsQKppRML/PqMNhQhV7VNxuBJ/1CrwFQEvHcffp7/Gb7+y69/9TZ8y/XIeB5F+fzn1R6TblDn/m4HYmYSSgDTkCETry2WEm7ASScc1888GyooBMssjgWNzwo7YaSBDpmGpGLM3kYanJA6CQO0n69jvIgApMCri8dzU0zSO+icvyGJ676gx2/pJFFDl4mFVPvwDzBSgeadsYuE355YQ4y/9sZFiPI4A/tng7uan/QEXjKLHQGhoT7K2+ccOaeseD1azF/sHn2/FfpTerP0xn+JyWfcEmf2edn8CRmJZrfnCYMNLawSYE2xjuRqqMZcgm9KNAJe7YpIR5DZiL1Sxc9AH1Z5hW2MF5I9ocPwqQMZ9+IQSwsD8qBu85b4lRVsYp29lOHB9M5BgLiA9vGiqZOv67jjryaEkShybFRqqE0SLAkCrYOsRFnqa3qfY/AU3rglDwc6PjtN95FN7n4zFs/fr5YvFL0l/O5d/1klJ7HLXxg0FLxp+c475B0ZDNFFdflSQWvBMg6jpqkc5zRENiWdDsclpzx9lHKAhSm+LVMoJGZr0YV40MpuVqaBJA8KusGDdvBmuz6UzgDynjVOpRQ0gSBY2ZUKs4xM44QCbaRGIRogkWP+Nyu/ull2OHZZKaPK957dHHxOXkPJlRHDlbE8gg8pc7oy51XFvH6vd5Ku37yXefefurd5796d23xHL1//rt3FosPnNBbavVx2DUtb30z8QJsFmd1kOwHQSS+aGUqS6Hb8q54ojkrlh44/3spWokFH1bZawtMokJiX/CNXeKlwmAnIiOgRMomytWlqsVLfsOh0+JpuBgD9wMetjrbZi2NgVWx5ePl0KeMSC6IhlUeY1U+qYfRspXV7gAjwKiuSo6A8nR0hl989OnTl3amf0cZ9vePzSa3rSkB9Y47vZXUj+aMFaudUchzkpG6H1Qna3KMIb87OrCDlvEw4wwpQfgwQkLkhTY2FLRPWRcTvOFMa7fWfQi9sh/mBAR7I3+AANDtWPDeN7zlARn12f5TF9uiVWwimmrTIHaw6T/O6Aud0SerM7qHbJ+7HNR9op8iMCXVaMHT7fufeevn6Cz0UqXdF+mno47pEp9Fz1lGJ37hp9aJ8dS+krPqWAwtYXNxdGdWTlh5fh8S32cxnyiJobcFTYFHXQvCbbGNHS8ScQ0NLY416a/pSKlKs4uLZX4I7aPwxDzgws+yfeSc8YcDD0oEElY40UP7XC4WNn0AGSyvFnoN+AHrHOIDaj1F4E5ePYPXIPk1PN2+/FEf+vT5dOdLFovZV0jwKcf0Cp/31ur1PGcgvwwQjNf9bfFFwg4JLpnPUNSR6ZHQTnuxyHQSHH9ZioHZKEPLJvrFA6BsJ7pbNKwlCq5Z+dHL2Ice7USpqTIsNJNtJ0v4KV3z03p1LW21/hqbeuAtD3BnKrS8yJszXNVr9KnO6BdWr9GHsblpq03LTZFPcYBSjx+SINv8nnra5z/y9O3ra7MX6wXniyW87dhspu9QW0yuROrzmI7x5QsxPM59krcEF6DOxpZjWOtPCgVRLdaYYXthdVhsQK5b8HHESPXwhT3Mh0k1JeXwYjakfQ8+k28FQF1g7hn4ZR46o4NVsy6wtOrMXr6sn7GmLkebtBsv6BXm/NB0srY1WS10xuggpRv+g6g9dbFKyHhtrgVfScpo3P+sUy9cW6x9kR4dfeFssnjhibWZ1v5ick0KW7qRpyTdVeaTuZztvUD6xeG1JjvwsCeaxQcxwFggosVoELdtLZghGdqJ9xUB3DJm62mv0HWQkA4F580fejBhVMG229HoJID9uib14yAiYnRAQM2Lnrq6HFa41EiHaStC0aX7dLY1X9x7dLZ6jV7zsJ96NDn7UVhhhhFQMs4mZ7Rw7xku7ZE+8LGbz57N1z5TWfy5yuFPVXJ+hM5ELteU0luxgn2gwIZESL1cSXiAXijJo9LBg9y3dMDsvdBkwNhaRNbTrlvITV6y3l/pW5aLnWffyY/Fu3SQAFv2yyY9QaddLTQadhTL3fPr6dK12BqLXOi6GTdbXbrXGO6nbgO+H/AKc+MReI0u7V9yRgl8z/hM//6nPe3EkaM7t2ulfrqW36cJ8QK9F/fpemTnVcBPTm1JoIf13IniZYHPpN6LxaIGarCYrXSLw7ycSVWxiNFjke2BMx+Davgxl5C1GGnaZ2dHRyLz5EfmomC32RHL7fRFO2Gu+hh8QOl0C9tjUHJIhJeGArdY+IzOXffVQs+R2V+l8VuVR3oElJw+02vRszDaa3r8/NmHfdjxk0cefM7ubO0Ttcg+UdjbxX62Fv+HHPUtPFFS4gDAW/O4u6dFqK9h8zfliPIiYCXF3MVhgUUXPDVa22DTtVDhmCHMwENHV9r9YqsFn3Bsc+kx6CDAZbe4HVP4N27w0aINLQkogzzbnS3EDB4Yg2FMF3qNPl3Ty6F7j60Weg3Lvuoc8n1hV6CHMQKZ4ix8zvbXLXxMPvCMzVvna7NnrU+nz5nPps+dLRbP0eL+GJ3KP1LiD9F7co8cZqY8W+xa7nv1cyTRs/12JNBlditCG1yLGJqY4owpLz4xY7oWup2YDn824AOJjeZiL7vipa3AJeZ6/+p6HTxKt2ICXLxsRBDF1wGATsj1rs7oa9fmWuhrq0t3xm2/pQ3ofhVWuL/YCLDIZCEWPqaWLvV76+99+tOP3XL4ytO2JvMP0939j5jPtfCniw/X6f1pOhh8qCzdIvxp2dRncqYntFT1S9OTw9oOic+n9UZn4Fpo5QO5oxEj41J0saRSBFGrkMUedPLoCHplp7WRUwC0klLTgxm4hSv7HABoWwZeRJqa64A30z2Oe4+uFnob2f00/j9PWtd6TGuK/wAAAABJRU5ErkJggg==
+      mediatype: image/png
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: true
+    - type: AllNamespaces
+      supported: true
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+        - name: gko-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+            template:
+              metadata:
+                annotations:
+                  checksum/config: 85cabf012524755bae823259499bbbcc3765e2ab754c34499e634904d460b3c5
+                labels:
+                  control-plane: controller-manager
+              spec:
+                securityContext:
+                  runAsNonRoot: true
+                containers:
+                  - args: []
+                    command:
+                      - /manager
+                    image: docker.io/graviteeio/kubernetes-operator:4.11.1
+                    imagePullPolicy: IfNotPresent
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    name: manager
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 256Mi
+                      requests:
+                        cpu: 50m
+                        memory: 128Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      readOnlyRootFilesystem: true
+                    volumeMounts:
+                      - name: tmp
+                        mountPath: /tmp
+                    ports:
+                      - containerPort: 8081
+                        name: probes
+                        protocol: TCP
+                      - containerPort: 8080
+                        name: metrics
+                        protocol: TCP
+                      - containerPort: 9443
+                        name: webhook
+                        protocol: TCP
+                    env:
+                      - name: ENABLE_LEADER_ELECTION
+                        value: "true"
+                      - name: RECONCILE_STRATEGY
+                        value: onSpecChange
+                      - name: LOGS_FORMAT
+                        value: json
+                      - name: LOGS_LEVEL
+                        value: info
+                      - name: LOGS_LEVEL_CASE
+                        value: upper
+                      - name: LOGS_TIMESTAMP_FIELD
+                        value: timestamp
+                      - name: LOGS_TIMESTAMP_FORMAT
+                        value: epoch-second
+                      - name: PROBES_PORT
+                        value: "8081"
+                      - name: ENABLE_METRICS
+                        value: "true"
+                      - name: METRICS_PORT
+                        value: "8080"
+                      - name: SECURE_METRICS
+                        value: "true"
+                      - name: ENABLE_INGRESS
+                        value: "true"
+                      - name: INGRESS_CLASSES
+                        value: graviteeio
+                      - name: HTTP_CLIENT_TIMEOUT_SECONDS
+                        value: "5"
+                      - name: ENABLE_WEBHOOK
+                        value: "true"
+                      - name: WEBHOOK_SERVICE_PORT
+                        value: "9443"
+                      - name: ENABLE_TEMPLATING
+                        value: "true"
+                      - name: NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                hostNetwork: false
+                serviceAccountName: gko-controller-manager
+                volumes:
+                  - name: tmp
+                    emptyDir: {}
+                terminationGracePeriodSeconds: 10
+      clusterPermissions:
+        - serviceAccountName: gko-controller-manager
+          rules:
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - validatingwebhookconfigurations
+              verbs:
+                - get
+                - update
+              resourceNames:
+                - gko-validating-webhook-configurations
+            - apiGroups:
+                - admissionregistration.k8s.io
+              resources:
+                - mutatingwebhookconfigurations
+              verbs:
+                - get
+                - update
+              resourceNames:
+                - gko-mutating-webhook-configurations
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              resourceNames:
+                - gko-webhook-cert
+              verbs:
+                - get
+                - create
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - apidefinitions
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - apidefinitions/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - apidefinitions/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - apiv4definitions
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - apiv4definitions/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - apiv4definitions/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - apiresources
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - apiresources/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - apiresources/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - notifications
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - notifications/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - notifications/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - managementcontexts
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - managementcontexts/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - managementcontexts/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - ingresses
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - applications
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - applications/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - applications/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - subscriptions
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - subscriptions/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - subscriptions/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - groups
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - groups/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - groups/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - sharedpolicygroups
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - sharedpolicygroups/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - sharedpolicygroups/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - gatewayclassparameters
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - gatewayclassparameters/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - gatewayclassparameters/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - kafkaroutes
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - kafkaroutes/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gravitee.io
+              resources:
+                - kafkaroutes/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - gatewayclasses
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - gatewayclasses/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - gatewayclasses/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - backendtlspolicies
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - backendtlspolicies/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - backendtlspolicies/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - gateways
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - gateways/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - gateways/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - referencegrants
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - services
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - serviceaccounts
+                - namespaces
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterroles
+                - clusterrolebindings
+                - roles
+                - rolebindings
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - httproutes
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - httproutes/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - httproutes/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - autoscaling
+              resources:
+                - horizontalpodautoscalers
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - nonResourceURLs:
+                - /metrics
+              verbs:
+                - get
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - services
+                - endpoints
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - subjectaccessreviews
+              verbs:
+                - create
+      permissions:
+        - serviceAccountName: gko-controller-manager
+          rules:
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+  customresourcedefinitions:
+    owned:
+      - name: managementcontexts.gravitee.io
+        version: v1alpha1
+        kind: ManagementContext
+        displayName: Management Context
+        description: Connection settings for a Gravitee API Management console or cloud
+          environment. Required for any resource that syncs with APIM.
+        specDescriptors:
+          - path: baseUrl
+            displayName: Base URL
+            description: URL of the Gravitee API Management REST API.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: environmentId
+            displayName: Environment ID
+            description: Target environment identifier.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: organizationId
+            displayName: Organization ID
+            description: Target organization identifier.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - path: conditions
+            displayName: Conditions
+            description: Latest observed conditions.
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+      - name: apidefinitions.gravitee.io
+        version: v1alpha1
+        kind: ApiDefinition
+        displayName: API Definition
+        description: Defines a v2 proxy API managed by Gravitee API Management. Supports
+          plans, policies, rate-limiting and backend endpoint groups.
+        specDescriptors:
+          - path: name
+            displayName: API Name
+            description: Human-readable API name.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: version
+            displayName: API Version
+            description: Semantic version of the API.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: description
+            displayName: Description
+            description: Short description of the API.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: state
+            displayName: Desired State
+            description: Desired lifecycle state (STARTED / STOPPED).
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: local
+            displayName: Local Mode
+            description: When true the API is managed locally without syncing to APIM.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        statusDescriptors:
+          - path: conditions
+            displayName: Conditions
+            description: Latest observed conditions.
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+          - path: id
+            displayName: API ID
+            description: Identifier assigned by APIM.
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - path: crossId
+            displayName: Cross ID
+            description: Cross-environment correlation identifier.
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - path: state
+            displayName: Observed State
+            description: Current lifecycle state reported by APIM.
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - path: processingStatus
+            displayName: Processing Status
+            description: Reconciliation processing status.
+            x-descriptors:
+              - urn:alm:descriptor:text
+      - name: apiv4definitions.gravitee.io
+        version: v1alpha1
+        kind: ApiV4Definition
+        displayName: API V4 Definition
+        description: Defines a v4 API (proxy, message, or native) managed by Gravitee
+          API Management. Supports listeners, endpoint groups, flow execution,
+          and plans.
+        specDescriptors:
+          - path: name
+            displayName: API Name
+            description: Human-readable API name.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: version
+            displayName: API Version
+            description: Semantic version of the API.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: description
+            displayName: Description
+            description: Short description of the API.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: type
+            displayName: API Type
+            description: API type (PROXY, MESSAGE, or NATIVE).
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: state
+            displayName: Desired State
+            description: Desired lifecycle state (STARTED / STOPPED).
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - path: conditions
+            displayName: Conditions
+            description: Latest observed conditions.
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+          - path: id
+            displayName: API ID
+            description: Identifier assigned by APIM.
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - path: crossId
+            displayName: Cross ID
+            description: Cross-environment correlation identifier.
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - path: state
+            displayName: Observed State
+            description: Current lifecycle state reported by APIM.
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - path: processingStatus
+            displayName: Processing Status
+            description: Reconciliation processing status.
+            x-descriptors:
+              - urn:alm:descriptor:text
+      - name: applications.gravitee.io
+        version: v1alpha1
+        kind: Application
+        displayName: Application
+        description: Represents an application that consumes APIs in Gravitee API
+          Management. Supports metadata, settings, and member management.
+        specDescriptors:
+          - path: name
+            displayName: Application Name
+            description: Human-readable application name.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: description
+            displayName: Description
+            description: Short description of the application.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: domain
+            displayName: Domain
+            description: Application domain URL.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - path: conditions
+            displayName: Conditions
+            description: Latest observed conditions.
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+          - path: id
+            displayName: Application ID
+            description: Identifier assigned by APIM.
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - path: processingStatus
+            displayName: Processing Status
+            description: Reconciliation processing status.
+            x-descriptors:
+              - urn:alm:descriptor:text
+      - name: subscriptions.gravitee.io
+        version: v1alpha1
+        kind: Subscription
+        displayName: Subscription
+        description: Subscribes an Application to an API plan in Gravitee API Management.
+        specDescriptors:
+          - path: plan
+            displayName: Plan
+            description: Name of the API plan to subscribe to.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: endingAt
+            displayName: Ending At
+            description: Subscription expiration date (RFC 3339).
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - path: conditions
+            displayName: Conditions
+            description: Latest observed conditions.
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+          - path: id
+            displayName: Subscription ID
+            description: Identifier assigned by APIM.
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - path: processingStatus
+            displayName: Processing Status
+            description: Reconciliation processing status.
+            x-descriptors:
+              - urn:alm:descriptor:text
+      - name: apiresources.gravitee.io
+        version: v1alpha1
+        kind: ApiResource
+        displayName: API Resource
+        description: Defines a reusable API resource (cache, OAuth2, LDAP, etc.) that
+          can be referenced by multiple Gravitee APIs.
+        specDescriptors:
+          - path: name
+            displayName: Resource Name
+            description: Logical name of the resource.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: type
+            displayName: Resource Type
+            description: Type of the resource (e.g. cache, oauth2).
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: enabled
+            displayName: Enabled
+            description: Whether the resource is active.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      - name: sharedpolicygroups.gravitee.io
+        version: v1alpha1
+        kind: SharedPolicyGroup
+        displayName: Shared Policy Group
+        description: A reusable group of policies that can be applied across multiple
+          APIs in Gravitee API Management.
+        specDescriptors:
+          - path: name
+            displayName: Name
+            description: Name of the shared policy group.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: description
+            displayName: Description
+            description: Short description of the shared policy group.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: apiType
+            displayName: API Type
+            description: Target API type (PROXY or MESSAGE).
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: phase
+            displayName: Phase
+            description: Execution phase (REQUEST or RESPONSE).
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - path: conditions
+            displayName: Conditions
+            description: Latest observed conditions.
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+          - path: id
+            displayName: ID
+            description: Identifier assigned by APIM.
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - path: processingStatus
+            displayName: Processing Status
+            description: Reconciliation processing status.
+            x-descriptors:
+              - urn:alm:descriptor:text
+      - name: groups.gravitee.io
+        version: v1alpha1
+        kind: Group
+        displayName: Group
+        description: Manages user groups and membership in Gravitee API Management.
+        specDescriptors:
+          - path: name
+            displayName: Group Name
+            description: Name of the group.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: notifyMembers
+            displayName: Notify Members
+            description: Whether to notify members on changes.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        statusDescriptors:
+          - path: conditions
+            displayName: Conditions
+            description: Latest observed conditions.
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+          - path: id
+            displayName: Group ID
+            description: Identifier assigned by APIM.
+            x-descriptors:
+              - urn:alm:descriptor:text
+          - path: processingStatus
+            displayName: Processing Status
+            description: Reconciliation processing status.
+            x-descriptors:
+              - urn:alm:descriptor:text
+      - name: notifications.gravitee.io
+        version: v1alpha1
+        kind: Notification
+        displayName: Notification
+        description: Configures notification settings for Gravitee API events.
+        specDescriptors:
+          - path: eventType
+            displayName: Event Type
+            description: Type of event that triggers the notification.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+          - path: target
+            displayName: Target
+            description: Notification target (e.g. webhook URL).
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+        statusDescriptors:
+          - path: conditions
+            displayName: Conditions
+            description: Latest observed conditions.
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+      - name: gatewayclassparameters.gravitee.io
+        version: v1alpha1
+        kind: GatewayClassParameters
+        displayName: Gateway Class Parameters
+        description: Parameters for the Gravitee GatewayClass when using the Kubernetes
+          Gateway API integration.
+        statusDescriptors:
+          - path: conditions
+            displayName: Conditions
+            description: Latest observed conditions.
+            x-descriptors:
+              - urn:alm:descriptor:io.kubernetes.conditions
+      - name: kafkaroutes.gravitee.io
+        version: v1alpha1
+        kind: KafkaRoute
+        displayName: Kafka Route
+        description: Defines Kafka routing rules for the Gravitee Gateway via the
+          Kubernetes Gateway API.
+        specDescriptors:
+          - path: hostname
+            displayName: Hostname
+            description: Kafka hostname for this route.
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:text
+  webhookdefinitions:
+    - type: ValidatingAdmissionWebhook
+      deploymentName: gko-controller-manager
+      containerPort: 443
+      targetPort: 9443
+      generateName: v1alpha1.gravitee.io.apidefinition.validate
+      webhookPath: /validate-gravitee-io-v1alpha1-apidefinition
+      admissionReviewVersions:
+        - v1
+      failurePolicy: Fail
+      sideEffects: None
+      rules:
+        - operations:
+            - CREATE
+            - UPDATE
+            - DELETE
+          apiGroups:
+            - gravitee.io
+          apiVersions:
+            - v1alpha1
+          resources:
+            - apidefinitions
+          scope: "*"
+    - type: ValidatingAdmissionWebhook
+      deploymentName: gko-controller-manager
+      containerPort: 443
+      targetPort: 9443
+      generateName: v1alpha1.gravitee.io.apiv4definition.validate
+      webhookPath: /validate-gravitee-io-v1alpha1-apiv4definition
+      admissionReviewVersions:
+        - v1
+      failurePolicy: Fail
+      sideEffects: None
+      rules:
+        - operations:
+            - CREATE
+            - UPDATE
+            - DELETE
+          apiGroups:
+            - gravitee.io
+          apiVersions:
+            - v1alpha1
+          resources:
+            - apiv4definitions
+          scope: "*"
+    - type: ValidatingAdmissionWebhook
+      deploymentName: gko-controller-manager
+      containerPort: 443
+      targetPort: 9443
+      generateName: v1alpha1.gravitee.io.application.validate
+      webhookPath: /validate-gravitee-io-v1alpha1-application
+      admissionReviewVersions:
+        - v1
+      failurePolicy: Fail
+      sideEffects: None
+      rules:
+        - operations:
+            - CREATE
+            - UPDATE
+            - DELETE
+          apiGroups:
+            - gravitee.io
+          apiVersions:
+            - v1alpha1
+          resources:
+            - applications
+          scope: "*"
+    - type: ValidatingAdmissionWebhook
+      deploymentName: gko-controller-manager
+      containerPort: 443
+      targetPort: 9443
+      generateName: v1alpha1.gravitee.io.apiresource.validate
+      webhookPath: /validate-gravitee-io-v1alpha1-apiresource
+      admissionReviewVersions:
+        - v1
+      failurePolicy: Fail
+      sideEffects: None
+      rules:
+        - operations:
+            - CREATE
+            - UPDATE
+            - DELETE
+          apiGroups:
+            - gravitee.io
+          apiVersions:
+            - v1alpha1
+          resources:
+            - apiresources
+          scope: "*"
+    - type: ValidatingAdmissionWebhook
+      deploymentName: gko-controller-manager
+      containerPort: 443
+      targetPort: 9443
+      generateName: v1alpha1.gravitee.io.managementcontext.validate
+      webhookPath: /validate-gravitee-io-v1alpha1-managementcontext
+      admissionReviewVersions:
+        - v1
+      failurePolicy: Fail
+      sideEffects: None
+      rules:
+        - operations:
+            - CREATE
+            - UPDATE
+            - DELETE
+          apiGroups:
+            - gravitee.io
+          apiVersions:
+            - v1alpha1
+          resources:
+            - managementcontexts
+          scope: "*"
+    - type: ValidatingAdmissionWebhook
+      deploymentName: gko-controller-manager
+      containerPort: 443
+      targetPort: 9443
+      generateName: v1alpha1.gravitee.io.subscription.validate
+      webhookPath: /validate-gravitee-io-v1alpha1-subscription
+      admissionReviewVersions:
+        - v1
+      failurePolicy: Fail
+      sideEffects: None
+      rules:
+        - operations:
+            - CREATE
+            - UPDATE
+            - DELETE
+          apiGroups:
+            - gravitee.io
+          apiVersions:
+            - v1alpha1
+          resources:
+            - subscriptions
+          scope: "*"
+    - type: ValidatingAdmissionWebhook
+      deploymentName: gko-controller-manager
+      containerPort: 443
+      targetPort: 9443
+      generateName: v1alpha1.gravitee.io.group.validate
+      webhookPath: /validate-gravitee-io-v1alpha1-group
+      admissionReviewVersions:
+        - v1
+      failurePolicy: Fail
+      sideEffects: None
+      rules:
+        - operations:
+            - CREATE
+            - UPDATE
+            - DELETE
+          apiGroups:
+            - gravitee.io
+          apiVersions:
+            - v1alpha1
+          resources:
+            - groups
+          scope: "*"
+    - type: ValidatingAdmissionWebhook
+      deploymentName: gko-controller-manager
+      containerPort: 443
+      targetPort: 9443
+      generateName: v1alpha1.gravitee.io.sharedpolicygroups.validate
+      webhookPath: /validate-gravitee-io-v1alpha1-sharedpolicygroup
+      admissionReviewVersions:
+        - v1
+      failurePolicy: Fail
+      sideEffects: None
+      rules:
+        - operations:
+            - CREATE
+            - UPDATE
+            - DELETE
+          apiGroups:
+            - gravitee.io
+          apiVersions:
+            - v1alpha1
+          resources:
+            - sharedpolicygroups
+          scope: "*"
+    - type: MutatingAdmissionWebhook
+      deploymentName: gko-controller-manager
+      containerPort: 443
+      targetPort: 9443
+      generateName: v1alpha1.gravitee.io.managementcontext.mutate
+      webhookPath: /mutate-gravitee-io-v1alpha1-managementcontext
+      admissionReviewVersions:
+        - v1
+      failurePolicy: Fail
+      sideEffects: None
+      rules:
+        - apiGroups:
+            - gravitee.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - managementcontexts
+          scope: "*"
+    - type: MutatingAdmissionWebhook
+      deploymentName: gko-controller-manager
+      containerPort: 443
+      targetPort: 9443
+      generateName: v1alpha1.gravitee.io.subscription.mutate
+      webhookPath: /mutate-gravitee-io-v1alpha1-subscription
+      admissionReviewVersions:
+        - v1
+      failurePolicy: Fail
+      sideEffects: None
+      rules:
+        - apiGroups:
+            - gravitee.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - subscriptions
+          scope: "*"
+    - type: MutatingAdmissionWebhook
+      deploymentName: gko-controller-manager
+      containerPort: 443
+      targetPort: 9443
+      generateName: v1alpha1.gravitee.io.group.mutate
+      webhookPath: /mutate-gravitee-io-v1alpha1-group
+      admissionReviewVersions:
+        - v1
+      failurePolicy: Fail
+      sideEffects: None
+      rules:
+        - apiGroups:
+            - gravitee.io
+          apiVersions:
+            - v1alpha1
+          operations:
+            - CREATE
+            - UPDATE
+          resources:
+            - groups
+          scope: "*"

--- a/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_apidefinitions.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_apidefinitions.yaml
@@ -1,0 +1,1881 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    gravitee.io/operator.version: 4.11.1
+  name: apidefinitions.gravitee.io
+spec:
+  group: gravitee.io
+  names:
+    kind: ApiDefinition
+    listKind: ApiDefinitionList
+    plural: apidefinitions
+    shortNames:
+      - graviteeapis
+    singular: apidefinition
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: API entrypoint.
+          jsonPath: .spec.proxy.virtual_hosts[*].path
+          name: Entrypoint
+          type: string
+        - description: API endpoint.
+          jsonPath: .spec.proxy.groups[*].endpoints[*].target
+          name: Endpoint
+          type: string
+        - description: API version.
+          jsonPath: .spec.version
+          name: Version
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ApiDefinition is the Schema for the apidefinitions API.
+          properties:
+            apiVersion:
+              description: APIVersion defines the versioned schema of this representation of
+                an object.
+              type: string
+            kind:
+              description: Kind is a string value representing the REST resource this object
+                represents.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: >-
+                The API definition is the main resource handled by the
+                Kubernetes Operator
+
+                Most of the...
+              properties:
+                categories:
+                  default: []
+                  description: The list of categories the API belongs to.
+                  items:
+                    type: string
+                  type: array
+                consoleNotificationConfiguration:
+                  description: ConsoleNotification struct sent to the mAPI, not part of the CRD
+                    spec.
+                  properties:
+                    config_type:
+                      type: string
+                    groups:
+                      items:
+                        type: string
+                      type: array
+                    hooks:
+                      items:
+                        type: string
+                      type: array
+                    origin:
+                      type: string
+                    referenceId:
+                      type: string
+                    referenceType:
+                      type: string
+                    user:
+                      type: string
+                  required:
+                    - config_type
+                    - groups
+                    - hooks
+                    - origin
+                  type: object
+                contextRef:
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                crossId:
+                  description: |-
+                    When promoting an API from one environment to the other,
+                    this ID identifies the API across those...
+                  type: string
+                definition_context:
+                  description: >-
+                    The definition context is used to inform a management API
+                    instance that this API definition
+
+                    is...
+                  properties:
+                    mode:
+                      default: fully_managed
+                      type: string
+                    origin:
+                      default: kubernetes
+                      type: string
+                    syncFrom:
+                      default: kubernetes
+                      type: string
+                  type: object
+                deployedAt:
+                  description: Shows the time that the API is deployed
+                  format: int64
+                  type: integer
+                description:
+                  description: API description
+                  type: string
+                execution_mode:
+                  default: v4-emulation-engine
+                  description: Execution mode that eventually runs the API in the gateway
+                  enum:
+                    - v3
+                    - v4-emulation-engine
+                  type: string
+                flow_mode:
+                  default: DEFAULT
+                  description: The flow mode of the API. The value is either `DEFAULT` or
+                    `BEST_MATCH`.
+                  enum:
+                    - DEFAULT
+                    - BEST_MATCH
+                  type: string
+                flows:
+                  default: []
+                  description: The flow of the API
+                  items:
+                    properties:
+                      condition:
+                        description: Flow condition
+                        type: string
+                      consumers:
+                        default: []
+                        description: List of the consumers of this Flow
+                        items:
+                          properties:
+                            consumerId:
+                              description: Consumer ID
+                              type: string
+                            consumerType:
+                              description: Consumer type (possible values TAG)
+                              type: integer
+                          type: object
+                        type: array
+                      enabled:
+                        default: true
+                        description: Indicate if this flow is enabled or disabled
+                        type: boolean
+                      id:
+                        description: Flow ID
+                        type: string
+                      methods:
+                        default: []
+                        description: A list of methods  for this flow
+                          (GET;POST;PUT;PATCH;DELETE;OPTIONS;HEAD;CONNECT;TRACE;OTHER)
+                        items:
+                          enum:
+                            - GET
+                            - POST
+                            - PUT
+                            - PATCH
+                            - DELETE
+                            - OPTIONS
+                            - HEAD
+                            - CONNECT
+                            - TRACE
+                            - OTHER
+                          type: string
+                        type: array
+                      name:
+                        description: Flow name
+                        type: string
+                      path-operator:
+                        description: List of path operators
+                        properties:
+                          operator:
+                            default: STARTS_WITH
+                            description: Operator (possible values STARTS_WITH or EQUALS)
+                            enum:
+                              - STARTS_WITH
+                              - EQUALS
+                            type: string
+                          path:
+                            description: Operator path
+                            type: string
+                        type: object
+                      post:
+                        default: []
+                        description: Flow post step
+                        items:
+                          properties:
+                            condition:
+                              description: FlowStep condition
+                              type: string
+                            configuration:
+                              description: FlowStep configuration is a map of arbitrary key-values
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            description:
+                              description: FlowStep description
+                              type: string
+                            enabled:
+                              default: true
+                              description: Indicate if this FlowStep is enabled or not
+                              type: boolean
+                            name:
+                              description: FlowStep name
+                              type: string
+                            policy:
+                              description: FlowStep policy
+                              type: string
+                          required:
+                            - enabled
+                          type: object
+                        type: array
+                      pre:
+                        default: []
+                        description: Flow pre step
+                        items:
+                          properties:
+                            condition:
+                              description: FlowStep condition
+                              type: string
+                            configuration:
+                              description: FlowStep configuration is a map of arbitrary key-values
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            description:
+                              description: FlowStep description
+                              type: string
+                            enabled:
+                              default: true
+                              description: Indicate if this FlowStep is enabled or not
+                              type: boolean
+                            name:
+                              description: FlowStep name
+                              type: string
+                            policy:
+                              description: FlowStep policy
+                              type: string
+                          required:
+                            - enabled
+                          type: object
+                        type: array
+                    required:
+                      - enabled
+                    type: object
+                  type: array
+                gravitee:
+                  default: 2.0.0
+                  description: The definition version of the API. For v1alpha1 resources, this
+                    field should always set to `2.0.0`.
+                  type: string
+                groupRefs:
+                  default: []
+                  description: |-
+                    List of group references associated with the API
+                    These groups are references to Group custom...
+                  items:
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                groups:
+                  default: []
+                  description: List of groups associated with the API.
+                  items:
+                    type: string
+                  type: array
+                id:
+                  description: >-
+                    The API ID. If empty, this field will take the value of the
+                    `metadata.uid`
+
+                    field of the resource.
+                  type: string
+                labels:
+                  default: []
+                  description: List of labels of the API
+                  items:
+                    type: string
+                  type: array
+                lifecycle_state:
+                  default: CREATED
+                  description: API life cycle state can be one of the values CREATED, PUBLISHED,
+                    UNPUBLISHED, DEPRECATED, ARCHIVED
+                  enum:
+                    - CREATED
+                    - PUBLISHED
+                    - UNPUBLISHED
+                    - DEPRECATED
+                    - ARCHIVED
+                  type: string
+                local:
+                  default: false
+                  description: local defines if the api is local or not.
+                  type: boolean
+                members:
+                  description: List of members associated with the API
+                  items:
+                    properties:
+                      role:
+                        default: USER
+                        description: The API role associated with this Member
+                        type: string
+                      source:
+                        description: Member source
+                        example: gravitee
+                        type: string
+                      sourceId:
+                        description: Member source ID
+                        example: user@email.com
+                        type: string
+                    required:
+                      - source
+                      - sourceId
+                    type: object
+                  type: array
+                metadata:
+                  default: []
+                  description: List of API metadata entries
+                  items:
+                    properties:
+                      defaultValue:
+                        description: Metadata Default value
+                        type: string
+                      format:
+                        description: Metadata Format
+                        enum:
+                          - STRING
+                          - NUMERIC
+                          - BOOLEAN
+                          - DATE
+                          - MAIL
+                          - URL
+                        type: string
+                      key:
+                        description: Metadata Key
+                        type: string
+                      name:
+                        description: Metadata Name
+                        type: string
+                      value:
+                        description: Metadata Value
+                        type: string
+                    required:
+                      - format
+                      - key
+                      - name
+                    type: object
+                  type: array
+                name:
+                  description: API name
+                  type: string
+                notificationsRefs:
+                  default: []
+                  description: References to Notification custom resources to setup notifications.
+                  items:
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                notifyMembers:
+                  default: true
+                  description: |-
+                    If true, new members added to the API spec will
+                    be notified when the API is synced with APIM.
+                  type: boolean
+                pages:
+                  additionalProperties:
+                    properties:
+                      accessControls:
+                        default: []
+                        description: If the page is private, defines a set of user groups with access
+                        items:
+                          properties:
+                            referenceId:
+                              description: The ID denied or granted by the access control (currently only
+                                group names are supported)
+                              type: string
+                            referenceType:
+                              description: >-
+                                The type of reference denied or granted by the
+                                access control
+
+                                Currently only GROUP is supported
+                              enum:
+                                - GROUP
+                              type: string
+                          required:
+                            - referenceId
+                            - referenceType
+                          type: object
+                        type: array
+                      api:
+                        description: The API of the page. If empty, will be set automatically to the
+                          generated ID of the API.
+                        type: string
+                      configuration:
+                        additionalProperties:
+                          type: string
+                        description: Custom page configuration (e.g. page rendering can be changed to
+                          use Redoc instead of Swagger ui)
+                        type: object
+                      content:
+                        description: The content of the page, if any.
+                        type: string
+                      crossId:
+                        description: CrossID is designed to identified a page across environments.
+                        type: string
+                      excludedAccessControls:
+                        description: >-
+                          if true, the references defined in the accessControls
+                          list will be
+
+                          denied access instead of being...
+                        type: boolean
+                      homepage:
+                        default: false
+                        description: If true, this page will be displayed as the homepage of your API
+                          documentation.
+                        type: boolean
+                      id:
+                        description: The ID of the page.
+                        type: string
+                      name:
+                        description: This is the display name of the page in APIM and on the portal.
+                        type: string
+                      order:
+                        description: The order used to display the page in APIM and on the portal.
+                        format: int64
+                        type: integer
+                      parent:
+                        description: >-
+                          If your page contains a folder, setting this field to
+                          the map key associated to the
+
+                          folder entry...
+                        type: string
+                      parentId:
+                        description: The parent ID of the page.
+                        type: string
+                      published:
+                        default: false
+                        description: If true, the page will be accessible from the portal (default is
+                          false)
+                        type: boolean
+                      source:
+                        description: >-
+                          Source allow you to fetch pages from various external
+                          sources, overriding page content
+
+                          each time...
+                        properties:
+                          configuration:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          type:
+                            type: string
+                        required:
+                          - configuration
+                          - type
+                        type: object
+                      type:
+                        description: The type of the documentation page or folder.
+                        enum:
+                          - MARKDOWN
+                          - SWAGGER
+                          - ASYNCAPI
+                          - ASCIIDOC
+                          - FOLDER
+                          - SYSTEM_FOLDER
+                          - ROOT
+                        type: string
+                      visibility:
+                        default: PUBLIC
+                        description: The visibility of the page.
+                        enum:
+                          - PUBLIC
+                          - PRIVATE
+                        type: string
+                    required:
+                      - name
+                      - type
+                    type: object
+                  description: A map of pages objects.
+                  type: object
+                path_mappings:
+                  description: API Path mapping
+                  items:
+                    type: string
+                  type: array
+                plans:
+                  default: []
+                  description: API plans
+                  items:
+                    properties:
+                      api:
+                        description: Specify the API associated with this plan
+                        type: string
+                      characteristics:
+                        description: List of plan characteristics
+                        items:
+                          type: string
+                        type: array
+                      comment_required:
+                        description: Indicate of comment is required for this plan or not
+                        type: boolean
+                      crossId:
+                        description: The plan Cross ID.
+                        type: string
+                      description:
+                        description: Plan Description
+                        type: string
+                      excluded_groups:
+                        default: []
+                        description: List of excluded groups for this plan
+                        items:
+                          type: string
+                        type: array
+                      flows:
+                        default: []
+                        description: List of different flows for this Plan
+                        items:
+                          properties:
+                            condition:
+                              description: Flow condition
+                              type: string
+                            consumers:
+                              default: []
+                              description: List of the consumers of this Flow
+                              items:
+                                properties:
+                                  consumerId:
+                                    description: Consumer ID
+                                    type: string
+                                  consumerType:
+                                    description: Consumer type (possible values TAG)
+                                    type: integer
+                                type: object
+                              type: array
+                            enabled:
+                              default: true
+                              description: Indicate if this flow is enabled or disabled
+                              type: boolean
+                            id:
+                              description: Flow ID
+                              type: string
+                            methods:
+                              default: []
+                              description: A list of methods  for this flow
+                                (GET;POST;PUT;PATCH;DELETE;OPTIONS;HEAD;CONNECT;TRACE;OTHER)
+                              items:
+                                enum:
+                                  - GET
+                                  - POST
+                                  - PUT
+                                  - PATCH
+                                  - DELETE
+                                  - OPTIONS
+                                  - HEAD
+                                  - CONNECT
+                                  - TRACE
+                                  - OTHER
+                                type: string
+                              type: array
+                            name:
+                              description: Flow name
+                              type: string
+                            path-operator:
+                              description: List of path operators
+                              properties:
+                                operator:
+                                  default: STARTS_WITH
+                                  description: Operator (possible values STARTS_WITH or EQUALS)
+                                  enum:
+                                    - STARTS_WITH
+                                    - EQUALS
+                                  type: string
+                                path:
+                                  description: Operator path
+                                  type: string
+                              type: object
+                            post:
+                              default: []
+                              description: Flow post step
+                              items:
+                                properties:
+                                  condition:
+                                    description: FlowStep condition
+                                    type: string
+                                  configuration:
+                                    description: FlowStep configuration is a map of arbitrary key-values
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description:
+                                    description: FlowStep description
+                                    type: string
+                                  enabled:
+                                    default: true
+                                    description: Indicate if this FlowStep is enabled or not
+                                    type: boolean
+                                  name:
+                                    description: FlowStep name
+                                    type: string
+                                  policy:
+                                    description: FlowStep policy
+                                    type: string
+                                required:
+                                  - enabled
+                                type: object
+                              type: array
+                            pre:
+                              default: []
+                              description: Flow pre step
+                              items:
+                                properties:
+                                  condition:
+                                    description: FlowStep condition
+                                    type: string
+                                  configuration:
+                                    description: FlowStep configuration is a map of arbitrary key-values
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description:
+                                    description: FlowStep description
+                                    type: string
+                                  enabled:
+                                    default: true
+                                    description: Indicate if this FlowStep is enabled or not
+                                    type: boolean
+                                  name:
+                                    description: FlowStep name
+                                    type: string
+                                  policy:
+                                    description: FlowStep policy
+                                    type: string
+                                required:
+                                  - enabled
+                                type: object
+                              type: array
+                          required:
+                            - enabled
+                          type: object
+                        type: array
+                      id:
+                        description: Plan ID
+                        type: string
+                      name:
+                        description: Plan name
+                        type: string
+                      order:
+                        description: Plan order
+                        type: integer
+                      paths:
+                        additionalProperties:
+                          items:
+                            properties:
+                              description:
+                                description: Rule description
+                                type: string
+                              enabled:
+                                description: Indicate if the Rule is enabled or not
+                                type: boolean
+                              methods:
+                                description: List of http methods for this Rule
+                                  (GET;POST;PUT;PATCH;DELETE;OPTIONS;HEAD;CONNECT;TRACE;OTHER)
+                                items:
+                                  enum:
+                                    - GET
+                                    - POST
+                                    - PUT
+                                    - PATCH
+                                    - DELETE
+                                    - OPTIONS
+                                    - HEAD
+                                    - CONNECT
+                                    - TRACE
+                                    - OTHER
+                                  type: string
+                                type: array
+                              policy:
+                                description: Rule policy
+                                properties:
+                                  configuration:
+                                    description: Policy configuration is a map of arbitrary key-values
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  name:
+                                    description: Policy name
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        description: A map of different paths (alongside their Rules) for this Plan
+                        type: object
+                      security:
+                        description: Plan Security
+                        type: string
+                      securityDefinition:
+                        description: Plan Security definition
+                        type: string
+                      selection_rule:
+                        description: Plan selection rule
+                        type: string
+                      status:
+                        default: PUBLISHED
+                        description: The plan status
+                        enum:
+                          - PUBLISHED
+                          - DEPRECATED
+                          - STAGING
+                        type: string
+                      tags:
+                        default: []
+                        description: List of plan tags
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        default: API
+                        description: Plan type
+                        enum:
+                          - API
+                          - CATALOG
+                        type: string
+                      validation:
+                        default: AUTO
+                        description: Plan validation strategy
+                        enum:
+                          - AUTO
+                          - MANUAL
+                        type: string
+                    required:
+                      - description
+                      - name
+                      - security
+                    type: object
+                  type: array
+                properties:
+                  default: []
+                  description: List of Properties for the API
+                  items:
+                    properties:
+                      dynamic:
+                        description: Property is dynamic or not?
+                        type: boolean
+                      encryptable:
+                        description: Property is encryptable or not?
+                        type: boolean
+                      encrypted:
+                        description: Property Encrypted or not?
+                        type: boolean
+                      key:
+                        description: Property Key
+                        type: string
+                      value:
+                        description: Property Value
+                        type: string
+                    type: object
+                  type: array
+                proxy:
+                  description: The proxy of the API that specifies its VirtualHosts and Groups.
+                  properties:
+                    cors:
+                      description: Proxy Cors
+                      properties:
+                        allowCredentials:
+                          description: Access Control - Allow credentials or not
+                          type: boolean
+                        allowHeaders:
+                          default: []
+                          description: Access Control - List of allowed headers
+                          items:
+                            type: string
+                          type: array
+                        allowMethods:
+                          default: []
+                          description: Access Control - List of allowed methods
+                          items:
+                            type: string
+                          type: array
+                        allowOrigin:
+                          default: []
+                          description: Access Control -  List of Allowed origins
+                          items:
+                            type: string
+                          type: array
+                        enabled:
+                          description: Indicate if the cors enabled or not
+                          type: boolean
+                        exposeHeaders:
+                          default: []
+                          description: Access Control - List of Exposed Headers
+                          items:
+                            type: string
+                          type: array
+                        maxAge:
+                          description: Access Control -  Max age
+                          type: integer
+                        runPolicies:
+                          default: false
+                          description: Run policies or not
+                          type: boolean
+                      required:
+                        - allowCredentials
+                        - enabled
+                        - maxAge
+                      type: object
+                    failover:
+                      description: Proxy Failover
+                      properties:
+                        cases:
+                          description: List of Failover cases
+                          items:
+                            type: string
+                          type: array
+                        maxAttempts:
+                          description: Maximum number of attempts
+                          type: integer
+                        retryTimeout:
+                          description: Retry timeout
+                          format: int64
+                          type: integer
+                      type: object
+                    groups:
+                      default: []
+                      description: List of endpoint groups of the proxy
+                      items:
+                        properties:
+                          endpoints:
+                            description: List of Endpoints belonging to this group
+                            items:
+                              properties:
+                                backup:
+                                  description: Indicate that this ia a back-end endpoint
+                                  type: boolean
+                                headers:
+                                  default: []
+                                  description: List of headers for this endpoint
+                                  items:
+                                    properties:
+                                      name:
+                                        description: The HTTP header name
+                                        type: string
+                                      value:
+                                        description: The HTTP header value
+                                        type: string
+                                    type: object
+                                  type: array
+                                healthcheck:
+                                  description: Specify EndpointHealthCheck service settings
+                                  properties:
+                                    enabled:
+                                      default: false
+                                      description: Is service enabled or not?
+                                      type: boolean
+                                    inherit:
+                                      default: false
+                                      type: boolean
+                                    name:
+                                      description: Service name
+                                      type: string
+                                    schedule:
+                                      type: string
+                                    steps:
+                                      default: []
+                                      description: List of health check steps
+                                      items:
+                                        properties:
+                                          name:
+                                            description: Health Check Step Name
+                                            type: string
+                                          request:
+                                            description: Health Check Step Request
+                                            properties:
+                                              body:
+                                                description: Health Check Request Body
+                                                type: string
+                                              fromRoot:
+                                                description: If true, the health check request will be issued without prepending
+                                                  the context path of the API.
+                                                type: boolean
+                                              headers:
+                                                default: []
+                                                description: List of HTTP headers to include in the health check request
+                                                items:
+                                                  properties:
+                                                    name:
+                                                      description: The HTTP header name
+                                                      type: string
+                                                    value:
+                                                      description: The HTTP header value
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              method:
+                                                description: The HTTP method to use when issuing the health check request
+                                                enum:
+                                                  - GET
+                                                  - POST
+                                                  - PUT
+                                                  - PATCH
+                                                  - DELETE
+                                                  - OPTIONS
+                                                  - HEAD
+                                                  - CONNECT
+                                                  - TRACE
+                                                  - OTHER
+                                                type: string
+                                              path:
+                                                description: The path of the endpoint handling the health check request
+                                                type: string
+                                            required:
+                                              - fromRoot
+                                            type: object
+                                          response:
+                                            description: Health Check Step Response
+                                            properties:
+                                              assertions:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                                http:
+                                  description: Custom HTTP client options used for this endpoint
+                                  properties:
+                                    clearTextUpgrade:
+                                      default: true
+                                      description: Should HTTP/2 clear text upgrade be used or not ?
+                                      type: boolean
+                                    connectTimeout:
+                                      description: Connection timeout of the http connection
+                                      format: int64
+                                      type: integer
+                                    followRedirects:
+                                      default: false
+                                      description: Should HTTP redirects be followed or not ?
+                                      type: boolean
+                                    idleTimeout:
+                                      description: " Idle Timeout for the http connection"
+                                      format: int64
+                                      type: integer
+                                    keepAlive:
+                                      default: true
+                                      type: boolean
+                                    keepAliveTimeout:
+                                      default: 30000
+                                      description: Should keep alive be used for the HTTP connection ?
+                                      format: int64
+                                      type: integer
+                                    maxChunkSize:
+                                      description: Maximum size of HTTP chunks
+                                      type: integer
+                                    maxConcurrentConnections:
+                                      description: HTTP max concurrent connections
+                                      type: integer
+                                    maxHeaderSize:
+                                      description: Maximum size of HTTP headers
+                                      type: integer
+                                    pipelining:
+                                      default: false
+                                      description: Should HTTP/1.1 pipelining be used for the connection or not ?
+                                      type: boolean
+                                    propagateClientAcceptEncoding:
+                                      default: false
+                                      description: Propagate Client Accept-Encoding header
+                                      type: boolean
+                                    readTimeout:
+                                      description: Read timeout
+                                      format: int64
+                                      type: integer
+                                    useCompression:
+                                      default: false
+                                      description: Should compression be used or not ?
+                                      type: boolean
+                                    version:
+                                      default: HTTP_1_1
+                                      description: HTTP Protocol Version (Possible values Http1 or Http2)
+                                      enum:
+                                        - HTTP_1_1
+                                        - HTTP_2
+                                      type: string
+                                  required:
+                                    - followRedirects
+                                    - pipelining
+                                    - useCompression
+                                  type: object
+                                inherit:
+                                  description: Is endpoint inherited or not
+                                  type: boolean
+                                name:
+                                  description: Name of the endpoint
+                                  type: string
+                                proxy:
+                                  description: Configure the HTTP Proxy settings to reach target if needed
+                                  properties:
+                                    enabled:
+                                      default: false
+                                      description: Specifies that the HTTP connection will be established through a
+                                        proxy
+                                      type: boolean
+                                    host:
+                                      description: Proxy host name
+                                      type: string
+                                    password:
+                                      description: The HTTP proxy password (if the proxy requires authentication)
+                                      type: string
+                                    port:
+                                      description: The HTTP proxy port
+                                      type: integer
+                                    type:
+                                      description: The HTTP proxy type (possible values Http, Socks4, Socks5)
+                                      type: string
+                                    useSystemProxy:
+                                      default: false
+                                      description: If true, the proxy defined at the system level will be used
+                                      type: boolean
+                                    username:
+                                      description: The HTTP proxy username (if the proxy requires authentication)
+                                      type: string
+                                  type: object
+                                ssl:
+                                  description: Custom HTTP SSL client options used for this endpoint
+                                  properties:
+                                    headers:
+                                      description: Http headers
+                                      items:
+                                        properties:
+                                          name:
+                                            description: The HTTP header name
+                                            type: string
+                                          value:
+                                            description: The HTTP header value
+                                            type: string
+                                        type: object
+                                      type: array
+                                    hostnameVerifier:
+                                      default: true
+                                      description: Verify Hostname when establishing connection
+                                      type: boolean
+                                    keyStore:
+                                      description: KeyStore type (possible values PEM, PKCS12, JKS)
+                                      properties:
+                                        certContent:
+                                          description: KeyStore cert content (Only applicable for PEM KeyStore)
+                                          type: string
+                                        certPath:
+                                          description: KeyStore cert path (Only applicable for PEM KeyStore)
+                                          type: string
+                                        content:
+                                          description: The base64 encoded trustStore content, if not relying on a path to
+                                            a file
+                                          type: string
+                                        keyContent:
+                                          description: >-
+                                            The base64 encoded trustStore
+                                            content, if not relying on a path to
+                                            a file
+
+                                            (Only applicable for PEM...
+                                          type: string
+                                        keyPath:
+                                          description: KeyStore key path (Only applicable for PEM KeyStore)
+                                          type: string
+                                        password:
+                                          type: string
+                                        path:
+                                          description: KeyStore path
+                                          type: string
+                                        type:
+                                          description: The KeyStore type to use (possible values are PEM, PKCS12, JKS)
+                                          enum:
+                                            - PEM
+                                            - PKCS12
+                                            - JKS
+                                          type: string
+                                      type: object
+                                    trustAll:
+                                      default: false
+                                      description: Whether to trust all issuers or not
+                                      type: boolean
+                                    trustStore:
+                                      description: TrustStore type (possible values PEM, PKCS12, JKS)
+                                      properties:
+                                        content:
+                                          description: The base64 encoded trustStore content, if not relying on a path to
+                                            a file
+                                          type: string
+                                        password:
+                                          description: TrustStore password (Not applicable for PEM TrustStore)
+                                          type: string
+                                        path:
+                                          type: string
+                                        type:
+                                          description: The TrustStore type to use (possible values are PEM, PKCS12, JKS)
+                                          enum:
+                                            - PEM
+                                            - PKCS12
+                                            - JKS
+                                          type: string
+                                      type: object
+                                  required:
+                                    - hostnameVerifier
+                                    - trustAll
+                                  type: object
+                                target:
+                                  description: The end target of this endpoint (backend)
+                                  type: string
+                                tenants:
+                                  default: []
+                                  description: The endpoint tenants
+                                  items:
+                                    type: string
+                                  type: array
+                                type:
+                                  description: The type of endpoint (HttpEndpointType or GrpcEndpointType)
+                                  type: string
+                                weight:
+                                  description: Endpoint weight used for load-balancing
+                                  type: integer
+                              type: object
+                            type: array
+                          headers:
+                            additionalProperties:
+                              type: string
+                            description: List of headers needed for this EndpointGroup
+                            type: object
+                          http:
+                            description: Custom HTTP SSL client options used for this EndpointGroup
+                            properties:
+                              clearTextUpgrade:
+                                default: true
+                                description: Should HTTP/2 clear text upgrade be used or not ?
+                                type: boolean
+                              connectTimeout:
+                                description: Connection timeout of the http connection
+                                format: int64
+                                type: integer
+                              followRedirects:
+                                default: false
+                                description: Should HTTP redirects be followed or not ?
+                                type: boolean
+                              idleTimeout:
+                                description: " Idle Timeout for the http connection"
+                                format: int64
+                                type: integer
+                              keepAlive:
+                                default: true
+                                type: boolean
+                              keepAliveTimeout:
+                                default: 30000
+                                description: Should keep alive be used for the HTTP connection ?
+                                format: int64
+                                type: integer
+                              maxChunkSize:
+                                description: Maximum size of HTTP chunks
+                                type: integer
+                              maxConcurrentConnections:
+                                description: HTTP max concurrent connections
+                                type: integer
+                              maxHeaderSize:
+                                description: Maximum size of HTTP headers
+                                type: integer
+                              pipelining:
+                                default: false
+                                description: Should HTTP/1.1 pipelining be used for the connection or not ?
+                                type: boolean
+                              propagateClientAcceptEncoding:
+                                default: false
+                                description: Propagate Client Accept-Encoding header
+                                type: boolean
+                              readTimeout:
+                                description: Read timeout
+                                format: int64
+                                type: integer
+                              useCompression:
+                                default: false
+                                description: Should compression be used or not ?
+                                type: boolean
+                              version:
+                                default: HTTP_1_1
+                                description: HTTP Protocol Version (Possible values Http1 or Http2)
+                                enum:
+                                  - HTTP_1_1
+                                  - HTTP_2
+                                type: string
+                            required:
+                              - followRedirects
+                              - pipelining
+                              - useCompression
+                            type: object
+                          load_balancing:
+                            description: The LoadBalancer Type
+                            properties:
+                              type:
+                                description: Type of the LoadBalancer (RoundRobin, Random, WeightedRoundRobin,
+                                  WeightedRandom)
+                                type: string
+                            type: object
+                          name:
+                            description: EndpointGroup name
+                            type: string
+                          proxy:
+                            description: Configure the HTTP Proxy settings for this EndpointGroup if needed
+                            properties:
+                              enabled:
+                                default: false
+                                description: Specifies that the HTTP connection will be established through a
+                                  proxy
+                                type: boolean
+                              host:
+                                description: Proxy host name
+                                type: string
+                              password:
+                                description: The HTTP proxy password (if the proxy requires authentication)
+                                type: string
+                              port:
+                                description: The HTTP proxy port
+                                type: integer
+                              type:
+                                description: The HTTP proxy type (possible values Http, Socks4, Socks5)
+                                type: string
+                              useSystemProxy:
+                                default: false
+                                description: If true, the proxy defined at the system level will be used
+                                type: boolean
+                              username:
+                                description: The HTTP proxy username (if the proxy requires authentication)
+                                type: string
+                            type: object
+                          services:
+                            description: Specify different Endpoint Services
+                            properties:
+                              discovery:
+                                description: Endpoint Discovery Service
+                                properties:
+                                  configuration:
+                                    description: Configuration, arbitrary map of key-values
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  enabled:
+                                    default: false
+                                    description: Is service enabled or not?
+                                    type: boolean
+                                  name:
+                                    description: Service name
+                                    type: string
+                                  provider:
+                                    description: Provider name
+                                    type: string
+                                  secondary:
+                                    description: Is it secondary or not?
+                                    type: boolean
+                                  tenants:
+                                    default: []
+                                    description: List of tenants
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              dynamic-property:
+                                description: Dynamic Property Service
+                                properties:
+                                  configuration:
+                                    description: Configuration, arbitrary map of key-values
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  enabled:
+                                    default: false
+                                    description: Is service enabled or not?
+                                    type: boolean
+                                  name:
+                                    description: Service name
+                                    type: string
+                                  provider:
+                                    enum:
+                                      - HTTP
+                                    type: string
+                                  schedule:
+                                    type: string
+                                type: object
+                              health-check:
+                                description: Health Check Service
+                                properties:
+                                  enabled:
+                                    default: false
+                                    description: Is service enabled or not?
+                                    type: boolean
+                                  name:
+                                    description: Service name
+                                    type: string
+                                  schedule:
+                                    type: string
+                                  steps:
+                                    default: []
+                                    description: List of health check steps
+                                    items:
+                                      properties:
+                                        name:
+                                          description: Health Check Step Name
+                                          type: string
+                                        request:
+                                          description: Health Check Step Request
+                                          properties:
+                                            body:
+                                              description: Health Check Request Body
+                                              type: string
+                                            fromRoot:
+                                              description: If true, the health check request will be issued without prepending
+                                                the context path of the API.
+                                              type: boolean
+                                            headers:
+                                              default: []
+                                              description: List of HTTP headers to include in the health check request
+                                              items:
+                                                properties:
+                                                  name:
+                                                    description: The HTTP header name
+                                                    type: string
+                                                  value:
+                                                    description: The HTTP header value
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            method:
+                                              description: The HTTP method to use when issuing the health check request
+                                              enum:
+                                                - GET
+                                                - POST
+                                                - PUT
+                                                - PATCH
+                                                - DELETE
+                                                - OPTIONS
+                                                - HEAD
+                                                - CONNECT
+                                                - TRACE
+                                                - OTHER
+                                              type: string
+                                            path:
+                                              description: The path of the endpoint handling the health check request
+                                              type: string
+                                          required:
+                                            - fromRoot
+                                          type: object
+                                        response:
+                                          description: Health Check Step Response
+                                          properties:
+                                            assertions:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          ssl:
+                            description: Custom HTTP SSL client options used for this EndpointGroup
+                            properties:
+                              headers:
+                                description: Http headers
+                                items:
+                                  properties:
+                                    name:
+                                      description: The HTTP header name
+                                      type: string
+                                    value:
+                                      description: The HTTP header value
+                                      type: string
+                                  type: object
+                                type: array
+                              hostnameVerifier:
+                                default: true
+                                description: Verify Hostname when establishing connection
+                                type: boolean
+                              keyStore:
+                                description: KeyStore type (possible values PEM, PKCS12, JKS)
+                                properties:
+                                  certContent:
+                                    description: KeyStore cert content (Only applicable for PEM KeyStore)
+                                    type: string
+                                  certPath:
+                                    description: KeyStore cert path (Only applicable for PEM KeyStore)
+                                    type: string
+                                  content:
+                                    description: The base64 encoded trustStore content, if not relying on a path to
+                                      a file
+                                    type: string
+                                  keyContent:
+                                    description: >-
+                                      The base64 encoded trustStore content, if
+                                      not relying on a path to a file
+
+                                      (Only applicable for PEM...
+                                    type: string
+                                  keyPath:
+                                    description: KeyStore key path (Only applicable for PEM KeyStore)
+                                    type: string
+                                  password:
+                                    type: string
+                                  path:
+                                    description: KeyStore path
+                                    type: string
+                                  type:
+                                    description: The KeyStore type to use (possible values are PEM, PKCS12, JKS)
+                                    enum:
+                                      - PEM
+                                      - PKCS12
+                                      - JKS
+                                    type: string
+                                type: object
+                              trustAll:
+                                default: false
+                                description: Whether to trust all issuers or not
+                                type: boolean
+                              trustStore:
+                                description: TrustStore type (possible values PEM, PKCS12, JKS)
+                                properties:
+                                  content:
+                                    description: The base64 encoded trustStore content, if not relying on a path to
+                                      a file
+                                    type: string
+                                  password:
+                                    description: TrustStore password (Not applicable for PEM TrustStore)
+                                    type: string
+                                  path:
+                                    type: string
+                                  type:
+                                    description: The TrustStore type to use (possible values are PEM, PKCS12, JKS)
+                                    enum:
+                                      - PEM
+                                      - PKCS12
+                                      - JKS
+                                    type: string
+                                type: object
+                            required:
+                              - hostnameVerifier
+                              - trustAll
+                            type: object
+                        type: object
+                      type: array
+                    logging:
+                      description: Logging
+                      properties:
+                        condition:
+                          description: The logging condition (supports EL expressions)
+                          type: string
+                        content:
+                          description: Which part of the request/response should be logged ?
+                          enum:
+                            - NONE
+                            - HEADERS
+                            - PAYLOADS
+                            - HEADERS_PAYLOADS
+                          type: string
+                        mode:
+                          description: The logging mode.
+                          enum:
+                            - NONE
+                            - CLIENT
+                            - PROXY
+                            - CLIENT_PROXY
+                          type: string
+                        scope:
+                          description: The logging scope (which phase of the request roundtrip should be
+                            included in each log entry.
+                          enum:
+                            - NONE
+                            - REQUEST
+                            - RESPONSE
+                            - REQUEST_RESPONSE
+                          type: string
+                      type: object
+                    preserve_host:
+                      description: Preserve Host
+                      type: boolean
+                    strip_context_path:
+                      description: Strip Context Path
+                      type: boolean
+                    virtual_hosts:
+                      description: list of Virtual hosts fot the proxy
+                      items:
+                        properties:
+                          host:
+                            description: Host name
+                            type: string
+                          override_entrypoint:
+                            description: Indicate if Entrypoint should be overridden or not
+                            type: boolean
+                          path:
+                            description: Path
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                resources:
+                  default: []
+                  description: >-
+                    Resources can be either inlined or reference the namespace
+                    and name
+
+                    of an <a...
+                  items:
+                    properties:
+                      configuration:
+                        description: Resource Configuration, arbitrary map of key-values
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      enabled:
+                        default: true
+                        description: Is resource enabled or not?
+                        type: boolean
+                      name:
+                        description: Resource Name
+                        type: string
+                      ref:
+                        description: Reference to a resource
+                        properties:
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type:
+                        description: Resource Type
+                        type: string
+                    type: object
+                  type: array
+                response_templates:
+                  additionalProperties:
+                    additionalProperties:
+                      properties:
+                        body:
+                          type: string
+                        headers:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        propagateErrorKeyToLogs:
+                          description: Propagate error key to logs
+                          type: boolean
+                        status:
+                          type: integer
+                      type: object
+                    type: object
+                  description: A list of Response Templates for the API
+                  type: object
+                services:
+                  description: Contains different services for the API (EndpointDiscovery,
+                    HealthCheck ...)
+                  properties:
+                    discovery:
+                      description: Endpoint Discovery Service
+                      properties:
+                        configuration:
+                          description: Configuration, arbitrary map of key-values
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        enabled:
+                          default: false
+                          description: Is service enabled or not?
+                          type: boolean
+                        name:
+                          description: Service name
+                          type: string
+                        provider:
+                          description: Provider name
+                          type: string
+                        secondary:
+                          description: Is it secondary or not?
+                          type: boolean
+                        tenants:
+                          default: []
+                          description: List of tenants
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    dynamic-property:
+                      description: Dynamic Property Service
+                      properties:
+                        configuration:
+                          description: Configuration, arbitrary map of key-values
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        enabled:
+                          default: false
+                          description: Is service enabled or not?
+                          type: boolean
+                        name:
+                          description: Service name
+                          type: string
+                        provider:
+                          enum:
+                            - HTTP
+                          type: string
+                        schedule:
+                          type: string
+                      type: object
+                    health-check:
+                      description: Health Check Service
+                      properties:
+                        enabled:
+                          default: false
+                          description: Is service enabled or not?
+                          type: boolean
+                        name:
+                          description: Service name
+                          type: string
+                        schedule:
+                          type: string
+                        steps:
+                          default: []
+                          description: List of health check steps
+                          items:
+                            properties:
+                              name:
+                                description: Health Check Step Name
+                                type: string
+                              request:
+                                description: Health Check Step Request
+                                properties:
+                                  body:
+                                    description: Health Check Request Body
+                                    type: string
+                                  fromRoot:
+                                    description: If true, the health check request will be issued without prepending
+                                      the context path of the API.
+                                    type: boolean
+                                  headers:
+                                    default: []
+                                    description: List of HTTP headers to include in the health check request
+                                    items:
+                                      properties:
+                                        name:
+                                          description: The HTTP header name
+                                          type: string
+                                        value:
+                                          description: The HTTP header value
+                                          type: string
+                                      type: object
+                                    type: array
+                                  method:
+                                    description: The HTTP method to use when issuing the health check request
+                                    enum:
+                                      - GET
+                                      - POST
+                                      - PUT
+                                      - PATCH
+                                      - DELETE
+                                      - OPTIONS
+                                      - HEAD
+                                      - CONNECT
+                                      - TRACE
+                                      - OTHER
+                                    type: string
+                                  path:
+                                    description: The path of the endpoint handling the health check request
+                                    type: string
+                                required:
+                                  - fromRoot
+                                type: object
+                              response:
+                                description: Health Check Step Response
+                                properties:
+                                  assertions:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                state:
+                  default: STARTED
+                  description: The state of API (setting the value to `STOPPED` will make the API
+                    un-reachable from the gateway)
+                  enum:
+                    - STARTED
+                    - STOPPED
+                  type: string
+                tags:
+                  description: List of Tags of the API
+                  items:
+                    type: string
+                  type: array
+                version:
+                  description: API version
+                  type: string
+                visibility:
+                  default: PRIVATE
+                  description: Should the API be publicly available from the portal or not ?
+                  enum:
+                    - PUBLIC
+                    - PRIVATE
+                  type: string
+              required:
+                - description
+                - name
+                - version
+              type: object
+            status:
+              description: ApiDefinitionStatus defines the observed state of API Definition.
+              properties:
+                conditions:
+                  default: []
+                  description: Conditions describe the current conditions of the API.
+                  items:
+                    description: Condition contains details for one aspect of the current state of
+                      this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from
+                          one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the
+                          transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the
+                          condition was set based upon.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for
+                          the condition's last transition.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 8
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                crossId:
+                  description: The Cross ID is used to identify an API that has been promoted from
+                    one environment to another.
+                  type: string
+                environmentId:
+                  description: The environment ID, if a management context has been defined to
+                    sync with an APIM instance
+                  type: string
+                errors:
+                  description: >-
+                    When API has been created regardless of errors, this field
+                    is
+
+                    used to persist the error message...
+                  properties:
+                    severe:
+                      description: >-
+                        severe errors do not pass admission and will block
+                        reconcile
+
+                        hence, this field should always be...
+                      items:
+                        type: string
+                      type: array
+                    warning:
+                      description: |-
+                        warning errors do not block object reconciliation,
+                        most of the time because the value is ignored or...
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                id:
+                  description: The ID of the API definition in the Gravitee API Management
+                    instance (if an API context has been...
+                  type: string
+                organizationId:
+                  description: The organization ID, if a management context has been defined to
+                    sync with an APIM instance
+                  type: string
+                plans:
+                  additionalProperties:
+                    type: string
+                  description: >-
+                    This field is used to store the list of plans that have been
+                    created
+
+                    for the API definition if a...
+                  type: object
+                processingStatus:
+                  description: The processing status of the API definition. *** DEPRECATED ***
+                  type: string
+                state:
+                  description: The state of the API. Can be either STARTED or STOPPED.
+                  enum:
+                    - STARTED
+                    - STOPPED
+                  type: string
+                subscriptions:
+                  description: The number of subscriptions that reference the API
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_apiresources.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_apiresources.yaml
@@ -1,0 +1,69 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    gravitee.io/operator.version: 4.11.1
+  name: apiresources.gravitee.io
+spec:
+  group: gravitee.io
+  names:
+    kind: ApiResource
+    listKind: ApiResourceList
+    plural: apiresources
+    singular: apiresource
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: APIVersion defines the versioned schema of this representation of
+                an object.
+              type: string
+            kind:
+              description: Kind is a string value representing the REST resource this object
+                represents.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ApiResourceSpec defines the desired state of ApiResource.
+              properties:
+                configuration:
+                  description: Resource Configuration, arbitrary map of key-values
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                enabled:
+                  default: true
+                  description: Is resource enabled or not?
+                  type: boolean
+                name:
+                  description: Resource Name
+                  type: string
+                type:
+                  description: Resource Type
+                  type: string
+              type: object
+            status:
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_apiv4definitions.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_apiv4definitions.yaml
@@ -1,0 +1,1769 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    gravitee.io/operator.version: 4.11.1
+  name: apiv4definitions.gravitee.io
+spec:
+  group: gravitee.io
+  names:
+    kind: ApiV4Definition
+    listKind: ApiV4DefinitionList
+    plural: apiv4definitions
+    shortNames:
+      - graviteev4apis
+    singular: apiv4definition
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: State
+          jsonPath: .spec.state
+          name: State
+          type: string
+        - description: Lifecycle State
+          jsonPath: .spec.lifecycleState
+          name: Lifecycle State
+          type: string
+        - description: API version.
+          jsonPath: .spec.version
+          name: Version
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ApiV4Definition is the Schema for the v4 apidefinitions API.
+          properties:
+            apiVersion:
+              description: APIVersion defines the versioned schema of this representation of
+                an object.
+              type: string
+            kind:
+              description: Kind is a string value representing the REST resource this object
+                represents.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ApiV4DefinitionSpec defines the desired state of ApiDefinition.
+              properties:
+                analytics:
+                  description: API Analytics (Not applicable for Native API)
+                  properties:
+                    enabled:
+                      default: true
+                      description: Analytics Enabled or not?
+                      type: boolean
+                    logging:
+                      description: Analytics Logging
+                      properties:
+                        condition:
+                          description: The logging condition. This field is evaluated for HTTP requests
+                            and supports EL expressions.
+                          type: string
+                        content:
+                          description: Defines which component of the request should be included in the
+                            log payload.
+                          properties:
+                            headers:
+                              description: Should HTTP headers be logged or not ?
+                              type: boolean
+                            messageHeaders:
+                              description: Should message headers be logged or not ?
+                              type: boolean
+                            messageMetadata:
+                              description: Should message metadata be logged or not ?
+                              type: boolean
+                            messagePayload:
+                              description: Should message payloads be logged or not ?
+                              type: boolean
+                            payload:
+                              description: Should HTTP payloads be logged or not ?
+                              type: boolean
+                          required:
+                            - headers
+                            - messageHeaders
+                            - messageMetadata
+                            - messagePayload
+                            - payload
+                          type: object
+                        messageCondition:
+                          description: The logging message condition. This field is evaluated for messages
+                            and supports EL expressions.
+                          type: string
+                        mode:
+                          description: >-
+                            The logging mode defines which "hop" of the request
+                            roundtrip
+
+                            should be included in the log payload.
+                          properties:
+                            endpoint:
+                              description: If true, the request to the upstream service will be included in
+                                the log payload
+                              type: boolean
+                            entrypoint:
+                              description: If true, the inbound request to the gateway will be included in the
+                                log payload
+                              type: boolean
+                          required:
+                            - endpoint
+                            - entrypoint
+                          type: object
+                        phase:
+                          description: |-
+                            Defines which phase of the request roundtrip
+                            should be included in the log payload.
+                          properties:
+                            request:
+                              description: Should the request phase of the request roundtrip be included in
+                                the log payload or not ?
+                              type: boolean
+                            response:
+                              description: Should the response phase of the request roundtrip be included in
+                                the log payload or not ?
+                              type: boolean
+                          required:
+                            - request
+                            - response
+                          type: object
+                      type: object
+                    sampling:
+                      description: Analytics Sampling
+                      properties:
+                        type:
+                          description: The sampling type to use
+                          enum:
+                            - PROBABILITY
+                            - TEMPORAL
+                            - COUNT
+                            - WINDOWED_COUNT
+                          type: string
+                        value:
+                          description: Sampling Value
+                          type: string
+                      required:
+                        - type
+                        - value
+                      type: object
+                    tracing:
+                      description: Analytics Tracing
+                      properties:
+                        enabled:
+                          description: Specify if Tracing is Enabled or not
+                          type: boolean
+                        verbose:
+                          description: Specify if Tracing is Verbose or not
+                          type: boolean
+                      type: object
+                  required:
+                    - enabled
+                  type: object
+                categories:
+                  default: []
+                  description: The list of categories the API belongs to.
+                  items:
+                    type: string
+                  type: array
+                consoleNotificationConfiguration:
+                  description: ConsoleNotification struct sent to the mAPI, not part of the CRD
+                    spec.
+                  properties:
+                    config_type:
+                      type: string
+                    groups:
+                      items:
+                        type: string
+                      type: array
+                    hooks:
+                      items:
+                        type: string
+                      type: array
+                    origin:
+                      type: string
+                    referenceId:
+                      type: string
+                    referenceType:
+                      type: string
+                    user:
+                      type: string
+                  required:
+                    - config_type
+                    - groups
+                    - hooks
+                    - origin
+                  type: object
+                contextRef:
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                crossId:
+                  description: |-
+                    When promoting an API from one environment to the other,
+                    this ID identifies the API across those...
+                  type: string
+                definitionContext:
+                  description: >-
+                    The API Definition context is used to identify the
+                    Kubernetes origin of the API,
+
+                    and define whether...
+                  properties:
+                    origin:
+                      default: KUBERNETES
+                      description: The definition context origin where the API definition is managed.
+                      enum:
+                        - KUBERNETES
+                      type: string
+                    syncFrom:
+                      default: MANAGEMENT
+                      description: The syncFrom field defines where the gateways should source the API
+                        definition from.
+                      enum:
+                        - KUBERNETES
+                        - MANAGEMENT
+                      type: string
+                  type: object
+                definitionVersion:
+                  default: V4
+                  description: The definition version of the API.
+                  enum:
+                    - V4
+                  type: string
+                description:
+                  description: API description
+                  type: string
+                endpointGroups:
+                  description: List of Endpoint groups
+                  items:
+                    properties:
+                      endpoints:
+                        default: []
+                        description: List of endpoint for the group
+                        items:
+                          properties:
+                            configuration:
+                              description: Endpoint Configuration, arbitrary map of key-values
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            inheritConfiguration:
+                              description: Should endpoint group configuration be inherited or not ?
+                              type: boolean
+                            name:
+                              description: The endpoint name (this value should be unique across endpoints)
+                              type: string
+                            secondary:
+                              description: Endpoint is secondary or not?
+                              type: boolean
+                            services:
+                              description: Endpoint Services
+                              properties:
+                                healthCheck:
+                                  description: Health check service
+                                  properties:
+                                    configuration:
+                                      description: Service Configuration, a map of arbitrary key-values
+                                      type: object
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    enabled:
+                                      description: Is the service enabled or not ?
+                                      type: boolean
+                                    overrideConfiguration:
+                                      description: Service Override Configuration or not?
+                                      type: boolean
+                                    type:
+                                      description: Service Type
+                                      type: string
+                                  required:
+                                    - enabled
+                                    - overrideConfiguration
+                                  type: object
+                              type: object
+                            sharedConfigurationOverride:
+                              description: Endpoint Configuration Override, arbitrary map of key-values
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            tenants:
+                              default: []
+                              description: List of endpoint tenants
+                              items:
+                                type: string
+                              type: array
+                            type:
+                              description: Endpoint Type
+                              type: string
+                            weight:
+                              description: Endpoint Weight
+                              format: int32
+                              type: integer
+                          required:
+                            - inheritConfiguration
+                            - secondary
+                            - type
+                          type: object
+                        type: array
+                      headers:
+                        additionalProperties:
+                          type: string
+                        description: Endpoint group headers, arbitrary map of key-values
+                        type: object
+                      http:
+                        description: Endpoint group http client options
+                        properties:
+                          clearTextUpgrade:
+                            default: true
+                            description: Should HTTP/2 clear text upgrade be used or not ?
+                            type: boolean
+                          connectTimeout:
+                            description: Connection timeout of the http connection
+                            format: int64
+                            type: integer
+                          followRedirects:
+                            default: false
+                            description: Should HTTP redirects be followed or not ?
+                            type: boolean
+                          idleTimeout:
+                            description: " Idle Timeout for the http connection"
+                            format: int64
+                            type: integer
+                          keepAlive:
+                            default: true
+                            type: boolean
+                          keepAliveTimeout:
+                            default: 30000
+                            description: Should keep alive be used for the HTTP connection ?
+                            format: int64
+                            type: integer
+                          maxChunkSize:
+                            description: Maximum size of HTTP chunks
+                            type: integer
+                          maxConcurrentConnections:
+                            description: HTTP max concurrent connections
+                            type: integer
+                          maxHeaderSize:
+                            description: Maximum size of HTTP headers
+                            type: integer
+                          pipelining:
+                            default: false
+                            description: Should HTTP/1.1 pipelining be used for the connection or not ?
+                            type: boolean
+                          propagateClientAcceptEncoding:
+                            default: false
+                            description: Propagate Client Accept-Encoding header
+                            type: boolean
+                          readTimeout:
+                            description: Read timeout
+                            format: int64
+                            type: integer
+                          useCompression:
+                            default: false
+                            description: Should compression be used or not ?
+                            type: boolean
+                          version:
+                            default: HTTP_1_1
+                            description: HTTP Protocol Version (Possible values Http1 or Http2)
+                            enum:
+                              - HTTP_1_1
+                              - HTTP_2
+                            type: string
+                        required:
+                          - followRedirects
+                          - pipelining
+                          - useCompression
+                        type: object
+                      loadBalancer:
+                        description: Endpoint group load balancer
+                        properties:
+                          type:
+                            default: ROUND_ROBIN
+                            enum:
+                              - ROUND_ROBIN
+                              - RANDOM
+                              - WEIGHTED_ROUND_ROBIN
+                              - WEIGHTED_RANDOM
+                            type: string
+                        required:
+                          - type
+                        type: object
+                      name:
+                        description: Endpoint group name
+                        type: string
+                      services:
+                        description: Endpoint group services
+                        properties:
+                          discovery:
+                            description: Endpoint group discovery service
+                            properties:
+                              configuration:
+                                description: Service Configuration, a map of arbitrary key-values
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              enabled:
+                                description: Is the service enabled or not ?
+                                type: boolean
+                              overrideConfiguration:
+                                description: Service Override Configuration or not?
+                                type: boolean
+                              type:
+                                description: Service Type
+                                type: string
+                            required:
+                              - enabled
+                              - overrideConfiguration
+                            type: object
+                          healthCheck:
+                            description: Endpoint group health check service
+                            properties:
+                              configuration:
+                                description: Service Configuration, a map of arbitrary key-values
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              enabled:
+                                description: Is the service enabled or not ?
+                                type: boolean
+                              overrideConfiguration:
+                                description: Service Override Configuration or not?
+                                type: boolean
+                              type:
+                                description: Service Type
+                                type: string
+                            required:
+                              - enabled
+                              - overrideConfiguration
+                            type: object
+                        type: object
+                      sharedConfiguration:
+                        description: Endpoint group shared configuration, arbitrary map of key-values
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      ssl:
+                        description: Endpoint group http client SSL options
+                        properties:
+                          headers:
+                            description: Http headers
+                            items:
+                              properties:
+                                name:
+                                  description: The HTTP header name
+                                  type: string
+                                value:
+                                  description: The HTTP header value
+                                  type: string
+                              type: object
+                            type: array
+                          hostnameVerifier:
+                            default: true
+                            description: Verify Hostname when establishing connection
+                            type: boolean
+                          keyStore:
+                            description: KeyStore type (possible values PEM, PKCS12, JKS)
+                            properties:
+                              certContent:
+                                description: KeyStore cert content (Only applicable for PEM KeyStore)
+                                type: string
+                              certPath:
+                                description: KeyStore cert path (Only applicable for PEM KeyStore)
+                                type: string
+                              content:
+                                description: The base64 encoded trustStore content, if not relying on a path to
+                                  a file
+                                type: string
+                              keyContent:
+                                description: >-
+                                  The base64 encoded trustStore content, if not
+                                  relying on a path to a file
+
+                                  (Only applicable for PEM...
+                                type: string
+                              keyPath:
+                                description: KeyStore key path (Only applicable for PEM KeyStore)
+                                type: string
+                              password:
+                                type: string
+                              path:
+                                description: KeyStore path
+                                type: string
+                              type:
+                                description: The KeyStore type to use (possible values are PEM, PKCS12, JKS)
+                                enum:
+                                  - PEM
+                                  - PKCS12
+                                  - JKS
+                                type: string
+                            type: object
+                          trustAll:
+                            default: false
+                            description: Whether to trust all issuers or not
+                            type: boolean
+                          trustStore:
+                            description: TrustStore type (possible values PEM, PKCS12, JKS)
+                            properties:
+                              content:
+                                description: The base64 encoded trustStore content, if not relying on a path to
+                                  a file
+                                type: string
+                              password:
+                                description: TrustStore password (Not applicable for PEM TrustStore)
+                                type: string
+                              path:
+                                type: string
+                              type:
+                                description: The TrustStore type to use (possible values are PEM, PKCS12, JKS)
+                                enum:
+                                  - PEM
+                                  - PKCS12
+                                  - JKS
+                                type: string
+                            type: object
+                        required:
+                          - hostnameVerifier
+                          - trustAll
+                        type: object
+                      type:
+                        description: Endpoint group type
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  minItems: 1
+                  type: array
+                failover:
+                  description: API Failover
+                  properties:
+                    enabled:
+                      default: false
+                      description: API Failover is enabled?
+                      type: boolean
+                    maxFailures:
+                      default: 5
+                      description: API Failover max failures
+                      type: integer
+                    maxRetries:
+                      default: 2
+                      description: API Failover max retires
+                      type: integer
+                    openStateDuration:
+                      default: 10000
+                      description: API Failover  open state duration
+                      format: int64
+                      type: integer
+                    perSubscription:
+                      default: true
+                      description: API Failover  per subscription
+                      type: boolean
+                    slowCallDuration:
+                      default: 2000
+                      description: API Failover slow call duration
+                      format: int64
+                      type: integer
+                  type: object
+                flowExecution:
+                  description: API Flow Execution (Not applicable for Native API)
+                  properties:
+                    matchRequired:
+                      description: Is match required or not ?
+                      type: boolean
+                    mode:
+                      description: The flow mode to use
+                      type: string
+                  required:
+                    - matchRequired
+                  type: object
+                flows:
+                  default: []
+                  description: List of flows for the API
+                  items:
+                    properties:
+                      connect:
+                        description: List of Connect flow steps (Only available for Native APIs)
+                        items:
+                          properties:
+                            condition:
+                              description: FlowStep condition
+                              type: string
+                            configuration:
+                              description: FlowStep configuration is a map of arbitrary key-values
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            description:
+                              description: FlowStep description
+                              type: string
+                            enabled:
+                              default: true
+                              description: Indicate if this FlowStep is enabled or not
+                              type: boolean
+                            messageCondition:
+                              description: The message condition (supports EL expressions)
+                              type: string
+                            name:
+                              description: FlowStep name
+                              type: string
+                            policy:
+                              description: FlowStep policy
+                              type: string
+                            sharedPolicyGroupRef:
+                              description: Reference to an existing Shared Policy Group
+                              properties:
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - enabled
+                          type: object
+                        type: array
+                      enabled:
+                        default: true
+                        description: Is flow enabled or not?
+                        type: boolean
+                      id:
+                        description: >-
+                          The ID of the flow this field is mainly used for
+                          compatibility with
+
+                          APIM exports and can be safely...
+                        type: string
+                      interact:
+                        description: List of Publish flow steps (Only available for Native APIs)
+                        items:
+                          properties:
+                            condition:
+                              description: FlowStep condition
+                              type: string
+                            configuration:
+                              description: FlowStep configuration is a map of arbitrary key-values
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            description:
+                              description: FlowStep description
+                              type: string
+                            enabled:
+                              default: true
+                              description: Indicate if this FlowStep is enabled or not
+                              type: boolean
+                            messageCondition:
+                              description: The message condition (supports EL expressions)
+                              type: string
+                            name:
+                              description: FlowStep name
+                              type: string
+                            policy:
+                              description: FlowStep policy
+                              type: string
+                            sharedPolicyGroupRef:
+                              description: Reference to an existing Shared Policy Group
+                              properties:
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - enabled
+                          type: object
+                        type: array
+                      name:
+                        description: Flow name
+                        type: string
+                      publish:
+                        description: List of Publish flow steps
+                        items:
+                          properties:
+                            condition:
+                              description: FlowStep condition
+                              type: string
+                            configuration:
+                              description: FlowStep configuration is a map of arbitrary key-values
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            description:
+                              description: FlowStep description
+                              type: string
+                            enabled:
+                              default: true
+                              description: Indicate if this FlowStep is enabled or not
+                              type: boolean
+                            messageCondition:
+                              description: The message condition (supports EL expressions)
+                              type: string
+                            name:
+                              description: FlowStep name
+                              type: string
+                            policy:
+                              description: FlowStep policy
+                              type: string
+                            sharedPolicyGroupRef:
+                              description: Reference to an existing Shared Policy Group
+                              properties:
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - enabled
+                          type: object
+                        type: array
+                      request:
+                        description: List of Request flow steps (NOT available for Native APIs)
+                        items:
+                          properties:
+                            condition:
+                              description: FlowStep condition
+                              type: string
+                            configuration:
+                              description: FlowStep configuration is a map of arbitrary key-values
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            description:
+                              description: FlowStep description
+                              type: string
+                            enabled:
+                              default: true
+                              description: Indicate if this FlowStep is enabled or not
+                              type: boolean
+                            messageCondition:
+                              description: The message condition (supports EL expressions)
+                              type: string
+                            name:
+                              description: FlowStep name
+                              type: string
+                            policy:
+                              description: FlowStep policy
+                              type: string
+                            sharedPolicyGroupRef:
+                              description: Reference to an existing Shared Policy Group
+                              properties:
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - enabled
+                          type: object
+                        type: array
+                      response:
+                        description: List of Response flow steps (NOT available for Native APIs)
+                        items:
+                          properties:
+                            condition:
+                              description: FlowStep condition
+                              type: string
+                            configuration:
+                              description: FlowStep configuration is a map of arbitrary key-values
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            description:
+                              description: FlowStep description
+                              type: string
+                            enabled:
+                              default: true
+                              description: Indicate if this FlowStep is enabled or not
+                              type: boolean
+                            messageCondition:
+                              description: The message condition (supports EL expressions)
+                              type: string
+                            name:
+                              description: FlowStep name
+                              type: string
+                            policy:
+                              description: FlowStep policy
+                              type: string
+                            sharedPolicyGroupRef:
+                              description: Reference to an existing Shared Policy Group
+                              properties:
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - enabled
+                          type: object
+                        type: array
+                      selectors:
+                        description: List of Flow selectors
+                        items:
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        type: array
+                      subscribe:
+                        description: List of Subscribe flow steps
+                        items:
+                          properties:
+                            condition:
+                              description: FlowStep condition
+                              type: string
+                            configuration:
+                              description: FlowStep configuration is a map of arbitrary key-values
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            description:
+                              description: FlowStep description
+                              type: string
+                            enabled:
+                              default: true
+                              description: Indicate if this FlowStep is enabled or not
+                              type: boolean
+                            messageCondition:
+                              description: The message condition (supports EL expressions)
+                              type: string
+                            name:
+                              description: FlowStep name
+                              type: string
+                            policy:
+                              description: FlowStep policy
+                              type: string
+                            sharedPolicyGroupRef:
+                              description: Reference to an existing Shared Policy Group
+                              properties:
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                namespace:
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - enabled
+                          type: object
+                        type: array
+                      tags:
+                        description: List of tags
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - enabled
+                    type: object
+                  type: array
+                groupRefs:
+                  default: []
+                  description: |-
+                    List of group references associated with the API
+                    These groups are references to Group custom...
+                  items:
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                groups:
+                  default: []
+                  description: List of groups associated with the API.
+                  items:
+                    type: string
+                  type: array
+                id:
+                  description: >-
+                    The API ID. If empty, this field will take the value of the
+                    `metadata.uid`
+
+                    field of the resource.
+                  type: string
+                labels:
+                  default: []
+                  description: List of labels of the API
+                  items:
+                    type: string
+                  type: array
+                lifecycleState:
+                  default: UNPUBLISHED
+                  description: API life cycle state can be one of the values PUBLISHED,
+                    UNPUBLISHED, DEPRECATED, ARCHIVED
+                  enum:
+                    - PUBLISHED
+                    - UNPUBLISHED
+                    - DEPRECATED
+                    - ARCHIVED
+                  type: string
+                listeners:
+                  description: List of listeners for this API
+                  items:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  minItems: 1
+                  type: array
+                members:
+                  description: List of members associated with the API
+                  items:
+                    properties:
+                      role:
+                        default: USER
+                        description: The API role associated with this Member
+                        type: string
+                      source:
+                        description: Member source
+                        example: gravitee
+                        type: string
+                      sourceId:
+                        description: Member source ID
+                        example: user@email.com
+                        type: string
+                    required:
+                      - source
+                      - sourceId
+                    type: object
+                  type: array
+                metadata:
+                  default: []
+                  description: List of API metadata entries
+                  items:
+                    properties:
+                      defaultValue:
+                        description: Metadata Default value
+                        type: string
+                      format:
+                        description: Metadata Format
+                        enum:
+                          - STRING
+                          - NUMERIC
+                          - BOOLEAN
+                          - DATE
+                          - MAIL
+                          - URL
+                        type: string
+                      key:
+                        description: Metadata Key
+                        type: string
+                      name:
+                        description: Metadata Name
+                        type: string
+                      value:
+                        description: Metadata Value
+                        type: string
+                    required:
+                      - format
+                      - key
+                      - name
+                    type: object
+                  type: array
+                name:
+                  description: API name
+                  type: string
+                notificationsRefs:
+                  default: []
+                  description: References to Notification custom resources to setup notifications.
+                  items:
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                notifyMembers:
+                  default: true
+                  description: |-
+                    If true, new members added to the API spec will
+                    be notified when the API is synced with APIM.
+                  type: boolean
+                pages:
+                  additionalProperties:
+                    properties:
+                      api:
+                        description: The API of the page. If empty, will be set automatically to the
+                          generated ID of the API.
+                        type: string
+                      configuration:
+                        additionalProperties:
+                          type: string
+                        description: Custom page configuration (e.g. page rendering can be changed to
+                          use Redoc instead of Swagger ui)
+                        type: object
+                      content:
+                        description: The content of the page, if any.
+                        type: string
+                      crossId:
+                        description: CrossID is designed to identified a page across environments.
+                        type: string
+                      homepage:
+                        default: false
+                        description: If true, this page will be displayed as the homepage of your API
+                          documentation.
+                        type: boolean
+                      id:
+                        description: The ID of the page.
+                        type: string
+                      name:
+                        description: This is the display name of the page in APIM and on the portal.
+                        type: string
+                      order:
+                        description: The order used to display the page in APIM and on the portal.
+                        format: int64
+                        type: integer
+                      parent:
+                        description: >-
+                          If your page contains a folder, setting this field to
+                          the map key associated to the
+
+                          folder entry...
+                        type: string
+                      parentId:
+                        description: The parent ID of the page.
+                        type: string
+                      published:
+                        default: false
+                        description: If true, the page will be accessible from the portal (default is
+                          false)
+                        type: boolean
+                      source:
+                        description: >-
+                          Source allow you to fetch pages from various external
+                          sources, overriding page content
+
+                          each time...
+                        properties:
+                          configuration:
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          type:
+                            type: string
+                        required:
+                          - configuration
+                          - type
+                        type: object
+                      type:
+                        description: The type of the documentation page or folder.
+                        enum:
+                          - MARKDOWN
+                          - SWAGGER
+                          - ASYNCAPI
+                          - ASCIIDOC
+                          - FOLDER
+                          - SYSTEM_FOLDER
+                          - ROOT
+                        type: string
+                      visibility:
+                        default: PUBLIC
+                        description: The visibility of the page.
+                        enum:
+                          - PUBLIC
+                          - PRIVATE
+                        type: string
+                    required:
+                      - name
+                      - type
+                    type: object
+                  description: A map of pages objects.
+                  type: object
+                plans:
+                  additionalProperties:
+                    properties:
+                      characteristics:
+                        description: List of plan characteristics
+                        items:
+                          type: string
+                        type: array
+                      comment_required:
+                        description: Indicate of comment is required for this plan or not
+                        type: boolean
+                      crossId:
+                        description: The plan Cross ID.
+                        type: string
+                      definitionVersion:
+                        default: V4
+                        description: Plan definition version
+                        type: string
+                      description:
+                        description: Plan Description
+                        type: string
+                      excludedGroups:
+                        default: []
+                        items:
+                          type: string
+                        type: array
+                      flows:
+                        default: []
+                        description: List of plan flows
+                        items:
+                          properties:
+                            connect:
+                              description: List of Connect flow steps (Only available for Native APIs)
+                              items:
+                                properties:
+                                  condition:
+                                    description: FlowStep condition
+                                    type: string
+                                  configuration:
+                                    description: FlowStep configuration is a map of arbitrary key-values
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description:
+                                    description: FlowStep description
+                                    type: string
+                                  enabled:
+                                    default: true
+                                    description: Indicate if this FlowStep is enabled or not
+                                    type: boolean
+                                  messageCondition:
+                                    description: The message condition (supports EL expressions)
+                                    type: string
+                                  name:
+                                    description: FlowStep name
+                                    type: string
+                                  policy:
+                                    description: FlowStep policy
+                                    type: string
+                                  sharedPolicyGroupRef:
+                                    description: Reference to an existing Shared Policy Group
+                                    properties:
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - enabled
+                                type: object
+                              type: array
+                            enabled:
+                              default: true
+                              description: Is flow enabled or not?
+                              type: boolean
+                            id:
+                              description: >-
+                                The ID of the flow this field is mainly used for
+                                compatibility with
+
+                                APIM exports and can be safely...
+                              type: string
+                            interact:
+                              description: List of Publish flow steps (Only available for Native APIs)
+                              items:
+                                properties:
+                                  condition:
+                                    description: FlowStep condition
+                                    type: string
+                                  configuration:
+                                    description: FlowStep configuration is a map of arbitrary key-values
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description:
+                                    description: FlowStep description
+                                    type: string
+                                  enabled:
+                                    default: true
+                                    description: Indicate if this FlowStep is enabled or not
+                                    type: boolean
+                                  messageCondition:
+                                    description: The message condition (supports EL expressions)
+                                    type: string
+                                  name:
+                                    description: FlowStep name
+                                    type: string
+                                  policy:
+                                    description: FlowStep policy
+                                    type: string
+                                  sharedPolicyGroupRef:
+                                    description: Reference to an existing Shared Policy Group
+                                    properties:
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - enabled
+                                type: object
+                              type: array
+                            name:
+                              description: Flow name
+                              type: string
+                            publish:
+                              description: List of Publish flow steps
+                              items:
+                                properties:
+                                  condition:
+                                    description: FlowStep condition
+                                    type: string
+                                  configuration:
+                                    description: FlowStep configuration is a map of arbitrary key-values
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description:
+                                    description: FlowStep description
+                                    type: string
+                                  enabled:
+                                    default: true
+                                    description: Indicate if this FlowStep is enabled or not
+                                    type: boolean
+                                  messageCondition:
+                                    description: The message condition (supports EL expressions)
+                                    type: string
+                                  name:
+                                    description: FlowStep name
+                                    type: string
+                                  policy:
+                                    description: FlowStep policy
+                                    type: string
+                                  sharedPolicyGroupRef:
+                                    description: Reference to an existing Shared Policy Group
+                                    properties:
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - enabled
+                                type: object
+                              type: array
+                            request:
+                              description: List of Request flow steps (NOT available for Native APIs)
+                              items:
+                                properties:
+                                  condition:
+                                    description: FlowStep condition
+                                    type: string
+                                  configuration:
+                                    description: FlowStep configuration is a map of arbitrary key-values
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description:
+                                    description: FlowStep description
+                                    type: string
+                                  enabled:
+                                    default: true
+                                    description: Indicate if this FlowStep is enabled or not
+                                    type: boolean
+                                  messageCondition:
+                                    description: The message condition (supports EL expressions)
+                                    type: string
+                                  name:
+                                    description: FlowStep name
+                                    type: string
+                                  policy:
+                                    description: FlowStep policy
+                                    type: string
+                                  sharedPolicyGroupRef:
+                                    description: Reference to an existing Shared Policy Group
+                                    properties:
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - enabled
+                                type: object
+                              type: array
+                            response:
+                              description: List of Response flow steps (NOT available for Native APIs)
+                              items:
+                                properties:
+                                  condition:
+                                    description: FlowStep condition
+                                    type: string
+                                  configuration:
+                                    description: FlowStep configuration is a map of arbitrary key-values
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description:
+                                    description: FlowStep description
+                                    type: string
+                                  enabled:
+                                    default: true
+                                    description: Indicate if this FlowStep is enabled or not
+                                    type: boolean
+                                  messageCondition:
+                                    description: The message condition (supports EL expressions)
+                                    type: string
+                                  name:
+                                    description: FlowStep name
+                                    type: string
+                                  policy:
+                                    description: FlowStep policy
+                                    type: string
+                                  sharedPolicyGroupRef:
+                                    description: Reference to an existing Shared Policy Group
+                                    properties:
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - enabled
+                                type: object
+                              type: array
+                            selectors:
+                              description: List of Flow selectors
+                              items:
+                                type: object
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            subscribe:
+                              description: List of Subscribe flow steps
+                              items:
+                                properties:
+                                  condition:
+                                    description: FlowStep condition
+                                    type: string
+                                  configuration:
+                                    description: FlowStep configuration is a map of arbitrary key-values
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description:
+                                    description: FlowStep description
+                                    type: string
+                                  enabled:
+                                    default: true
+                                    description: Indicate if this FlowStep is enabled or not
+                                    type: boolean
+                                  messageCondition:
+                                    description: The message condition (supports EL expressions)
+                                    type: string
+                                  name:
+                                    description: FlowStep name
+                                    type: string
+                                  policy:
+                                    description: FlowStep policy
+                                    type: string
+                                  sharedPolicyGroupRef:
+                                    description: Reference to an existing Shared Policy Group
+                                    properties:
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                      namespace:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                required:
+                                  - enabled
+                                type: object
+                              type: array
+                            tags:
+                              description: List of tags
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - enabled
+                          type: object
+                        type: array
+                      generalConditions:
+                        description: The general conditions defined to use this plan
+                        type: string
+                      id:
+                        description: Plan ID
+                        type: string
+                      mode:
+                        allOf:
+                          - enum:
+                              - STANDARD
+                              - PUSH
+                          - enum:
+                              - STANDARD
+                              - PUSH
+                        default: STANDARD
+                        description: The plan mode
+                        type: string
+                      name:
+                        description: >-
+                          Plan display name, this will be the name displayed in
+                          the UI
+
+                          if a management context is used to...
+                        type: string
+                      order:
+                        description: Plan order
+                        type: integer
+                      security:
+                        description: Plan security
+                        properties:
+                          configuration:
+                            description: Plan security configuration, a map of arbitrary key-values
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                          type:
+                            description: Plan Security type
+                            type: string
+                        required:
+                          - type
+                        type: object
+                      selectionRule:
+                        description: Plan selection rule
+                        type: string
+                      status:
+                        default: PUBLISHED
+                        description: The plan status
+                        enum:
+                          - PUBLISHED
+                          - DEPRECATED
+                          - STAGING
+                        type: string
+                      tags:
+                        default: []
+                        description: List of plan tags
+                        items:
+                          type: string
+                        type: array
+                      type:
+                        default: API
+                        description: Plan type
+                        enum:
+                          - API
+                          - CATALOG
+                        type: string
+                      validation:
+                        default: AUTO
+                        description: Plan validation strategy
+                        enum:
+                          - AUTO
+                          - MANUAL
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  description: >-
+                    A map of plan identifiers to plan
+
+                    Keys uniquely identify plans and are used to keep them in
+                    sync...
+                  type: object
+                properties:
+                  default: []
+                  description: List of Properties for the API
+                  items:
+                    properties:
+                      dynamic:
+                        description: Property is dynamic or not?
+                        type: boolean
+                      encryptable:
+                        description: Property is encryptable or not?
+                        type: boolean
+                      encrypted:
+                        description: Property Encrypted or not?
+                        type: boolean
+                      key:
+                        description: Property Key
+                        type: string
+                      value:
+                        description: Property Value
+                        type: string
+                    type: object
+                  type: array
+                resources:
+                  default: []
+                  description: >-
+                    Resources can be either inlined or reference the namespace
+                    and name
+
+                    of an <a...
+                  items:
+                    properties:
+                      configuration:
+                        description: Resource Configuration, arbitrary map of key-values
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      enabled:
+                        default: true
+                        description: Is resource enabled or not?
+                        type: boolean
+                      name:
+                        description: Resource Name
+                        type: string
+                      ref:
+                        description: Reference to a resource
+                        properties:
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type:
+                        description: Resource Type
+                        type: string
+                    type: object
+                  type: array
+                responseTemplates:
+                  additionalProperties:
+                    additionalProperties:
+                      properties:
+                        body:
+                          type: string
+                        headers:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        propagateErrorKeyToLogs:
+                          description: Propagate error key to logs
+                          type: boolean
+                        status:
+                          type: integer
+                      type: object
+                    type: object
+                  description: A list of Response Templates for the API (Not applicable for Native
+                    API)
+                  type: object
+                services:
+                  description: API Services (Not applicable for Native API)
+                  properties:
+                    dynamicProperty:
+                      description: API dynamic property service
+                      properties:
+                        configuration:
+                          description: Service Configuration, a map of arbitrary key-values
+                          type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        enabled:
+                          description: Is the service enabled or not ?
+                          type: boolean
+                        overrideConfiguration:
+                          description: Service Override Configuration or not?
+                          type: boolean
+                        type:
+                          description: Service Type
+                          type: string
+                      required:
+                        - enabled
+                        - overrideConfiguration
+                      type: object
+                  type: object
+                state:
+                  default: STARTED
+                  description: The state of API (setting the value to `STOPPED` will make the API
+                    un-reachable from the gateway)
+                  enum:
+                    - STARTED
+                    - STOPPED
+                  type: string
+                tags:
+                  description: List of Tags of the API
+                  items:
+                    type: string
+                  type: array
+                type:
+                  description: Api Type (proxy or message)
+                  enum:
+                    - PROXY
+                    - MESSAGE
+                    - NATIVE
+                    - LLM_PROXY
+                    - MCP_PROXY
+                    - A2A_PROXY
+                  type: string
+                version:
+                  description: API version
+                  type: string
+                visibility:
+                  default: PRIVATE
+                  description: Should the API be publicly available from the portal or not ?
+                  enum:
+                    - PUBLIC
+                    - PRIVATE
+                  type: string
+              required:
+                - endpointGroups
+                - listeners
+                - name
+                - type
+                - version
+              type: object
+            status:
+              description: ApiV4DefinitionStatus defines the observed state of API Definition.
+              properties:
+                conditions:
+                  default: []
+                  description: Conditions describe the current conditions of the API.
+                  items:
+                    description: Condition contains details for one aspect of the current state of
+                      this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from
+                          one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the
+                          transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the
+                          condition was set based upon.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for
+                          the condition's last transition.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 8
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                crossId:
+                  description: The Cross ID is used to identify an API that has been promoted from
+                    one environment to another.
+                  type: string
+                environmentId:
+                  description: The environment ID, if a management context has been defined to
+                    sync with an APIM instance
+                  type: string
+                errors:
+                  description: >-
+                    When API has been created regardless of errors, this field
+                    is
+
+                    used to persist the error message...
+                  properties:
+                    severe:
+                      description: >-
+                        severe errors do not pass admission and will block
+                        reconcile
+
+                        hence, this field should always be...
+                      items:
+                        type: string
+                      type: array
+                    warning:
+                      description: |-
+                        warning errors do not block object reconciliation,
+                        most of the time because the value is ignored or...
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                id:
+                  description: The ID of the API definition in the Gravitee API Management
+                    instance (if an API context has been...
+                  type: string
+                organizationId:
+                  description: The organization ID, if a management context has been defined to
+                    sync with an APIM instance
+                  type: string
+                plans:
+                  additionalProperties:
+                    type: string
+                  description: >-
+                    This field is used to store the list of plans that have been
+                    created
+
+                    for the API definition if a...
+                  type: object
+                processingStatus:
+                  description: The processing status of the API definition. *** DEPRECATED ***
+                  type: string
+                state:
+                  description: The state of the API. Can be either STARTED or STOPPED.
+                  enum:
+                    - STARTED
+                    - STOPPED
+                  type: string
+                subscriptions:
+                  description: The number of subscriptions that reference the API
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_applications.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_applications.yaml
@@ -1,0 +1,370 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    gravitee.io/operator.version: 4.11.1
+  name: applications.gravitee.io
+spec:
+  group: gravitee.io
+  names:
+    kind: Application
+    listKind: ApplicationList
+    plural: applications
+    shortNames:
+      - graviteeapplications
+    singular: application
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.name
+          name: Name
+          type: string
+        - jsonPath: .spec.applicationType
+          name: Type
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: APIVersion defines the versioned schema of this representation of
+                an object.
+              type: string
+            kind:
+              description: Kind is a string value representing the REST resource this object
+                represents.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Application is the main resource handled by the Kubernetes Operator
+              properties:
+                background:
+                  description: The base64 encoded background to use for this application when
+                    displaying it on the portal
+                  type: string
+                contextRef:
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                description:
+                  description: Application Description
+                  type: string
+                domain:
+                  description: Application domain
+                  type: string
+                groups:
+                  description: Application groups
+                  items:
+                    type: string
+                  type: array
+                id:
+                  description: |-
+                    io.gravitee.definition.model.Application
+                    Application ID
+                  type: string
+                members:
+                  description: Application members
+                  items:
+                    properties:
+                      role:
+                        default: USER
+                        description: The API role associated with this Member
+                        type: string
+                      source:
+                        description: Member source
+                        example: gravitee
+                        type: string
+                      sourceId:
+                        description: Member source ID
+                        example: user@email.com
+                        type: string
+                    required:
+                      - source
+                      - sourceId
+                    type: object
+                  type: array
+                metadata:
+                  description: Application metadata
+                  items:
+                    properties:
+                      defaultValue:
+                        description: Metadata DefaultValue
+                        type: string
+                      format:
+                        description: Metadata Format
+                        enum:
+                          - STRING
+                          - NUMERIC
+                          - BOOLEAN
+                          - DATE
+                          - MAIL
+                          - URL
+                        type: string
+                      hidden:
+                        description: Metadata is hidden or not?
+                        type: boolean
+                      name:
+                        description: Metadata Name
+                        type: string
+                      value:
+                        description: Metadata Value
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  type: array
+                name:
+                  description: Application name
+                  type: string
+                notifyMembers:
+                  description: Notify members when they are added to the application
+                  type: boolean
+                picture:
+                  description: The base64 encoded picture to use for this application when
+                    displaying it on the portal (if not...
+                  type: string
+                pictureUrl:
+                  description: A URL pointing to the picture to use when displaying the
+                    application on the portal
+                  type: string
+                settings:
+                  description: Application settings
+                  properties:
+                    app:
+                      properties:
+                        clientId:
+                          description: ClientID is the client id of the application
+                          type: string
+                        type:
+                          description: Application Type
+                          type: string
+                      required:
+                        - type
+                      type: object
+                    oauth:
+                      properties:
+                        applicationType:
+                          description: Oauth client application type
+                          enum:
+                            - BACKEND_TO_BACKEND
+                            - NATIVE
+                            - BROWSER
+                            - WEB
+                          type: string
+                        grantTypes:
+                          description: List of Oauth client grant types
+                          items:
+                            enum:
+                              - authorization_code
+                              - client_credentials
+                              - refresh_token
+                              - password
+                              - implicit
+                            type: string
+                          type: array
+                        redirectUris:
+                          description: List of Oauth client redirect uris
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - applicationType
+                        - grantTypes
+                      type: object
+                    tls:
+                      description: >-
+                        TLS settings are used to configure client side TLS in
+                        order
+
+                        to be able to subscribe to a MTLS plan.
+                      properties:
+                        clientCertificate:
+                          description: "Deprecated: use ClientCertificates instead."
+                          type: string
+                        clientCertificates:
+                          description: List of client certificates for mTLS plans.
+                          items:
+                            description: ClientCertificate represents a client certificate for mTLS plans.
+                            properties:
+                              content:
+                                description: Content is the certificate inlined (PEM or Base64) or a template [[
+                                  ]] notation.
+                                type: string
+                              encoded:
+                                description: Encoded indicates whether the content is base64 encoded.
+                                type: boolean
+                              endsAt:
+                                description: EndsAt is the optional end date of the certificate validity
+                                  (RFC3339).
+                                type: string
+                              name:
+                                description: Name is an optional label for this certificate.
+                                type: string
+                              ref:
+                                description: Ref is a reference to a Secret or ConfigMap containing the
+                                  certificate.
+                                properties:
+                                  key:
+                                    default: tls.crt
+                                    description: Key in the referenced Secret or ConfigMap data. Defaults to
+                                      "tls.crt".
+                                    type: string
+                                  kind:
+                                    default: secrets
+                                    description: Kind of the referenced resource. Defaults to "secrets".
+                                    enum:
+                                      - secrets
+                                      - configmaps
+                                    type: string
+                                  name:
+                                    description: Name of the referenced Secret or ConfigMap.
+                                    type: string
+                                  namespace:
+                                    description: Namespace of the referenced resource. Defaults to the Application
+                                      namespace.
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              startsAt:
+                                description: StartsAt is the optional start date of the certificate validity
+                                  (RFC3339).
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+              required:
+                - contextRef
+                - description
+                - name
+                - settings
+              type: object
+            status:
+              description: ApplicationStatus defines the observed state of Application.
+              properties:
+                conditions:
+                  default: []
+                  description: Conditions describe the current conditions of the Application.
+                  items:
+                    description: Condition contains details for one aspect of the current state of
+                      this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from
+                          one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the
+                          transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the
+                          condition was set based upon.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for
+                          the condition's last transition.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 8
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                environmentId:
+                  description: The environment ID, if a management context has been defined to
+                    sync with an APIM instance
+                  type: string
+                errors:
+                  description: >-
+                    When application has been created regardless of errors, this
+                    field is
+
+                    used to persist the error...
+                  properties:
+                    severe:
+                      description: >-
+                        severe errors do not pass admission and will block
+                        reconcile
+
+                        hence, this field should always be...
+                      items:
+                        type: string
+                      type: array
+                    warning:
+                      description: |-
+                        warning errors do not block object reconciliation,
+                        most of the time because the value is ignored or...
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                id:
+                  description: The ID of the Application, if a management context has been defined
+                    to sync with an APIM instance
+                  type: string
+                organizationId:
+                  description: The organization ID, if a management context has been defined to
+                    sync with an APIM instance
+                  type: string
+                processingStatus:
+                  description: The processing status of the Application.
+                  type: string
+                subscriptions:
+                  description: The number of subscriptions that reference the application
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_gatewayclassparameters.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_gatewayclassparameters.yaml
@@ -1,0 +1,7623 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    gravitee.io/extends: gateway.networking.k8s.io
+    gravitee.io/operator.version: 4.11.1
+  name: gatewayclassparameters.gravitee.io
+spec:
+  group: gravitee.io
+  names:
+    kind: GatewayClassParameters
+    listKind: GatewayClassParametersList
+    plural: gatewayclassparameters
+    singular: gatewayclassparameters
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: APIVersion defines the versioned schema of this representation of
+                an object.
+              type: string
+            kind:
+              description: Kind is a string value representing the REST resource this object
+                represents.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GatewayClassParametersSpec defines the desired state of
+                GatewayClassParameters
+              properties:
+                gravitee:
+                  description: |-
+                    The gravitee section controls Gravitee specific features
+                    and allows you to configure and customize...
+                  properties:
+                    kafka:
+                      default:
+                        enabled: false
+                      description: Use this field to enable Kafka support in the Gateway.
+                      properties:
+                        enabled:
+                          default: true
+                          type: boolean
+                        routingHostMode:
+                          default: {}
+                          properties:
+                            bootstrapDomainPattern:
+                              default: "{apiHost}"
+                              description: You can find details about these configurations options in our...
+                              type: string
+                            brokerDomainPattern:
+                              default: broker-{brokerId}-{apiHost}
+                              type: string
+                          type: object
+                      type: object
+                    licenseRef:
+                      description: A reference to a Kubernetes Secret that contains your Gravitee
+                        license key.
+                      properties:
+                        group:
+                          default: ""
+                          description: Group is the group of the referent. For example,
+                            "gateway.networking.k8s.io".
+                          maxLength: 253
+                          pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        kind:
+                          default: Secret
+                          description: Kind is kind of the referent. For example "Secret".
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                          type: string
+                        name:
+                          description: Name is the name of the referent.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the referenced object.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    yaml:
+                      description: |-
+                        Use this field to provide custom gateway configuration,
+                        giving you control over additional...
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
+                kubernetes:
+                  description: |-
+                    The kubernetes section of the GatewayClassParameters
+                    spec lets you customize core Kubernetes...
+                  properties:
+                    autoscaling:
+                      description: Use this field to configure Kubernetes HorizontalPodAutoscaler for
+                        the Gateway.
+                      properties:
+                        behavior:
+                          description: Behavior configures scaling behavior for the
+                            HorizontalPodAutoscaler.
+                          properties:
+                            scaleDown:
+                              description: scaleDown is scaling policy for scaling Down.
+                              properties:
+                                policies:
+                                  description: policies is a list of potential scaling polices which can be used
+                                    during scaling.
+                                  items:
+                                    description: HPAScalingPolicy is a single policy which must hold true for a
+                                      specified past interval.
+                                    properties:
+                                      periodSeconds:
+                                        description: periodSeconds specifies the window of time for which the policy
+                                          should hold true.
+                                        format: int32
+                                        type: integer
+                                      type:
+                                        description: type is used to specify the scaling policy.
+                                        type: string
+                                      value:
+                                        description: >-
+                                          value contains the amount of change
+                                          which is permitted by the policy.
+
+                                          It must be greater than zero
+                                        format: int32
+                                        type: integer
+                                    required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                selectPolicy:
+                                  description: selectPolicy is used to specify which policy should be used.
+                                  type: string
+                                stabilizationWindowSeconds:
+                                  description: stabilizationWindowSeconds is the number of seconds for which past
+                                    recommendations should be...
+                                  format: int32
+                                  type: integer
+                                tolerance:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: >-
+                                    tolerance is the tolerance on the ratio
+                                    between the current and desired
+
+                                    metric value under which no...
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            scaleUp:
+                              description: scaleUp is scaling policy for scaling Up.
+                              properties:
+                                policies:
+                                  description: policies is a list of potential scaling polices which can be used
+                                    during scaling.
+                                  items:
+                                    description: HPAScalingPolicy is a single policy which must hold true for a
+                                      specified past interval.
+                                    properties:
+                                      periodSeconds:
+                                        description: periodSeconds specifies the window of time for which the policy
+                                          should hold true.
+                                        format: int32
+                                        type: integer
+                                      type:
+                                        description: type is used to specify the scaling policy.
+                                        type: string
+                                      value:
+                                        description: >-
+                                          value contains the amount of change
+                                          which is permitted by the policy.
+
+                                          It must be greater than zero
+                                        format: int32
+                                        type: integer
+                                    required:
+                                      - periodSeconds
+                                      - type
+                                      - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                selectPolicy:
+                                  description: selectPolicy is used to specify which policy should be used.
+                                  type: string
+                                stabilizationWindowSeconds:
+                                  description: stabilizationWindowSeconds is the number of seconds for which past
+                                    recommendations should be...
+                                  format: int32
+                                  type: integer
+                                tolerance:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: >-
+                                    tolerance is the tolerance on the ratio
+                                    between the current and desired
+
+                                    metric value under which no...
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
+                        enabled:
+                          default: false
+                          description: Use this field to enable HorizontalPodAutoscaler reconciliation for
+                            the Gateway.
+                          type: boolean
+                        maxReplicas:
+                          default: 10
+                          description: The maximum number of replicas when autoscaling is enabled.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        metrics:
+                          description: The metrics used by the HorizontalPodAutoscaler to determine the
+                            desired replica count.
+                          items:
+                            description: >-
+                              MetricSpec specifies how to scale based on a
+                              single metric
+
+                              (only `type` and one other matching...
+                            properties:
+                              containerResource:
+                                description: >-
+                                  containerResource refers to a resource metric
+                                  (such as those specified in
+
+                                  requests and limits)...
+                                properties:
+                                  container:
+                                    description: container is the name of the container in the pods of the scaling
+                                      target
+                                    type: string
+                                  name:
+                                    description: name is the name of the resource in question.
+                                    type: string
+                                  target:
+                                    description: target specifies the target value for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: >-
+                                          averageUtilization is the target value
+                                          of the average of the
+
+                                          resource metric across all relevant...
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: >-
+                                          averageValue is the target value of
+                                          the average of the
+
+                                          metric across all relevant pods (as
+                                          a...
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric type is Utilization, Value, or
+                                          AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: value is the target value of the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - type
+                                    type: object
+                                required:
+                                  - container
+                                  - name
+                                  - target
+                                type: object
+                              external:
+                                description: >-
+                                  external refers to a global metric that is not
+                                  associated
+
+                                  with any Kubernetes object.
+                                properties:
+                                  metric:
+                                    description: metric identifies the target metric by name and selector
+                                    properties:
+                                      name:
+                                        description: name is the name of the given metric
+                                        type: string
+                                      selector:
+                                        description: selector is the string-encoded form of a standard kubernetes label
+                                          selector for the given metric...
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement is a selector that contains values, a
+                                                key, and an operator that...
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value} pairs.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - name
+                                    type: object
+                                  target:
+                                    description: target specifies the target value for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: >-
+                                          averageUtilization is the target value
+                                          of the average of the
+
+                                          resource metric across all relevant...
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: >-
+                                          averageValue is the target value of
+                                          the average of the
+
+                                          metric across all relevant pods (as
+                                          a...
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric type is Utilization, Value, or
+                                          AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: value is the target value of the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - type
+                                    type: object
+                                required:
+                                  - metric
+                                  - target
+                                type: object
+                              object:
+                                description: >-
+                                  object refers to a metric describing a single
+                                  kubernetes object
+
+                                  (for example, hits-per-second on an...
+                                properties:
+                                  describedObject:
+                                    description: describedObject specifies the descriptions of a object,such as
+                                      kind,name apiVersion
+                                    properties:
+                                      apiVersion:
+                                        description: apiVersion is the API version of the referent
+                                        type: string
+                                      kind:
+                                        description: "kind is the kind of the referent; More info: https://git.k8s."
+                                        type: string
+                                      name:
+                                        description: "name is the name of the referent; More info: https://kubernetes."
+                                        type: string
+                                    required:
+                                      - kind
+                                      - name
+                                    type: object
+                                  metric:
+                                    description: metric identifies the target metric by name and selector
+                                    properties:
+                                      name:
+                                        description: name is the name of the given metric
+                                        type: string
+                                      selector:
+                                        description: selector is the string-encoded form of a standard kubernetes label
+                                          selector for the given metric...
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement is a selector that contains values, a
+                                                key, and an operator that...
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value} pairs.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - name
+                                    type: object
+                                  target:
+                                    description: target specifies the target value for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: >-
+                                          averageUtilization is the target value
+                                          of the average of the
+
+                                          resource metric across all relevant...
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: >-
+                                          averageValue is the target value of
+                                          the average of the
+
+                                          metric across all relevant pods (as
+                                          a...
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric type is Utilization, Value, or
+                                          AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: value is the target value of the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - type
+                                    type: object
+                                required:
+                                  - describedObject
+                                  - metric
+                                  - target
+                                type: object
+                              pods:
+                                description: >-
+                                  pods refers to a metric describing each pod in
+                                  the current scale target
+
+                                  (for example,...
+                                properties:
+                                  metric:
+                                    description: metric identifies the target metric by name and selector
+                                    properties:
+                                      name:
+                                        description: name is the name of the given metric
+                                        type: string
+                                      selector:
+                                        description: selector is the string-encoded form of a standard kubernetes label
+                                          selector for the given metric...
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement is a selector that contains values, a
+                                                key, and an operator that...
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value} pairs.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - name
+                                    type: object
+                                  target:
+                                    description: target specifies the target value for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: >-
+                                          averageUtilization is the target value
+                                          of the average of the
+
+                                          resource metric across all relevant...
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: >-
+                                          averageValue is the target value of
+                                          the average of the
+
+                                          metric across all relevant pods (as
+                                          a...
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric type is Utilization, Value, or
+                                          AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: value is the target value of the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - type
+                                    type: object
+                                required:
+                                  - metric
+                                  - target
+                                type: object
+                              resource:
+                                description: >-
+                                  resource refers to a resource metric (such as
+                                  those specified in
+
+                                  requests and limits) known to...
+                                properties:
+                                  name:
+                                    description: name is the name of the resource in question.
+                                    type: string
+                                  target:
+                                    description: target specifies the target value for the given metric
+                                    properties:
+                                      averageUtilization:
+                                        description: >-
+                                          averageUtilization is the target value
+                                          of the average of the
+
+                                          resource metric across all relevant...
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: >-
+                                          averageValue is the target value of
+                                          the average of the
+
+                                          metric across all relevant pods (as
+                                          a...
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        description: type represents whether the metric type is Utilization, Value, or
+                                          AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: value is the target value of the metric (as a quantity).
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - type
+                                    type: object
+                                required:
+                                  - name
+                                  - target
+                                type: object
+                              type:
+                                description: type is the type of metric source.
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          type: array
+                        minReplicas:
+                          default: 1
+                          description: The minimum number of replicas when autoscaling is enabled.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                      type: object
+                    deployment:
+                      description: |-
+                        Use this field to modify pod labels and annotations,
+                        adjust the number of replicas to control...
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        replicas:
+                          default: 1
+                          format: int32
+                          type: integer
+                        strategy:
+                          description: DeploymentStrategy describes how to replace existing pods with new
+                            ones.
+                          properties:
+                            rollingUpdate:
+                              description: >-
+                                Rolling update config params. Present only if
+                                DeploymentStrategyType =
+
+                                RollingUpdate.
+                              properties:
+                                maxSurge:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: >-
+                                    The maximum number of pods that can be
+                                    scheduled above the desired number of
+
+                                    pods.
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: The maximum number of pods that can be unavailable during the
+                                    update.
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default
+                                is RollingUpdate.
+                              type: string
+                          type: object
+                        template:
+                          description: The template.
+                          properties:
+                            metadata:
+                              description: |-
+                                Standard object's metadata.
+                                More info: https://git.k8s.
+                              type: object
+                            spec:
+                              description: >-
+                                Specification of the desired behavior of the
+                                pod.
+
+                                More info: https://git.k8s.
+                              properties:
+                                activeDeadlineSeconds:
+                                  description: >-
+                                    Optional duration in seconds the pod may be
+                                    active on the node relative to
+
+                                    StartTime before the...
+                                  format: int64
+                                  type: integer
+                                affinity:
+                                  description: If specified, the pod's scheduling constraints
+                                  properties:
+                                    nodeAffinity:
+                                      description: Describes node affinity scheduling rules for the pod.
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: >-
+                                            The scheduler will prefer to
+                                            schedule pods to nodes that satisfy
+
+                                            the affinity expressions
+                                            specified...
+                                          items:
+                                            description: >-
+                                              An empty preferred scheduling term
+                                              matches all objects with implicit
+                                              weight 0
+
+                                              (i.e. it's a no-op).
+                                            properties:
+                                              preference:
+                                                description: A node selector term, associated with the corresponding weight.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: A list of node selector requirements by node's labels.
+                                                    items:
+                                                      description: >-
+                                                        A node selector
+                                                        requirement is a
+                                                        selector that contains
+                                                        values, a key, and an
+                                                        operator
+
+                                                        that relates...
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: Represents a key's relationship to a set of values.
+                                                          type: string
+                                                        values:
+                                                          description: >-
+                                                            An array of string
+                                                            values. If the
+                                                            operator is In or
+                                                            NotIn,
+
+                                                            the values array
+                                                            must be non-empty.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchFields:
+                                                    description: A list of node selector requirements by node's fields.
+                                                    items:
+                                                      description: >-
+                                                        A node selector
+                                                        requirement is a
+                                                        selector that contains
+                                                        values, a key, and an
+                                                        operator
+
+                                                        that relates...
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: Represents a key's relationship to a set of values.
+                                                          type: string
+                                                        values:
+                                                          description: >-
+                                                            An array of string
+                                                            values. If the
+                                                            operator is In or
+                                                            NotIn,
+
+                                                            the values array
+                                                            must be non-empty.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              weight:
+                                                description: Weight associated with matching the corresponding nodeSelectorTerm,
+                                                  in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                              - preference
+                                              - weight
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: >-
+                                            If the affinity requirements
+                                            specified by this field are not met
+                                            at
+
+                                            scheduling time, the pod will...
+                                          properties:
+                                            nodeSelectorTerms:
+                                              description: Required. A list of node selector terms. The terms are ORed.
+                                              items:
+                                                description: >-
+                                                  A null or empty node selector
+                                                  term matches no objects. The
+                                                  requirements of
+
+                                                  them are ANDed.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: A list of node selector requirements by node's labels.
+                                                    items:
+                                                      description: >-
+                                                        A node selector
+                                                        requirement is a
+                                                        selector that contains
+                                                        values, a key, and an
+                                                        operator
+
+                                                        that relates...
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: Represents a key's relationship to a set of values.
+                                                          type: string
+                                                        values:
+                                                          description: >-
+                                                            An array of string
+                                                            values. If the
+                                                            operator is In or
+                                                            NotIn,
+
+                                                            the values array
+                                                            must be non-empty.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchFields:
+                                                    description: A list of node selector requirements by node's fields.
+                                                    items:
+                                                      description: >-
+                                                        A node selector
+                                                        requirement is a
+                                                        selector that contains
+                                                        values, a key, and an
+                                                        operator
+
+                                                        that relates...
+                                                      properties:
+                                                        key:
+                                                          description: The label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: Represents a key's relationship to a set of values.
+                                                          type: string
+                                                        values:
+                                                          description: >-
+                                                            An array of string
+                                                            values. If the
+                                                            operator is In or
+                                                            NotIn,
+
+                                                            the values array
+                                                            must be non-empty.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                            - nodeSelectorTerms
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    podAffinity:
+                                      description: Describes pod affinity scheduling rules (e.g. co-locate this pod in
+                                        the same node, zone, etc.
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: >-
+                                            The scheduler will prefer to
+                                            schedule pods to nodes that satisfy
+
+                                            the affinity expressions
+                                            specified...
+                                          items:
+                                            description: The weights of all of the matched WeightedPodAffinityTerm fields
+                                              are added per-node to find the...
+                                            properties:
+                                              podAffinityTerm:
+                                                description: Required. A pod affinity term, associated with the corresponding
+                                                  weight.
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a set of resources, in this case pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The
+                                                          requirements are
+                                                          ANDed.
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a
+                                                            key, and an operator
+                                                            that...
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: matchLabels is a map of {key,value} pairs.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: >-
+                                                      MatchLabelKeys is a set of
+                                                      pod label keys to select
+                                                      which pods will
+
+                                                      be taken into
+                                                      consideration.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: >-
+                                                      MismatchLabelKeys is a set
+                                                      of pod label keys to
+                                                      select which pods will
+
+                                                      be taken into
+                                                      consideration.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: A label query over the set of namespaces that the term applies to.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The
+                                                          requirements are
+                                                          ANDed.
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a
+                                                            key, and an operator
+                                                            that...
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: matchLabels is a map of {key,value} pairs.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: namespaces specifies a static list of namespace names that the term
+                                                      applies to.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located
+                                                      (anti-affinity) with the
+                                                      pods matching...
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              weight:
+                                                description: >-
+                                                  weight associated with
+                                                  matching the corresponding
+                                                  podAffinityTerm,
+
+                                                  in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                              - podAffinityTerm
+                                              - weight
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: >-
+                                            If the affinity requirements
+                                            specified by this field are not met
+                                            at
+
+                                            scheduling time, the pod will...
+                                          items:
+                                            description: >-
+                                              Defines a set of pods (namely
+                                              those matching the labelSelector
+
+                                              relative to the given
+                                              namespace(s))...
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The
+                                                      requirements are ANDed.
+                                                    items:
+                                                      description: A label selector requirement is a selector that contains values, a
+                                                        key, and an operator
+                                                        that...
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents a key's relationship to a set of values.
+                                                          type: string
+                                                        values:
+                                                          description: values is an array of string values.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a map of {key,value} pairs.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: >-
+                                                  MatchLabelKeys is a set of pod
+                                                  label keys to select which
+                                                  pods will
+
+                                                  be taken into consideration.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: >-
+                                                  MismatchLabelKeys is a set of
+                                                  pod label keys to select which
+                                                  pods will
+
+                                                  be taken into consideration.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              namespaceSelector:
+                                                description: A label query over the set of namespaces that the term applies to.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The
+                                                      requirements are ANDed.
+                                                    items:
+                                                      description: A label selector requirement is a selector that contains values, a
+                                                        key, and an operator
+                                                        that...
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents a key's relationship to a set of values.
+                                                          type: string
+                                                        values:
+                                                          description: values is an array of string values.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a map of {key,value} pairs.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: namespaces specifies a static list of namespace names that the term
+                                                  applies to.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              topologyKey:
+                                                description: This pod should be co-located (affinity) or not co-located
+                                                  (anti-affinity) with the pods
+                                                  matching...
+                                                type: string
+                                            required:
+                                              - topologyKey
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    podAntiAffinity:
+                                      description: Describes pod anti-affinity scheduling rules (e.g.
+                                      properties:
+                                        preferredDuringSchedulingIgnoredDuringExecution:
+                                          description: >-
+                                            The scheduler will prefer to
+                                            schedule pods to nodes that satisfy
+
+                                            the anti-affinity expressions...
+                                          items:
+                                            description: The weights of all of the matched WeightedPodAffinityTerm fields
+                                              are added per-node to find the...
+                                            properties:
+                                              podAffinityTerm:
+                                                description: Required. A pod affinity term, associated with the corresponding
+                                                  weight.
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a set of resources, in this case pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The
+                                                          requirements are
+                                                          ANDed.
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a
+                                                            key, and an operator
+                                                            that...
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: matchLabels is a map of {key,value} pairs.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: >-
+                                                      MatchLabelKeys is a set of
+                                                      pod label keys to select
+                                                      which pods will
+
+                                                      be taken into
+                                                      consideration.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: >-
+                                                      MismatchLabelKeys is a set
+                                                      of pod label keys to
+                                                      select which pods will
+
+                                                      be taken into
+                                                      consideration.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: A label query over the set of namespaces that the term applies to.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The
+                                                          requirements are
+                                                          ANDed.
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a
+                                                            key, and an operator
+                                                            that...
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: matchLabels is a map of {key,value} pairs.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: namespaces specifies a static list of namespace names that the term
+                                                      applies to.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  topologyKey:
+                                                    description: This pod should be co-located (affinity) or not co-located
+                                                      (anti-affinity) with the
+                                                      pods matching...
+                                                    type: string
+                                                required:
+                                                  - topologyKey
+                                                type: object
+                                              weight:
+                                                description: >-
+                                                  weight associated with
+                                                  matching the corresponding
+                                                  podAffinityTerm,
+
+                                                  in the range 1-100.
+                                                format: int32
+                                                type: integer
+                                            required:
+                                              - podAffinityTerm
+                                              - weight
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        requiredDuringSchedulingIgnoredDuringExecution:
+                                          description: >-
+                                            If the anti-affinity requirements
+                                            specified by this field are not met
+                                            at
+
+                                            scheduling time, the pod...
+                                          items:
+                                            description: >-
+                                              Defines a set of pods (namely
+                                              those matching the labelSelector
+
+                                              relative to the given
+                                              namespace(s))...
+                                            properties:
+                                              labelSelector:
+                                                description: A label query over a set of resources, in this case pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The
+                                                      requirements are ANDed.
+                                                    items:
+                                                      description: A label selector requirement is a selector that contains values, a
+                                                        key, and an operator
+                                                        that...
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents a key's relationship to a set of values.
+                                                          type: string
+                                                        values:
+                                                          description: values is an array of string values.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a map of {key,value} pairs.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: >-
+                                                  MatchLabelKeys is a set of pod
+                                                  label keys to select which
+                                                  pods will
+
+                                                  be taken into consideration.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: >-
+                                                  MismatchLabelKeys is a set of
+                                                  pod label keys to select which
+                                                  pods will
+
+                                                  be taken into consideration.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              namespaceSelector:
+                                                description: A label query over the set of namespaces that the term applies to.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The
+                                                      requirements are ANDed.
+                                                    items:
+                                                      description: A label selector requirement is a selector that contains values, a
+                                                        key, and an operator
+                                                        that...
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: operator represents a key's relationship to a set of values.
+                                                          type: string
+                                                        values:
+                                                          description: values is an array of string values.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                        - key
+                                                        - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: matchLabels is a map of {key,value} pairs.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: namespaces specifies a static list of namespace names that the term
+                                                  applies to.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              topologyKey:
+                                                description: This pod should be co-located (affinity) or not co-located
+                                                  (anti-affinity) with the pods
+                                                  matching...
+                                                type: string
+                                            required:
+                                              - topologyKey
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                  type: object
+                                automountServiceAccountToken:
+                                  description: AutomountServiceAccountToken indicates whether a service account
+                                    token should be automatically...
+                                  type: boolean
+                                containers:
+                                  description: >-
+                                    List of containers belonging to the pod.
+
+                                    Containers cannot currently be added or
+                                    removed.
+                                  items:
+                                    description: A single application container that you want to run within a pod.
+                                    properties:
+                                      args:
+                                        description: >-
+                                          Arguments to the entrypoint.
+
+                                          The container image's CMD is used if
+                                          this is not provided.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      command:
+                                        description: Entrypoint array. Not executed within a shell.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      env:
+                                        description: >-
+                                          List of environment variables to set
+                                          in the container.
+
+                                          Cannot be updated.
+                                        items:
+                                          description: EnvVar represents an environment variable present in a Container.
+                                          properties:
+                                            name:
+                                              description: >-
+                                                Name of the environment
+                                                variable.
+
+                                                May consist of any printable
+                                                ASCII characters except '='.
+                                              type: string
+                                            value:
+                                              description: >-
+                                                Variable references $(VAR_NAME)
+                                                are expanded
+
+                                                using the previously defined
+                                                environment variables in...
+                                              type: string
+                                            valueFrom:
+                                              description: Source for the environment variable's value. Cannot be used if
+                                                value is not empty.
+                                              properties:
+                                                configMapKeyRef:
+                                                  description: Selects a key of a ConfigMap.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: Name of the referent.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the ConfigMap or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  description: "Selects a field of the pod: supports metadata.name,
+                                                    metadata.namespace,
+                                                    `metadata."
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the schema the FieldPath is written in terms of,
+                                                        defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field to select in the specified API version.
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  description: >-
+                                                    FileKeyRef selects a key of
+                                                    the env file.
+
+                                                    Requires the EnvFiles
+                                                    feature gate to be enabled.
+                                                  properties:
+                                                    key:
+                                                      description: The key within the env file. An invalid key will prevent the pod
+                                                        from starting.
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      description: Specify whether the file or its key must be defined.
+                                                      type: boolean
+                                                    path:
+                                                      description: The path within the volume from which to select the file.
+                                                      type: string
+                                                    volumeName:
+                                                      description: The name of the volume mount containing the env file.
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  description: >-
+                                                    Selects a resource of the
+                                                    container: only resources
+                                                    limits and requests
+
+                                                    (limits.cpu, limits.
+                                                  properties:
+                                                    containerName:
+                                                      description: "Container name: required for volumes, optional for env vars"
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      description: Specifies the output format of the exposed resources, defaults to
+                                                        "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: "Required: resource to select"
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  description: Selects a key of a secret in the pod's namespace
+                                                  properties:
+                                                    key:
+                                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: Name of the referent.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the Secret or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      envFrom:
+                                        description: List of sources to populate environment variables in the container.
+                                        items:
+                                          description: EnvFromSource represents the source of a set of ConfigMaps or
+                                            Secrets
+                                          properties:
+                                            configMapRef:
+                                              description: The ConfigMap to select from
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  description: Name of the referent.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the ConfigMap must be defined
+                                                  type: boolean
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            prefix:
+                                              description: Optional text to prepend to the name of each environment variable.
+                                              type: string
+                                            secretRef:
+                                              description: The Secret to select from
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  description: Name of the referent.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the Secret must be defined
+                                                  type: boolean
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      image:
+                                        description: |-
+                                          Container image name.
+                                          More info: https://kubernetes.
+                                        type: string
+                                      imagePullPolicy:
+                                        description: |-
+                                          Image pull policy.
+                                          One of Always, Never, IfNotPresent.
+                                        type: string
+                                      lifecycle:
+                                        description: Actions that the management system should take in response to
+                                          container lifecycle events.
+                                        properties:
+                                          postStart:
+                                            description: PostStart is called immediately after a container is created.
+                                            properties:
+                                              exec:
+                                                description: Exec specifies a command to execute in the container.
+                                                properties:
+                                                  command:
+                                                    description: >-
+                                                      Command is the command
+                                                      line to execute inside the
+                                                      container, the working
+                                                      directory for the
+
+                                                      command ...
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies an HTTP GET request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect to, defaults to the pod IP.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header field name.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: >-
+                                                      Name or number of the port
+                                                      to access on the
+                                                      container.
+
+                                                      Number must be in the
+                                                      range 1 to 65535.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: >-
+                                                      Scheme to use for
+                                                      connecting to the host.
+
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              sleep:
+                                                description: Sleep represents a duration that the container should sleep.
+                                                properties:
+                                                  seconds:
+                                                    description: Seconds is the number of seconds to sleep.
+                                                    format: int64
+                                                    type: integer
+                                                required:
+                                                  - seconds
+                                                type: object
+                                              tcpSocket:
+                                                description: >-
+                                                  Deprecated. TCPSocket is NOT
+                                                  supported as a
+                                                  LifecycleHandler and kept
+
+                                                  for backward compatibility.
+                                                properties:
+                                                  host:
+                                                    description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: >-
+                                                      Number or name of the port
+                                                      to access on the
+                                                      container.
+
+                                                      Number must be in the
+                                                      range 1 to 65535.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                            type: object
+                                          preStop:
+                                            description: >-
+                                              PreStop is called immediately
+                                              before a container is terminated
+                                              due to an
+
+                                              API request or management...
+                                            properties:
+                                              exec:
+                                                description: Exec specifies a command to execute in the container.
+                                                properties:
+                                                  command:
+                                                    description: >-
+                                                      Command is the command
+                                                      line to execute inside the
+                                                      container, the working
+                                                      directory for the
+
+                                                      command ...
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies an HTTP GET request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect to, defaults to the pod IP.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header field name.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: >-
+                                                      Name or number of the port
+                                                      to access on the
+                                                      container.
+
+                                                      Number must be in the
+                                                      range 1 to 65535.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: >-
+                                                      Scheme to use for
+                                                      connecting to the host.
+
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              sleep:
+                                                description: Sleep represents a duration that the container should sleep.
+                                                properties:
+                                                  seconds:
+                                                    description: Seconds is the number of seconds to sleep.
+                                                    format: int64
+                                                    type: integer
+                                                required:
+                                                  - seconds
+                                                type: object
+                                              tcpSocket:
+                                                description: >-
+                                                  Deprecated. TCPSocket is NOT
+                                                  supported as a
+                                                  LifecycleHandler and kept
+
+                                                  for backward compatibility.
+                                                properties:
+                                                  host:
+                                                    description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: >-
+                                                      Number or name of the port
+                                                      to access on the
+                                                      container.
+
+                                                      Number must be in the
+                                                      range 1 to 65535.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                            type: object
+                                          stopSignal:
+                                            description: StopSignal defines which signal will be sent to a container when it
+                                              is being stopped.
+                                            type: string
+                                        type: object
+                                      livenessProbe:
+                                        description: >-
+                                          Periodic probe of container liveness.
+
+                                          Container will be restarted if the
+                                          probe fails.
+                                        properties:
+                                          exec:
+                                            description: Exec specifies a command to execute in the container.
+                                            properties:
+                                              command:
+                                                description: >-
+                                                  Command is the command line to
+                                                  execute inside the container,
+                                                  the working directory for the
+
+                                                  command ...
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe to be considered failed
+                                              after having succeeded.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies a GRPC HealthCheckRequest.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC service. Number must be in the range 1 to
+                                                  65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                default: ""
+                                                description: >-
+                                                  Service is the name of the
+                                                  service to place in the gRPC
+                                                  HealthCheckRequest
+
+                                                  (see https://github.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies an HTTP GET request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name.
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Name or number of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: >-
+                                                  Scheme to use for connecting
+                                                  to the host.
+
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: Number of seconds after the container has started before liveness
+                                              probes are initiated.
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: >-
+                                              How often (in seconds) to perform
+                                              the probe.
+
+                                              Default to 10 seconds. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe to be considered
+                                              successful after having failed.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies a connection to a TCP port.
+                                            properties:
+                                              host:
+                                                description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Number or name of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds the pod needs to terminate gracefully
+                                              upon probe failure.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: >-
+                                              Number of seconds after which the
+                                              probe times out.
+
+                                              Defaults to 1 second. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      name:
+                                        description: Name of the container specified as a DNS_LABEL.
+                                        type: string
+                                      ports:
+                                        description: List of ports to expose from the container.
+                                        items:
+                                          description: ContainerPort represents a network port in a single container.
+                                          properties:
+                                            containerPort:
+                                              description: >-
+                                                Number of port to expose on the
+                                                pod's IP address.
+
+                                                This must be a valid port
+                                                number, 0 < x < 65536.
+                                              format: int32
+                                              type: integer
+                                            hostIP:
+                                              description: What host IP to bind the external port to.
+                                              type: string
+                                            hostPort:
+                                              description: >-
+                                                Number of port to expose on the
+                                                host.
+
+                                                If specified, this must be a
+                                                valid port number, 0 < x <
+                                                65536.
+                                              format: int32
+                                              type: integer
+                                            name:
+                                              description: If specified, this must be an IANA_SVC_NAME and unique within the
+                                                pod.
+                                              type: string
+                                            protocol:
+                                              default: TCP
+                                              description: >-
+                                                Protocol for port. Must be UDP,
+                                                TCP, or SCTP.
+
+                                                Defaults to "TCP".
+                                              type: string
+                                          required:
+                                            - containerPort
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                        x-kubernetes-list-type: map
+                                      readinessProbe:
+                                        description: Periodic probe of container service readiness.
+                                        properties:
+                                          exec:
+                                            description: Exec specifies a command to execute in the container.
+                                            properties:
+                                              command:
+                                                description: >-
+                                                  Command is the command line to
+                                                  execute inside the container,
+                                                  the working directory for the
+
+                                                  command ...
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe to be considered failed
+                                              after having succeeded.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies a GRPC HealthCheckRequest.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC service. Number must be in the range 1 to
+                                                  65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                default: ""
+                                                description: >-
+                                                  Service is the name of the
+                                                  service to place in the gRPC
+                                                  HealthCheckRequest
+
+                                                  (see https://github.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies an HTTP GET request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name.
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Name or number of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: >-
+                                                  Scheme to use for connecting
+                                                  to the host.
+
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: Number of seconds after the container has started before liveness
+                                              probes are initiated.
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: >-
+                                              How often (in seconds) to perform
+                                              the probe.
+
+                                              Default to 10 seconds. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe to be considered
+                                              successful after having failed.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies a connection to a TCP port.
+                                            properties:
+                                              host:
+                                                description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Number or name of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds the pod needs to terminate gracefully
+                                              upon probe failure.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: >-
+                                              Number of seconds after which the
+                                              probe times out.
+
+                                              Defaults to 1 second. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      resizePolicy:
+                                        description: >-
+                                          Resources resize policy for the
+                                          container.
+
+                                          This field cannot be set on ephemeral
+                                          containers.
+                                        items:
+                                          description: ContainerResizePolicy represents resource resize policy for the
+                                            container.
+                                          properties:
+                                            resourceName:
+                                              description: >-
+                                                Name of the resource to which
+                                                this resource resize policy
+                                                applies.
+
+                                                Supported values: cpu, memory.
+                                              type: string
+                                            restartPolicy:
+                                              description: Restart policy to apply when specified resource is resized.
+                                              type: string
+                                          required:
+                                            - resourceName
+                                            - restartPolicy
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      resources:
+                                        description: >-
+                                          Compute Resources required by this
+                                          container.
+
+                                          Cannot be updated.
+
+                                          More info: https://kubernetes.
+                                        properties:
+                                          claims:
+                                            description: Claims lists the names of resources, defined in spec.
+                                            items:
+                                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                              properties:
+                                                name:
+                                                  description: Name must match the name of one entry in pod.spec.
+                                                  type: string
+                                                request:
+                                                  description: Request is the name chosen for a request in the referenced claim.
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: >-
+                                              Limits describes the maximum
+                                              amount of compute resources
+                                              allowed.
+
+                                              More info: https://kubernetes.
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: Requests describes the minimum amount of compute resources
+                                              required.
+                                            type: object
+                                        type: object
+                                      restartPolicy:
+                                        description: RestartPolicy defines the restart behavior of individual containers
+                                          in a pod.
+                                        type: string
+                                      restartPolicyRules:
+                                        description: >-
+                                          Represents a list of rules to be
+                                          checked to determine if the
+
+                                          container should be restarted on exit.
+                                        items:
+                                          description: ContainerRestartRule describes how a container exit is handled.
+                                          properties:
+                                            action:
+                                              description: >-
+                                                Specifies the action taken on a
+                                                container exit if the
+                                                requirements
+
+                                                are satisfied.
+                                              type: string
+                                            exitCodes:
+                                              description: Represents the exit codes to check on container exits.
+                                              properties:
+                                                operator:
+                                                  description: >-
+                                                    Represents the relationship
+                                                    between the container exit
+                                                    code(s) and the
+
+                                                    specified values.
+                                                  type: string
+                                                values:
+                                                  description: >-
+                                                    Specifies the set of values
+                                                    to check for container exit
+                                                    codes.
+
+                                                    At most 255 elements are
+                                                    allowed.
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                                - operator
+                                              type: object
+                                          required:
+                                            - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      securityContext:
+                                        description: SecurityContext defines the security options the container should
+                                          be run with.
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            description: >-
+                                              AllowPrivilegeEscalation controls
+                                              whether a process can gain more
+
+                                              privileges than its parent...
+                                            type: boolean
+                                          appArmorProfile:
+                                            description: appArmorProfile is the AppArmor options to use by this container.
+                                            properties:
+                                              localhostProfile:
+                                                description: localhostProfile indicates a profile loaded on the node that should
+                                                  be used.
+                                                type: string
+                                              type:
+                                                description: type indicates which kind of AppArmor profile will be applied.
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            description: The capabilities to add/drop when running containers.
+                                            properties:
+                                              add:
+                                                description: Added capabilities
+                                                items:
+                                                  description: Capability represent POSIX capabilities type
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                description: Removed capabilities
+                                                items:
+                                                  description: Capability represent POSIX capabilities type
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            description: Run container in privileged mode.
+                                            type: boolean
+                                          procMount:
+                                            description: procMount denotes the type of proc mount to use for the containers.
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            description: >-
+                                              Whether this container has a
+                                              read-only root filesystem.
+
+                                              Default is false.
+                                            type: boolean
+                                          runAsGroup:
+                                            description: >-
+                                              The GID to run the entrypoint of
+                                              the container process.
+
+                                              Uses runtime default if unset.
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            description: Indicates that the container must run as a non-root user.
+                                            type: boolean
+                                          runAsUser:
+                                            description: The UID to run the entrypoint of the container process.
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            description: The SELinux context to be applied to the container.
+                                            properties:
+                                              level:
+                                                description: Level is SELinux level label that applies to the container.
+                                                type: string
+                                              role:
+                                                description: Role is a SELinux role label that applies to the container.
+                                                type: string
+                                              type:
+                                                description: Type is a SELinux type label that applies to the container.
+                                                type: string
+                                              user:
+                                                description: User is a SELinux user label that applies to the container.
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            description: The seccomp options to use by this container.
+                                            properties:
+                                              localhostProfile:
+                                                description: localhostProfile indicates a profile defined in a file on the node
+                                                  should be used.
+                                                type: string
+                                              type:
+                                                description: type indicates which kind of seccomp profile will be applied.
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            description: The Windows specific settings applied to all containers.
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                description: >-
+                                                  GMSACredentialSpec is where
+                                                  the GMSA admission webhook
+
+                                                  (https://github.
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                description: GMSACredentialSpecName is the name of the GMSA credential spec to
+                                                  use.
+                                                type: string
+                                              hostProcess:
+                                                description: HostProcess determines if a container should be run as a 'Host
+                                                  Process' container.
+                                                type: boolean
+                                              runAsUserName:
+                                                description: The UserName in Windows to run the entrypoint of the container
+                                                  process.
+                                                type: string
+                                            type: object
+                                        type: object
+                                      startupProbe:
+                                        description: StartupProbe indicates that the Pod has successfully initialized.
+                                        properties:
+                                          exec:
+                                            description: Exec specifies a command to execute in the container.
+                                            properties:
+                                              command:
+                                                description: >-
+                                                  Command is the command line to
+                                                  execute inside the container,
+                                                  the working directory for the
+
+                                                  command ...
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe to be considered failed
+                                              after having succeeded.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies a GRPC HealthCheckRequest.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC service. Number must be in the range 1 to
+                                                  65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                default: ""
+                                                description: >-
+                                                  Service is the name of the
+                                                  service to place in the gRPC
+                                                  HealthCheckRequest
+
+                                                  (see https://github.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies an HTTP GET request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name.
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Name or number of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: >-
+                                                  Scheme to use for connecting
+                                                  to the host.
+
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: Number of seconds after the container has started before liveness
+                                              probes are initiated.
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: >-
+                                              How often (in seconds) to perform
+                                              the probe.
+
+                                              Default to 10 seconds. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe to be considered
+                                              successful after having failed.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies a connection to a TCP port.
+                                            properties:
+                                              host:
+                                                description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Number or name of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds the pod needs to terminate gracefully
+                                              upon probe failure.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: >-
+                                              Number of seconds after which the
+                                              probe times out.
+
+                                              Defaults to 1 second. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      stdin:
+                                        description: Whether this container should allocate a buffer for stdin in the
+                                          container runtime.
+                                        type: boolean
+                                      stdinOnce:
+                                        description: >-
+                                          Whether the container runtime should
+                                          close the stdin channel after it has
+                                          been opened by
+
+                                          a single...
+                                        type: boolean
+                                      terminationMessagePath:
+                                        description: >-
+                                          Optional: Path at which the file to
+                                          which the container's termination
+                                          message
+
+                                          will be written is...
+                                        type: string
+                                      terminationMessagePolicy:
+                                        description: Indicate how the termination message should be populated.
+                                        type: string
+                                      tty:
+                                        description: Whether this container should allocate a TTY for itself, also
+                                          requires 'stdin' to be true.
+                                        type: boolean
+                                      volumeDevices:
+                                        description: volumeDevices is the list of block devices to be used by the
+                                          container.
+                                        items:
+                                          description: volumeDevice describes a mapping of a raw block device within a
+                                            container.
+                                          properties:
+                                            devicePath:
+                                              description: devicePath is the path inside of the container that the device will
+                                                be mapped to.
+                                              type: string
+                                            name:
+                                              description: name must match the name of a persistentVolumeClaim in the pod
+                                              type: string
+                                          required:
+                                            - devicePath
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - devicePath
+                                        x-kubernetes-list-type: map
+                                      volumeMounts:
+                                        description: >-
+                                          Pod volumes to mount into the
+                                          container's filesystem.
+
+                                          Cannot be updated.
+                                        items:
+                                          description: VolumeMount describes a mounting of a Volume within a container.
+                                          properties:
+                                            mountPath:
+                                              description: >-
+                                                Path within the container at
+                                                which the volume should be
+                                                mounted.  Must
+
+                                                not contain ':'.
+                                              type: string
+                                            mountPropagation:
+                                              description: >-
+                                                mountPropagation determines how
+                                                mounts are propagated from the
+                                                host
+
+                                                to container and the other
+                                                way...
+                                              type: string
+                                            name:
+                                              description: This must match the Name of a Volume.
+                                              type: string
+                                            readOnly:
+                                              description: >-
+                                                Mounted read-only if true,
+                                                read-write otherwise (false or
+                                                unspecified).
+
+                                                Defaults to false.
+                                              type: boolean
+                                            recursiveReadOnly:
+                                              description: >-
+                                                RecursiveReadOnly specifies
+                                                whether read-only mounts should
+                                                be handled
+
+                                                recursively.
+                                              type: string
+                                            subPath:
+                                              description: Path within the volume from which the container's volume should be
+                                                mounted.
+                                              type: string
+                                            subPathExpr:
+                                              description: Expanded path within the volume from which the container's volume
+                                                should be mounted.
+                                              type: string
+                                          required:
+                                            - mountPath
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - mountPath
+                                        x-kubernetes-list-type: map
+                                      workingDir:
+                                        description: Container's working directory.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                dnsConfig:
+                                  description: Specifies the DNS parameters of a pod.
+                                  properties:
+                                    nameservers:
+                                      description: A list of DNS name server IP addresses.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    options:
+                                      description: >-
+                                        A list of DNS resolver options.
+
+                                        This will be merged with the base
+                                        options generated from DNSPolicy.
+                                      items:
+                                        description: PodDNSConfigOption defines DNS resolver options of a pod.
+                                        properties:
+                                          name:
+                                            description: >-
+                                              Name is this DNS resolver option's
+                                              name.
+
+                                              Required.
+                                            type: string
+                                          value:
+                                            description: Value is this DNS resolver option's value.
+                                            type: string
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    searches:
+                                      description: A list of DNS search domains for host-name lookup.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                dnsPolicy:
+                                  description: |-
+                                    Set DNS policy for the pod.
+                                    Defaults to "ClusterFirst".
+                                  type: string
+                                enableServiceLinks:
+                                  description: EnableServiceLinks indicates whether information about services
+                                    should be injected into pod's...
+                                  type: boolean
+                                ephemeralContainers:
+                                  description: List of ephemeral containers run in this pod.
+                                  items:
+                                    description: An EphemeralContainer is a temporary container that you may add to
+                                      an existing Pod for...
+                                    properties:
+                                      args:
+                                        description: >-
+                                          Arguments to the entrypoint.
+
+                                          The image's CMD is used if this is not
+                                          provided.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      command:
+                                        description: Entrypoint array. Not executed within a shell.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      env:
+                                        description: >-
+                                          List of environment variables to set
+                                          in the container.
+
+                                          Cannot be updated.
+                                        items:
+                                          description: EnvVar represents an environment variable present in a Container.
+                                          properties:
+                                            name:
+                                              description: >-
+                                                Name of the environment
+                                                variable.
+
+                                                May consist of any printable
+                                                ASCII characters except '='.
+                                              type: string
+                                            value:
+                                              description: >-
+                                                Variable references $(VAR_NAME)
+                                                are expanded
+
+                                                using the previously defined
+                                                environment variables in...
+                                              type: string
+                                            valueFrom:
+                                              description: Source for the environment variable's value. Cannot be used if
+                                                value is not empty.
+                                              properties:
+                                                configMapKeyRef:
+                                                  description: Selects a key of a ConfigMap.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: Name of the referent.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the ConfigMap or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  description: "Selects a field of the pod: supports metadata.name,
+                                                    metadata.namespace,
+                                                    `metadata."
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the schema the FieldPath is written in terms of,
+                                                        defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field to select in the specified API version.
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  description: >-
+                                                    FileKeyRef selects a key of
+                                                    the env file.
+
+                                                    Requires the EnvFiles
+                                                    feature gate to be enabled.
+                                                  properties:
+                                                    key:
+                                                      description: The key within the env file. An invalid key will prevent the pod
+                                                        from starting.
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      description: Specify whether the file or its key must be defined.
+                                                      type: boolean
+                                                    path:
+                                                      description: The path within the volume from which to select the file.
+                                                      type: string
+                                                    volumeName:
+                                                      description: The name of the volume mount containing the env file.
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  description: >-
+                                                    Selects a resource of the
+                                                    container: only resources
+                                                    limits and requests
+
+                                                    (limits.cpu, limits.
+                                                  properties:
+                                                    containerName:
+                                                      description: "Container name: required for volumes, optional for env vars"
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      description: Specifies the output format of the exposed resources, defaults to
+                                                        "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: "Required: resource to select"
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  description: Selects a key of a secret in the pod's namespace
+                                                  properties:
+                                                    key:
+                                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: Name of the referent.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the Secret or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      envFrom:
+                                        description: List of sources to populate environment variables in the container.
+                                        items:
+                                          description: EnvFromSource represents the source of a set of ConfigMaps or
+                                            Secrets
+                                          properties:
+                                            configMapRef:
+                                              description: The ConfigMap to select from
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  description: Name of the referent.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the ConfigMap must be defined
+                                                  type: boolean
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            prefix:
+                                              description: Optional text to prepend to the name of each environment variable.
+                                              type: string
+                                            secretRef:
+                                              description: The Secret to select from
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  description: Name of the referent.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the Secret must be defined
+                                                  type: boolean
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      image:
+                                        description: |-
+                                          Container image name.
+                                          More info: https://kubernetes.io/docs/concepts/containers/images
+                                        type: string
+                                      imagePullPolicy:
+                                        description: |-
+                                          Image pull policy.
+                                          One of Always, Never, IfNotPresent.
+                                        type: string
+                                      lifecycle:
+                                        description: Lifecycle is not allowed for ephemeral containers.
+                                        properties:
+                                          postStart:
+                                            description: PostStart is called immediately after a container is created.
+                                            properties:
+                                              exec:
+                                                description: Exec specifies a command to execute in the container.
+                                                properties:
+                                                  command:
+                                                    description: >-
+                                                      Command is the command
+                                                      line to execute inside the
+                                                      container, the working
+                                                      directory for the
+
+                                                      command ...
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies an HTTP GET request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect to, defaults to the pod IP.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header field name.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: >-
+                                                      Name or number of the port
+                                                      to access on the
+                                                      container.
+
+                                                      Number must be in the
+                                                      range 1 to 65535.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: >-
+                                                      Scheme to use for
+                                                      connecting to the host.
+
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              sleep:
+                                                description: Sleep represents a duration that the container should sleep.
+                                                properties:
+                                                  seconds:
+                                                    description: Seconds is the number of seconds to sleep.
+                                                    format: int64
+                                                    type: integer
+                                                required:
+                                                  - seconds
+                                                type: object
+                                              tcpSocket:
+                                                description: >-
+                                                  Deprecated. TCPSocket is NOT
+                                                  supported as a
+                                                  LifecycleHandler and kept
+
+                                                  for backward compatibility.
+                                                properties:
+                                                  host:
+                                                    description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: >-
+                                                      Number or name of the port
+                                                      to access on the
+                                                      container.
+
+                                                      Number must be in the
+                                                      range 1 to 65535.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                            type: object
+                                          preStop:
+                                            description: >-
+                                              PreStop is called immediately
+                                              before a container is terminated
+                                              due to an
+
+                                              API request or management...
+                                            properties:
+                                              exec:
+                                                description: Exec specifies a command to execute in the container.
+                                                properties:
+                                                  command:
+                                                    description: >-
+                                                      Command is the command
+                                                      line to execute inside the
+                                                      container, the working
+                                                      directory for the
+
+                                                      command ...
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies an HTTP GET request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect to, defaults to the pod IP.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header field name.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: >-
+                                                      Name or number of the port
+                                                      to access on the
+                                                      container.
+
+                                                      Number must be in the
+                                                      range 1 to 65535.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: >-
+                                                      Scheme to use for
+                                                      connecting to the host.
+
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              sleep:
+                                                description: Sleep represents a duration that the container should sleep.
+                                                properties:
+                                                  seconds:
+                                                    description: Seconds is the number of seconds to sleep.
+                                                    format: int64
+                                                    type: integer
+                                                required:
+                                                  - seconds
+                                                type: object
+                                              tcpSocket:
+                                                description: >-
+                                                  Deprecated. TCPSocket is NOT
+                                                  supported as a
+                                                  LifecycleHandler and kept
+
+                                                  for backward compatibility.
+                                                properties:
+                                                  host:
+                                                    description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: >-
+                                                      Number or name of the port
+                                                      to access on the
+                                                      container.
+
+                                                      Number must be in the
+                                                      range 1 to 65535.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                            type: object
+                                          stopSignal:
+                                            description: StopSignal defines which signal will be sent to a container when it
+                                              is being stopped.
+                                            type: string
+                                        type: object
+                                      livenessProbe:
+                                        description: Probes are not allowed for ephemeral containers.
+                                        properties:
+                                          exec:
+                                            description: Exec specifies a command to execute in the container.
+                                            properties:
+                                              command:
+                                                description: >-
+                                                  Command is the command line to
+                                                  execute inside the container,
+                                                  the working directory for the
+
+                                                  command ...
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe to be considered failed
+                                              after having succeeded.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies a GRPC HealthCheckRequest.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC service. Number must be in the range 1 to
+                                                  65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                default: ""
+                                                description: >-
+                                                  Service is the name of the
+                                                  service to place in the gRPC
+                                                  HealthCheckRequest
+
+                                                  (see https://github.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies an HTTP GET request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name.
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Name or number of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: >-
+                                                  Scheme to use for connecting
+                                                  to the host.
+
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: Number of seconds after the container has started before liveness
+                                              probes are initiated.
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: >-
+                                              How often (in seconds) to perform
+                                              the probe.
+
+                                              Default to 10 seconds. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe to be considered
+                                              successful after having failed.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies a connection to a TCP port.
+                                            properties:
+                                              host:
+                                                description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Number or name of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds the pod needs to terminate gracefully
+                                              upon probe failure.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: >-
+                                              Number of seconds after which the
+                                              probe times out.
+
+                                              Defaults to 1 second. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      name:
+                                        description: Name of the ephemeral container specified as a DNS_LABEL.
+                                        type: string
+                                      ports:
+                                        description: Ports are not allowed for ephemeral containers.
+                                        items:
+                                          description: ContainerPort represents a network port in a single container.
+                                          properties:
+                                            containerPort:
+                                              description: >-
+                                                Number of port to expose on the
+                                                pod's IP address.
+
+                                                This must be a valid port
+                                                number, 0 < x < 65536.
+                                              format: int32
+                                              type: integer
+                                            hostIP:
+                                              description: What host IP to bind the external port to.
+                                              type: string
+                                            hostPort:
+                                              description: >-
+                                                Number of port to expose on the
+                                                host.
+
+                                                If specified, this must be a
+                                                valid port number, 0 < x <
+                                                65536.
+                                              format: int32
+                                              type: integer
+                                            name:
+                                              description: If specified, this must be an IANA_SVC_NAME and unique within the
+                                                pod.
+                                              type: string
+                                            protocol:
+                                              default: TCP
+                                              description: >-
+                                                Protocol for port. Must be UDP,
+                                                TCP, or SCTP.
+
+                                                Defaults to "TCP".
+                                              type: string
+                                          required:
+                                            - containerPort
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                        x-kubernetes-list-type: map
+                                      readinessProbe:
+                                        description: Probes are not allowed for ephemeral containers.
+                                        properties:
+                                          exec:
+                                            description: Exec specifies a command to execute in the container.
+                                            properties:
+                                              command:
+                                                description: >-
+                                                  Command is the command line to
+                                                  execute inside the container,
+                                                  the working directory for the
+
+                                                  command ...
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe to be considered failed
+                                              after having succeeded.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies a GRPC HealthCheckRequest.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC service. Number must be in the range 1 to
+                                                  65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                default: ""
+                                                description: >-
+                                                  Service is the name of the
+                                                  service to place in the gRPC
+                                                  HealthCheckRequest
+
+                                                  (see https://github.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies an HTTP GET request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name.
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Name or number of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: >-
+                                                  Scheme to use for connecting
+                                                  to the host.
+
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: Number of seconds after the container has started before liveness
+                                              probes are initiated.
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: >-
+                                              How often (in seconds) to perform
+                                              the probe.
+
+                                              Default to 10 seconds. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe to be considered
+                                              successful after having failed.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies a connection to a TCP port.
+                                            properties:
+                                              host:
+                                                description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Number or name of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds the pod needs to terminate gracefully
+                                              upon probe failure.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: >-
+                                              Number of seconds after which the
+                                              probe times out.
+
+                                              Defaults to 1 second. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      resizePolicy:
+                                        description: Resources resize policy for the container.
+                                        items:
+                                          description: ContainerResizePolicy represents resource resize policy for the
+                                            container.
+                                          properties:
+                                            resourceName:
+                                              description: >-
+                                                Name of the resource to which
+                                                this resource resize policy
+                                                applies.
+
+                                                Supported values: cpu, memory.
+                                              type: string
+                                            restartPolicy:
+                                              description: Restart policy to apply when specified resource is resized.
+                                              type: string
+                                          required:
+                                            - resourceName
+                                            - restartPolicy
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      resources:
+                                        description: Resources are not allowed for ephemeral containers.
+                                        properties:
+                                          claims:
+                                            description: Claims lists the names of resources, defined in spec.
+                                            items:
+                                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                              properties:
+                                                name:
+                                                  description: Name must match the name of one entry in pod.spec.
+                                                  type: string
+                                                request:
+                                                  description: Request is the name chosen for a request in the referenced claim.
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: >-
+                                              Limits describes the maximum
+                                              amount of compute resources
+                                              allowed.
+
+                                              More info: https://kubernetes.
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: Requests describes the minimum amount of compute resources
+                                              required.
+                                            type: object
+                                        type: object
+                                      restartPolicy:
+                                        description: >-
+                                          Restart policy for the container to
+                                          manage the restart behavior of each
+
+                                          container within a pod.
+                                        type: string
+                                      restartPolicyRules:
+                                        description: >-
+                                          Represents a list of rules to be
+                                          checked to determine if the
+
+                                          container should be restarted on exit.
+                                        items:
+                                          description: ContainerRestartRule describes how a container exit is handled.
+                                          properties:
+                                            action:
+                                              description: >-
+                                                Specifies the action taken on a
+                                                container exit if the
+                                                requirements
+
+                                                are satisfied.
+                                              type: string
+                                            exitCodes:
+                                              description: Represents the exit codes to check on container exits.
+                                              properties:
+                                                operator:
+                                                  description: >-
+                                                    Represents the relationship
+                                                    between the container exit
+                                                    code(s) and the
+
+                                                    specified values.
+                                                  type: string
+                                                values:
+                                                  description: >-
+                                                    Specifies the set of values
+                                                    to check for container exit
+                                                    codes.
+
+                                                    At most 255 elements are
+                                                    allowed.
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                                - operator
+                                              type: object
+                                          required:
+                                            - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      securityContext:
+                                        description: "Optional: SecurityContext defines the security options the
+                                          ephemeral container should be run
+                                          with."
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            description: >-
+                                              AllowPrivilegeEscalation controls
+                                              whether a process can gain more
+
+                                              privileges than its parent...
+                                            type: boolean
+                                          appArmorProfile:
+                                            description: appArmorProfile is the AppArmor options to use by this container.
+                                            properties:
+                                              localhostProfile:
+                                                description: localhostProfile indicates a profile loaded on the node that should
+                                                  be used.
+                                                type: string
+                                              type:
+                                                description: type indicates which kind of AppArmor profile will be applied.
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            description: The capabilities to add/drop when running containers.
+                                            properties:
+                                              add:
+                                                description: Added capabilities
+                                                items:
+                                                  description: Capability represent POSIX capabilities type
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                description: Removed capabilities
+                                                items:
+                                                  description: Capability represent POSIX capabilities type
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            description: Run container in privileged mode.
+                                            type: boolean
+                                          procMount:
+                                            description: procMount denotes the type of proc mount to use for the containers.
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            description: >-
+                                              Whether this container has a
+                                              read-only root filesystem.
+
+                                              Default is false.
+                                            type: boolean
+                                          runAsGroup:
+                                            description: >-
+                                              The GID to run the entrypoint of
+                                              the container process.
+
+                                              Uses runtime default if unset.
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            description: Indicates that the container must run as a non-root user.
+                                            type: boolean
+                                          runAsUser:
+                                            description: The UID to run the entrypoint of the container process.
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            description: The SELinux context to be applied to the container.
+                                            properties:
+                                              level:
+                                                description: Level is SELinux level label that applies to the container.
+                                                type: string
+                                              role:
+                                                description: Role is a SELinux role label that applies to the container.
+                                                type: string
+                                              type:
+                                                description: Type is a SELinux type label that applies to the container.
+                                                type: string
+                                              user:
+                                                description: User is a SELinux user label that applies to the container.
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            description: The seccomp options to use by this container.
+                                            properties:
+                                              localhostProfile:
+                                                description: localhostProfile indicates a profile defined in a file on the node
+                                                  should be used.
+                                                type: string
+                                              type:
+                                                description: type indicates which kind of seccomp profile will be applied.
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            description: The Windows specific settings applied to all containers.
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                description: >-
+                                                  GMSACredentialSpec is where
+                                                  the GMSA admission webhook
+
+                                                  (https://github.
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                description: GMSACredentialSpecName is the name of the GMSA credential spec to
+                                                  use.
+                                                type: string
+                                              hostProcess:
+                                                description: HostProcess determines if a container should be run as a 'Host
+                                                  Process' container.
+                                                type: boolean
+                                              runAsUserName:
+                                                description: The UserName in Windows to run the entrypoint of the container
+                                                  process.
+                                                type: string
+                                            type: object
+                                        type: object
+                                      startupProbe:
+                                        description: Probes are not allowed for ephemeral containers.
+                                        properties:
+                                          exec:
+                                            description: Exec specifies a command to execute in the container.
+                                            properties:
+                                              command:
+                                                description: >-
+                                                  Command is the command line to
+                                                  execute inside the container,
+                                                  the working directory for the
+
+                                                  command ...
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe to be considered failed
+                                              after having succeeded.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies a GRPC HealthCheckRequest.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC service. Number must be in the range 1 to
+                                                  65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                default: ""
+                                                description: >-
+                                                  Service is the name of the
+                                                  service to place in the gRPC
+                                                  HealthCheckRequest
+
+                                                  (see https://github.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies an HTTP GET request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name.
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Name or number of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: >-
+                                                  Scheme to use for connecting
+                                                  to the host.
+
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: Number of seconds after the container has started before liveness
+                                              probes are initiated.
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: >-
+                                              How often (in seconds) to perform
+                                              the probe.
+
+                                              Default to 10 seconds. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe to be considered
+                                              successful after having failed.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies a connection to a TCP port.
+                                            properties:
+                                              host:
+                                                description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Number or name of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds the pod needs to terminate gracefully
+                                              upon probe failure.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: >-
+                                              Number of seconds after which the
+                                              probe times out.
+
+                                              Defaults to 1 second. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      stdin:
+                                        description: Whether this container should allocate a buffer for stdin in the
+                                          container runtime.
+                                        type: boolean
+                                      stdinOnce:
+                                        description: >-
+                                          Whether the container runtime should
+                                          close the stdin channel after it has
+                                          been opened by
+
+                                          a single...
+                                        type: boolean
+                                      targetContainerName:
+                                        description: If set, the name of the container from PodSpec that this ephemeral
+                                          container targets.
+                                        type: string
+                                      terminationMessagePath:
+                                        description: >-
+                                          Optional: Path at which the file to
+                                          which the container's termination
+                                          message
+
+                                          will be written is...
+                                        type: string
+                                      terminationMessagePolicy:
+                                        description: Indicate how the termination message should be populated.
+                                        type: string
+                                      tty:
+                                        description: Whether this container should allocate a TTY for itself, also
+                                          requires 'stdin' to be true.
+                                        type: boolean
+                                      volumeDevices:
+                                        description: volumeDevices is the list of block devices to be used by the
+                                          container.
+                                        items:
+                                          description: volumeDevice describes a mapping of a raw block device within a
+                                            container.
+                                          properties:
+                                            devicePath:
+                                              description: devicePath is the path inside of the container that the device will
+                                                be mapped to.
+                                              type: string
+                                            name:
+                                              description: name must match the name of a persistentVolumeClaim in the pod
+                                              type: string
+                                          required:
+                                            - devicePath
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - devicePath
+                                        x-kubernetes-list-type: map
+                                      volumeMounts:
+                                        description: Pod volumes to mount into the container's filesystem.
+                                        items:
+                                          description: VolumeMount describes a mounting of a Volume within a container.
+                                          properties:
+                                            mountPath:
+                                              description: >-
+                                                Path within the container at
+                                                which the volume should be
+                                                mounted.  Must
+
+                                                not contain ':'.
+                                              type: string
+                                            mountPropagation:
+                                              description: >-
+                                                mountPropagation determines how
+                                                mounts are propagated from the
+                                                host
+
+                                                to container and the other
+                                                way...
+                                              type: string
+                                            name:
+                                              description: This must match the Name of a Volume.
+                                              type: string
+                                            readOnly:
+                                              description: >-
+                                                Mounted read-only if true,
+                                                read-write otherwise (false or
+                                                unspecified).
+
+                                                Defaults to false.
+                                              type: boolean
+                                            recursiveReadOnly:
+                                              description: >-
+                                                RecursiveReadOnly specifies
+                                                whether read-only mounts should
+                                                be handled
+
+                                                recursively.
+                                              type: string
+                                            subPath:
+                                              description: Path within the volume from which the container's volume should be
+                                                mounted.
+                                              type: string
+                                            subPathExpr:
+                                              description: Expanded path within the volume from which the container's volume
+                                                should be mounted.
+                                              type: string
+                                          required:
+                                            - mountPath
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - mountPath
+                                        x-kubernetes-list-type: map
+                                      workingDir:
+                                        description: Container's working directory.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                hostAliases:
+                                  description: >-
+                                    HostAliases is an optional list of hosts and
+                                    IPs that will be injected into the pod's
+                                    hosts
+
+                                    file if...
+                                  items:
+                                    description: >-
+                                      HostAlias holds the mapping between IP and
+                                      hostnames that will be injected as an
+                                      entry in the
+
+                                      pod's...
+                                    properties:
+                                      hostnames:
+                                        description: Hostnames for the above IP address.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      ip:
+                                        description: IP address of the host file entry.
+                                        type: string
+                                    required:
+                                      - ip
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - ip
+                                  x-kubernetes-list-type: map
+                                hostIPC:
+                                  description: |-
+                                    Use the host's ipc namespace.
+                                    Optional: Default to false.
+                                  type: boolean
+                                hostNetwork:
+                                  description: Host networking requested for this pod. Use the host's network
+                                    namespace.
+                                  type: boolean
+                                hostPID:
+                                  description: |-
+                                    Use the host's pid namespace.
+                                    Optional: Default to false.
+                                  type: boolean
+                                hostUsers:
+                                  description: |-
+                                    Use the host's user namespace.
+                                    Optional: Default to true.
+                                  type: boolean
+                                hostname:
+                                  description: >-
+                                    Specifies the hostname of the Pod
+
+                                    If not specified, the pod's hostname will be
+                                    set to a...
+                                  type: string
+                                hostnameOverride:
+                                  description: HostnameOverride specifies an explicit override for the pod's
+                                    hostname as perceived by the pod.
+                                  type: string
+                                imagePullSecrets:
+                                  description: ImagePullSecrets is an optional list of references to secrets in
+                                    the same namespace to use for...
+                                  items:
+                                    description: >-
+                                      LocalObjectReference contains enough
+                                      information to let you locate the
+
+                                      referenced object inside the...
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: Name of the referent.
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                initContainers:
+                                  description: List of initialization containers belonging to the pod.
+                                  items:
+                                    description: A single application container that you want to run within a pod.
+                                    properties:
+                                      args:
+                                        description: >-
+                                          Arguments to the entrypoint.
+
+                                          The container image's CMD is used if
+                                          this is not provided.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      command:
+                                        description: Entrypoint array. Not executed within a shell.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      env:
+                                        description: >-
+                                          List of environment variables to set
+                                          in the container.
+
+                                          Cannot be updated.
+                                        items:
+                                          description: EnvVar represents an environment variable present in a Container.
+                                          properties:
+                                            name:
+                                              description: >-
+                                                Name of the environment
+                                                variable.
+
+                                                May consist of any printable
+                                                ASCII characters except '='.
+                                              type: string
+                                            value:
+                                              description: >-
+                                                Variable references $(VAR_NAME)
+                                                are expanded
+
+                                                using the previously defined
+                                                environment variables in...
+                                              type: string
+                                            valueFrom:
+                                              description: Source for the environment variable's value. Cannot be used if
+                                                value is not empty.
+                                              properties:
+                                                configMapKeyRef:
+                                                  description: Selects a key of a ConfigMap.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: Name of the referent.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the ConfigMap or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  description: "Selects a field of the pod: supports metadata.name,
+                                                    metadata.namespace,
+                                                    `metadata."
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the schema the FieldPath is written in terms of,
+                                                        defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field to select in the specified API version.
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fileKeyRef:
+                                                  description: >-
+                                                    FileKeyRef selects a key of
+                                                    the env file.
+
+                                                    Requires the EnvFiles
+                                                    feature gate to be enabled.
+                                                  properties:
+                                                    key:
+                                                      description: The key within the env file. An invalid key will prevent the pod
+                                                        from starting.
+                                                      type: string
+                                                    optional:
+                                                      default: false
+                                                      description: Specify whether the file or its key must be defined.
+                                                      type: boolean
+                                                    path:
+                                                      description: The path within the volume from which to select the file.
+                                                      type: string
+                                                    volumeName:
+                                                      description: The name of the volume mount containing the env file.
+                                                      type: string
+                                                  required:
+                                                    - key
+                                                    - path
+                                                    - volumeName
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  description: >-
+                                                    Selects a resource of the
+                                                    container: only resources
+                                                    limits and requests
+
+                                                    (limits.cpu, limits.
+                                                  properties:
+                                                    containerName:
+                                                      description: "Container name: required for volumes, optional for env vars"
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      description: Specifies the output format of the exposed resources, defaults to
+                                                        "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: "Required: resource to select"
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  description: Selects a key of a secret in the pod's namespace
+                                                  properties:
+                                                    key:
+                                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: Name of the referent.
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the Secret or its key must be defined
+                                                      type: boolean
+                                                  required:
+                                                    - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - name
+                                        x-kubernetes-list-type: map
+                                      envFrom:
+                                        description: List of sources to populate environment variables in the container.
+                                        items:
+                                          description: EnvFromSource represents the source of a set of ConfigMaps or
+                                            Secrets
+                                          properties:
+                                            configMapRef:
+                                              description: The ConfigMap to select from
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  description: Name of the referent.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the ConfigMap must be defined
+                                                  type: boolean
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            prefix:
+                                              description: Optional text to prepend to the name of each environment variable.
+                                              type: string
+                                            secretRef:
+                                              description: The Secret to select from
+                                              properties:
+                                                name:
+                                                  default: ""
+                                                  description: Name of the referent.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the Secret must be defined
+                                                  type: boolean
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      image:
+                                        description: |-
+                                          Container image name.
+                                          More info: https://kubernetes.
+                                        type: string
+                                      imagePullPolicy:
+                                        description: |-
+                                          Image pull policy.
+                                          One of Always, Never, IfNotPresent.
+                                        type: string
+                                      lifecycle:
+                                        description: Actions that the management system should take in response to
+                                          container lifecycle events.
+                                        properties:
+                                          postStart:
+                                            description: PostStart is called immediately after a container is created.
+                                            properties:
+                                              exec:
+                                                description: Exec specifies a command to execute in the container.
+                                                properties:
+                                                  command:
+                                                    description: >-
+                                                      Command is the command
+                                                      line to execute inside the
+                                                      container, the working
+                                                      directory for the
+
+                                                      command ...
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies an HTTP GET request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect to, defaults to the pod IP.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header field name.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: >-
+                                                      Name or number of the port
+                                                      to access on the
+                                                      container.
+
+                                                      Number must be in the
+                                                      range 1 to 65535.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: >-
+                                                      Scheme to use for
+                                                      connecting to the host.
+
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              sleep:
+                                                description: Sleep represents a duration that the container should sleep.
+                                                properties:
+                                                  seconds:
+                                                    description: Seconds is the number of seconds to sleep.
+                                                    format: int64
+                                                    type: integer
+                                                required:
+                                                  - seconds
+                                                type: object
+                                              tcpSocket:
+                                                description: >-
+                                                  Deprecated. TCPSocket is NOT
+                                                  supported as a
+                                                  LifecycleHandler and kept
+
+                                                  for backward compatibility.
+                                                properties:
+                                                  host:
+                                                    description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: >-
+                                                      Number or name of the port
+                                                      to access on the
+                                                      container.
+
+                                                      Number must be in the
+                                                      range 1 to 65535.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                            type: object
+                                          preStop:
+                                            description: >-
+                                              PreStop is called immediately
+                                              before a container is terminated
+                                              due to an
+
+                                              API request or management...
+                                            properties:
+                                              exec:
+                                                description: Exec specifies a command to execute in the container.
+                                                properties:
+                                                  command:
+                                                    description: >-
+                                                      Command is the command
+                                                      line to execute inside the
+                                                      container, the working
+                                                      directory for the
+
+                                                      command ...
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies an HTTP GET request to perform.
+                                                properties:
+                                                  host:
+                                                    description: Host name to connect to, defaults to the pod IP.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: The header field name.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                        - name
+                                                        - value
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: >-
+                                                      Name or number of the port
+                                                      to access on the
+                                                      container.
+
+                                                      Number must be in the
+                                                      range 1 to 65535.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: >-
+                                                      Scheme to use for
+                                                      connecting to the host.
+
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                  - port
+                                                type: object
+                                              sleep:
+                                                description: Sleep represents a duration that the container should sleep.
+                                                properties:
+                                                  seconds:
+                                                    description: Seconds is the number of seconds to sleep.
+                                                    format: int64
+                                                    type: integer
+                                                required:
+                                                  - seconds
+                                                type: object
+                                              tcpSocket:
+                                                description: >-
+                                                  Deprecated. TCPSocket is NOT
+                                                  supported as a
+                                                  LifecycleHandler and kept
+
+                                                  for backward compatibility.
+                                                properties:
+                                                  host:
+                                                    description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                    description: >-
+                                                      Number or name of the port
+                                                      to access on the
+                                                      container.
+
+                                                      Number must be in the
+                                                      range 1 to 65535.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                  - port
+                                                type: object
+                                            type: object
+                                          stopSignal:
+                                            description: StopSignal defines which signal will be sent to a container when it
+                                              is being stopped.
+                                            type: string
+                                        type: object
+                                      livenessProbe:
+                                        description: >-
+                                          Periodic probe of container liveness.
+
+                                          Container will be restarted if the
+                                          probe fails.
+                                        properties:
+                                          exec:
+                                            description: Exec specifies a command to execute in the container.
+                                            properties:
+                                              command:
+                                                description: >-
+                                                  Command is the command line to
+                                                  execute inside the container,
+                                                  the working directory for the
+
+                                                  command ...
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe to be considered failed
+                                              after having succeeded.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies a GRPC HealthCheckRequest.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC service. Number must be in the range 1 to
+                                                  65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                default: ""
+                                                description: >-
+                                                  Service is the name of the
+                                                  service to place in the gRPC
+                                                  HealthCheckRequest
+
+                                                  (see https://github.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies an HTTP GET request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name.
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Name or number of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: >-
+                                                  Scheme to use for connecting
+                                                  to the host.
+
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: Number of seconds after the container has started before liveness
+                                              probes are initiated.
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: >-
+                                              How often (in seconds) to perform
+                                              the probe.
+
+                                              Default to 10 seconds. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe to be considered
+                                              successful after having failed.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies a connection to a TCP port.
+                                            properties:
+                                              host:
+                                                description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Number or name of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds the pod needs to terminate gracefully
+                                              upon probe failure.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: >-
+                                              Number of seconds after which the
+                                              probe times out.
+
+                                              Defaults to 1 second. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      name:
+                                        description: Name of the container specified as a DNS_LABEL.
+                                        type: string
+                                      ports:
+                                        description: List of ports to expose from the container.
+                                        items:
+                                          description: ContainerPort represents a network port in a single container.
+                                          properties:
+                                            containerPort:
+                                              description: >-
+                                                Number of port to expose on the
+                                                pod's IP address.
+
+                                                This must be a valid port
+                                                number, 0 < x < 65536.
+                                              format: int32
+                                              type: integer
+                                            hostIP:
+                                              description: What host IP to bind the external port to.
+                                              type: string
+                                            hostPort:
+                                              description: >-
+                                                Number of port to expose on the
+                                                host.
+
+                                                If specified, this must be a
+                                                valid port number, 0 < x <
+                                                65536.
+                                              format: int32
+                                              type: integer
+                                            name:
+                                              description: If specified, this must be an IANA_SVC_NAME and unique within the
+                                                pod.
+                                              type: string
+                                            protocol:
+                                              default: TCP
+                                              description: >-
+                                                Protocol for port. Must be UDP,
+                                                TCP, or SCTP.
+
+                                                Defaults to "TCP".
+                                              type: string
+                                          required:
+                                            - containerPort
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - containerPort
+                                          - protocol
+                                        x-kubernetes-list-type: map
+                                      readinessProbe:
+                                        description: Periodic probe of container service readiness.
+                                        properties:
+                                          exec:
+                                            description: Exec specifies a command to execute in the container.
+                                            properties:
+                                              command:
+                                                description: >-
+                                                  Command is the command line to
+                                                  execute inside the container,
+                                                  the working directory for the
+
+                                                  command ...
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe to be considered failed
+                                              after having succeeded.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies a GRPC HealthCheckRequest.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC service. Number must be in the range 1 to
+                                                  65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                default: ""
+                                                description: >-
+                                                  Service is the name of the
+                                                  service to place in the gRPC
+                                                  HealthCheckRequest
+
+                                                  (see https://github.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies an HTTP GET request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name.
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Name or number of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: >-
+                                                  Scheme to use for connecting
+                                                  to the host.
+
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: Number of seconds after the container has started before liveness
+                                              probes are initiated.
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: >-
+                                              How often (in seconds) to perform
+                                              the probe.
+
+                                              Default to 10 seconds. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe to be considered
+                                              successful after having failed.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies a connection to a TCP port.
+                                            properties:
+                                              host:
+                                                description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Number or name of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds the pod needs to terminate gracefully
+                                              upon probe failure.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: >-
+                                              Number of seconds after which the
+                                              probe times out.
+
+                                              Defaults to 1 second. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      resizePolicy:
+                                        description: >-
+                                          Resources resize policy for the
+                                          container.
+
+                                          This field cannot be set on ephemeral
+                                          containers.
+                                        items:
+                                          description: ContainerResizePolicy represents resource resize policy for the
+                                            container.
+                                          properties:
+                                            resourceName:
+                                              description: >-
+                                                Name of the resource to which
+                                                this resource resize policy
+                                                applies.
+
+                                                Supported values: cpu, memory.
+                                              type: string
+                                            restartPolicy:
+                                              description: Restart policy to apply when specified resource is resized.
+                                              type: string
+                                          required:
+                                            - resourceName
+                                            - restartPolicy
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      resources:
+                                        description: >-
+                                          Compute Resources required by this
+                                          container.
+
+                                          Cannot be updated.
+
+                                          More info: https://kubernetes.
+                                        properties:
+                                          claims:
+                                            description: Claims lists the names of resources, defined in spec.
+                                            items:
+                                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                              properties:
+                                                name:
+                                                  description: Name must match the name of one entry in pod.spec.
+                                                  type: string
+                                                request:
+                                                  description: Request is the name chosen for a request in the referenced claim.
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                              - name
+                                            x-kubernetes-list-type: map
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: >-
+                                              Limits describes the maximum
+                                              amount of compute resources
+                                              allowed.
+
+                                              More info: https://kubernetes.
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            description: Requests describes the minimum amount of compute resources
+                                              required.
+                                            type: object
+                                        type: object
+                                      restartPolicy:
+                                        description: RestartPolicy defines the restart behavior of individual containers
+                                          in a pod.
+                                        type: string
+                                      restartPolicyRules:
+                                        description: >-
+                                          Represents a list of rules to be
+                                          checked to determine if the
+
+                                          container should be restarted on exit.
+                                        items:
+                                          description: ContainerRestartRule describes how a container exit is handled.
+                                          properties:
+                                            action:
+                                              description: >-
+                                                Specifies the action taken on a
+                                                container exit if the
+                                                requirements
+
+                                                are satisfied.
+                                              type: string
+                                            exitCodes:
+                                              description: Represents the exit codes to check on container exits.
+                                              properties:
+                                                operator:
+                                                  description: >-
+                                                    Represents the relationship
+                                                    between the container exit
+                                                    code(s) and the
+
+                                                    specified values.
+                                                  type: string
+                                                values:
+                                                  description: >-
+                                                    Specifies the set of values
+                                                    to check for container exit
+                                                    codes.
+
+                                                    At most 255 elements are
+                                                    allowed.
+                                                  items:
+                                                    format: int32
+                                                    type: integer
+                                                  type: array
+                                                  x-kubernetes-list-type: set
+                                              required:
+                                                - operator
+                                              type: object
+                                          required:
+                                            - action
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      securityContext:
+                                        description: SecurityContext defines the security options the container should
+                                          be run with.
+                                        properties:
+                                          allowPrivilegeEscalation:
+                                            description: >-
+                                              AllowPrivilegeEscalation controls
+                                              whether a process can gain more
+
+                                              privileges than its parent...
+                                            type: boolean
+                                          appArmorProfile:
+                                            description: appArmorProfile is the AppArmor options to use by this container.
+                                            properties:
+                                              localhostProfile:
+                                                description: localhostProfile indicates a profile loaded on the node that should
+                                                  be used.
+                                                type: string
+                                              type:
+                                                description: type indicates which kind of AppArmor profile will be applied.
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          capabilities:
+                                            description: The capabilities to add/drop when running containers.
+                                            properties:
+                                              add:
+                                                description: Added capabilities
+                                                items:
+                                                  description: Capability represent POSIX capabilities type
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              drop:
+                                                description: Removed capabilities
+                                                items:
+                                                  description: Capability represent POSIX capabilities type
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          privileged:
+                                            description: Run container in privileged mode.
+                                            type: boolean
+                                          procMount:
+                                            description: procMount denotes the type of proc mount to use for the containers.
+                                            type: string
+                                          readOnlyRootFilesystem:
+                                            description: >-
+                                              Whether this container has a
+                                              read-only root filesystem.
+
+                                              Default is false.
+                                            type: boolean
+                                          runAsGroup:
+                                            description: >-
+                                              The GID to run the entrypoint of
+                                              the container process.
+
+                                              Uses runtime default if unset.
+                                            format: int64
+                                            type: integer
+                                          runAsNonRoot:
+                                            description: Indicates that the container must run as a non-root user.
+                                            type: boolean
+                                          runAsUser:
+                                            description: The UID to run the entrypoint of the container process.
+                                            format: int64
+                                            type: integer
+                                          seLinuxOptions:
+                                            description: The SELinux context to be applied to the container.
+                                            properties:
+                                              level:
+                                                description: Level is SELinux level label that applies to the container.
+                                                type: string
+                                              role:
+                                                description: Role is a SELinux role label that applies to the container.
+                                                type: string
+                                              type:
+                                                description: Type is a SELinux type label that applies to the container.
+                                                type: string
+                                              user:
+                                                description: User is a SELinux user label that applies to the container.
+                                                type: string
+                                            type: object
+                                          seccompProfile:
+                                            description: The seccomp options to use by this container.
+                                            properties:
+                                              localhostProfile:
+                                                description: localhostProfile indicates a profile defined in a file on the node
+                                                  should be used.
+                                                type: string
+                                              type:
+                                                description: type indicates which kind of seccomp profile will be applied.
+                                                type: string
+                                            required:
+                                              - type
+                                            type: object
+                                          windowsOptions:
+                                            description: The Windows specific settings applied to all containers.
+                                            properties:
+                                              gmsaCredentialSpec:
+                                                description: >-
+                                                  GMSACredentialSpec is where
+                                                  the GMSA admission webhook
+
+                                                  (https://github.
+                                                type: string
+                                              gmsaCredentialSpecName:
+                                                description: GMSACredentialSpecName is the name of the GMSA credential spec to
+                                                  use.
+                                                type: string
+                                              hostProcess:
+                                                description: HostProcess determines if a container should be run as a 'Host
+                                                  Process' container.
+                                                type: boolean
+                                              runAsUserName:
+                                                description: The UserName in Windows to run the entrypoint of the container
+                                                  process.
+                                                type: string
+                                            type: object
+                                        type: object
+                                      startupProbe:
+                                        description: StartupProbe indicates that the Pod has successfully initialized.
+                                        properties:
+                                          exec:
+                                            description: Exec specifies a command to execute in the container.
+                                            properties:
+                                              command:
+                                                description: >-
+                                                  Command is the command line to
+                                                  execute inside the container,
+                                                  the working directory for the
+
+                                                  command ...
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          failureThreshold:
+                                            description: Minimum consecutive failures for the probe to be considered failed
+                                              after having succeeded.
+                                            format: int32
+                                            type: integer
+                                          grpc:
+                                            description: GRPC specifies a GRPC HealthCheckRequest.
+                                            properties:
+                                              port:
+                                                description: Port number of the gRPC service. Number must be in the range 1 to
+                                                  65535.
+                                                format: int32
+                                                type: integer
+                                              service:
+                                                default: ""
+                                                description: >-
+                                                  Service is the name of the
+                                                  service to place in the gRPC
+                                                  HealthCheckRequest
+
+                                                  (see https://github.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies an HTTP GET request to perform.
+                                            properties:
+                                              host:
+                                                description: Host name to connect to, defaults to the pod IP.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                items:
+                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: The header field name.
+                                                      type: string
+                                                    value:
+                                                      description: The header field value
+                                                      type: string
+                                                  required:
+                                                    - name
+                                                    - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Name or number of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: >-
+                                                  Scheme to use for connecting
+                                                  to the host.
+
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                              - port
+                                            type: object
+                                          initialDelaySeconds:
+                                            description: Number of seconds after the container has started before liveness
+                                              probes are initiated.
+                                            format: int32
+                                            type: integer
+                                          periodSeconds:
+                                            description: >-
+                                              How often (in seconds) to perform
+                                              the probe.
+
+                                              Default to 10 seconds. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                          successThreshold:
+                                            description: Minimum consecutive successes for the probe to be considered
+                                              successful after having failed.
+                                            format: int32
+                                            type: integer
+                                          tcpSocket:
+                                            description: TCPSocket specifies a connection to a TCP port.
+                                            properties:
+                                              host:
+                                                description: "Optional: Host name to connect to, defaults to the pod IP."
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                description: >-
+                                                  Number or name of the port to
+                                                  access on the container.
+
+                                                  Number must be in the range 1
+                                                  to 65535.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                              - port
+                                            type: object
+                                          terminationGracePeriodSeconds:
+                                            description: Optional duration in seconds the pod needs to terminate gracefully
+                                              upon probe failure.
+                                            format: int64
+                                            type: integer
+                                          timeoutSeconds:
+                                            description: >-
+                                              Number of seconds after which the
+                                              probe times out.
+
+                                              Defaults to 1 second. Minimum
+                                              value is 1.
+                                            format: int32
+                                            type: integer
+                                        type: object
+                                      stdin:
+                                        description: Whether this container should allocate a buffer for stdin in the
+                                          container runtime.
+                                        type: boolean
+                                      stdinOnce:
+                                        description: >-
+                                          Whether the container runtime should
+                                          close the stdin channel after it has
+                                          been opened by
+
+                                          a single...
+                                        type: boolean
+                                      terminationMessagePath:
+                                        description: >-
+                                          Optional: Path at which the file to
+                                          which the container's termination
+                                          message
+
+                                          will be written is...
+                                        type: string
+                                      terminationMessagePolicy:
+                                        description: Indicate how the termination message should be populated.
+                                        type: string
+                                      tty:
+                                        description: Whether this container should allocate a TTY for itself, also
+                                          requires 'stdin' to be true.
+                                        type: boolean
+                                      volumeDevices:
+                                        description: volumeDevices is the list of block devices to be used by the
+                                          container.
+                                        items:
+                                          description: volumeDevice describes a mapping of a raw block device within a
+                                            container.
+                                          properties:
+                                            devicePath:
+                                              description: devicePath is the path inside of the container that the device will
+                                                be mapped to.
+                                              type: string
+                                            name:
+                                              description: name must match the name of a persistentVolumeClaim in the pod
+                                              type: string
+                                          required:
+                                            - devicePath
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - devicePath
+                                        x-kubernetes-list-type: map
+                                      volumeMounts:
+                                        description: >-
+                                          Pod volumes to mount into the
+                                          container's filesystem.
+
+                                          Cannot be updated.
+                                        items:
+                                          description: VolumeMount describes a mounting of a Volume within a container.
+                                          properties:
+                                            mountPath:
+                                              description: >-
+                                                Path within the container at
+                                                which the volume should be
+                                                mounted.  Must
+
+                                                not contain ':'.
+                                              type: string
+                                            mountPropagation:
+                                              description: >-
+                                                mountPropagation determines how
+                                                mounts are propagated from the
+                                                host
+
+                                                to container and the other
+                                                way...
+                                              type: string
+                                            name:
+                                              description: This must match the Name of a Volume.
+                                              type: string
+                                            readOnly:
+                                              description: >-
+                                                Mounted read-only if true,
+                                                read-write otherwise (false or
+                                                unspecified).
+
+                                                Defaults to false.
+                                              type: boolean
+                                            recursiveReadOnly:
+                                              description: >-
+                                                RecursiveReadOnly specifies
+                                                whether read-only mounts should
+                                                be handled
+
+                                                recursively.
+                                              type: string
+                                            subPath:
+                                              description: Path within the volume from which the container's volume should be
+                                                mounted.
+                                              type: string
+                                            subPathExpr:
+                                              description: Expanded path within the volume from which the container's volume
+                                                should be mounted.
+                                              type: string
+                                          required:
+                                            - mountPath
+                                            - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                          - mountPath
+                                        x-kubernetes-list-type: map
+                                      workingDir:
+                                        description: Container's working directory.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                nodeName:
+                                  description: NodeName indicates in which node this pod is scheduled.
+                                  type: string
+                                nodeSelector:
+                                  additionalProperties:
+                                    type: string
+                                  description: NodeSelector is a selector which must be true for the pod to fit on
+                                    a node.
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                os:
+                                  description: Specifies the OS of the containers in the pod.
+                                  properties:
+                                    name:
+                                      description: Name is the name of the operating system. The currently supported
+                                        values are linux and windows.
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                overhead:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: Overhead represents the resource overhead associated with running a
+                                    pod for a given RuntimeClass.
+                                  type: object
+                                preemptionPolicy:
+                                  description: PreemptionPolicy is the Policy for preempting pods with lower
+                                    priority.
+                                  type: string
+                                priority:
+                                  description: >-
+                                    The priority value. Various system
+                                    components use this field to find the
+
+                                    priority of the pod.
+                                  format: int32
+                                  type: integer
+                                priorityClassName:
+                                  description: If specified, indicates the pod's priority.
+                                  type: string
+                                readinessGates:
+                                  description: If specified, all readiness gates will be evaluated for pod
+                                    readiness.
+                                  items:
+                                    description: PodReadinessGate contains the reference to a pod condition
+                                    properties:
+                                      conditionType:
+                                        description: ConditionType refers to a condition in the pod's condition list
+                                          with matching type.
+                                        type: string
+                                    required:
+                                      - conditionType
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resourceClaims:
+                                  description: >-
+                                    ResourceClaims defines which ResourceClaims
+                                    must be allocated
+
+                                    and reserved before the Pod is...
+                                  items:
+                                    description: >-
+                                      PodResourceClaim references exactly one
+                                      ResourceClaim, either directly
+
+                                      or by naming a...
+                                    properties:
+                                      name:
+                                        description: >-
+                                          Name uniquely identifies this resource
+                                          claim inside the pod.
+
+                                          This must be a DNS_LABEL.
+                                        type: string
+                                      resourceClaimName:
+                                        description: >-
+                                          ResourceClaimName is the name of a
+                                          ResourceClaim object in the same
+
+                                          namespace as this pod.
+                                        type: string
+                                      resourceClaimTemplateName:
+                                        description: >-
+                                          ResourceClaimTemplateName is the name
+                                          of a ResourceClaimTemplate
+
+                                          object in the same namespace as...
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                resources:
+                                  description: >-
+                                    Resources is the total amount of CPU and
+                                    Memory resources required by all
+
+                                    containers in the pod.
+                                  properties:
+                                    claims:
+                                      description: Claims lists the names of resources, defined in spec.
+                                      items:
+                                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                        properties:
+                                          name:
+                                            description: Name must match the name of one entry in pod.spec.
+                                            type: string
+                                          request:
+                                            description: Request is the name chosen for a request in the referenced claim.
+                                            type: string
+                                        required:
+                                          - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: >-
+                                        Limits describes the maximum amount of
+                                        compute resources allowed.
+
+                                        More info: https://kubernetes.
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: Requests describes the minimum amount of compute resources
+                                        required.
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  description: >-
+                                    Restart policy for all containers within the
+                                    pod.
+
+                                    One of Always, OnFailure, Never.
+                                  type: string
+                                runtimeClassName:
+                                  description: RuntimeClassName refers to a RuntimeClass object in the node.k8s.
+                                  type: string
+                                schedulerName:
+                                  description: If specified, the pod will be dispatched by specified scheduler.
+                                  type: string
+                                schedulingGates:
+                                  description: SchedulingGates is an opaque list of values that if specified will
+                                    block scheduling the pod.
+                                  items:
+                                    description: PodSchedulingGate is associated to a Pod to guard its scheduling.
+                                    properties:
+                                      name:
+                                        description: >-
+                                          Name of the scheduling gate.
+
+                                          Each scheduling gate must have a
+                                          unique name field.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                securityContext:
+                                  description: SecurityContext holds pod-level security attributes and common
+                                    container settings.
+                                  properties:
+                                    appArmorProfile:
+                                      description: appArmorProfile is the AppArmor options to use by the containers in
+                                        this pod.
+                                      properties:
+                                        localhostProfile:
+                                          description: localhostProfile indicates a profile loaded on the node that should
+                                            be used.
+                                          type: string
+                                        type:
+                                          description: type indicates which kind of AppArmor profile will be applied.
+                                          type: string
+                                      required:
+                                        - type
+                                      type: object
+                                    fsGroup:
+                                      description: A special supplemental group that applies to all containers in a
+                                        pod.
+                                      format: int64
+                                      type: integer
+                                    fsGroupChangePolicy:
+                                      description: >-
+                                        fsGroupChangePolicy defines behavior of
+                                        changing ownership and permission of the
+                                        volume
+
+                                        before...
+                                      type: string
+                                    runAsGroup:
+                                      description: >-
+                                        The GID to run the entrypoint of the
+                                        container process.
+
+                                        Uses runtime default if unset.
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      description: Indicates that the container must run as a non-root user.
+                                      type: boolean
+                                    runAsUser:
+                                      description: The UID to run the entrypoint of the container process.
+                                      format: int64
+                                      type: integer
+                                    seLinuxChangePolicy:
+                                      description: seLinuxChangePolicy defines how the container's SELinux label is
+                                        applied to all volumes used by the...
+                                      type: string
+                                    seLinuxOptions:
+                                      description: The SELinux context to be applied to all containers.
+                                      properties:
+                                        level:
+                                          description: Level is SELinux level label that applies to the container.
+                                          type: string
+                                        role:
+                                          description: Role is a SELinux role label that applies to the container.
+                                          type: string
+                                        type:
+                                          description: Type is a SELinux type label that applies to the container.
+                                          type: string
+                                        user:
+                                          description: User is a SELinux user label that applies to the container.
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      description: The seccomp options to use by the containers in this pod.
+                                      properties:
+                                        localhostProfile:
+                                          description: localhostProfile indicates a profile defined in a file on the node
+                                            should be used.
+                                          type: string
+                                        type:
+                                          description: type indicates which kind of seccomp profile will be applied.
+                                          type: string
+                                      required:
+                                        - type
+                                      type: object
+                                    supplementalGroups:
+                                      description: >-
+                                        A list of groups applied to the first
+                                        process run in each container, in
+
+                                        addition to the container's...
+                                      items:
+                                        format: int64
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    supplementalGroupsPolicy:
+                                      description: Defines how supplemental groups of the first container processes
+                                        are calculated.
+                                      type: string
+                                    sysctls:
+                                      description: Sysctls hold a list of namespaced sysctls used for the pod.
+                                      items:
+                                        description: Sysctl defines a kernel parameter to be set
+                                        properties:
+                                          name:
+                                            description: Name of a property to set
+                                            type: string
+                                          value:
+                                            description: Value of a property to set
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    windowsOptions:
+                                      description: The Windows specific settings applied to all containers.
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          description: >-
+                                            GMSACredentialSpec is where the GMSA
+                                            admission webhook
+
+                                            (https://github.
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          description: GMSACredentialSpecName is the name of the GMSA credential spec to
+                                            use.
+                                          type: string
+                                        hostProcess:
+                                          description: HostProcess determines if a container should be run as a 'Host
+                                            Process' container.
+                                          type: boolean
+                                        runAsUserName:
+                                          description: The UserName in Windows to run the entrypoint of the container
+                                            process.
+                                          type: string
+                                      type: object
+                                  type: object
+                                serviceAccount:
+                                  description: DeprecatedServiceAccount is a deprecated alias for
+                                    ServiceAccountName.
+                                  type: string
+                                serviceAccountName:
+                                  description: ServiceAccountName is the name of the ServiceAccount to use to run
+                                    this pod.
+                                  type: string
+                                setHostnameAsFQDN:
+                                  description: If true the pod's hostname will be configured as the pod's FQDN,
+                                    rather than the leaf name (the...
+                                  type: boolean
+                                shareProcessNamespace:
+                                  description: Share a single process namespace between all of the containers in a
+                                    pod.
+                                  type: boolean
+                                subdomain:
+                                  description: If specified, the fully qualified Pod hostname will be
+                                    "<hostname>.<subdomain>.<pod namespace>.svc.
+                                  type: string
+                                terminationGracePeriodSeconds:
+                                  description: Optional duration in seconds the pod needs to terminate gracefully.
+                                  format: int64
+                                  type: integer
+                                tolerations:
+                                  description: If specified, the pod's tolerations.
+                                  items:
+                                    description: >-
+                                      The pod this Toleration is attached to
+                                      tolerates any taint that matches
+
+                                      the triple...
+                                    properties:
+                                      effect:
+                                        description: Effect indicates the taint effect to match. Empty means match all
+                                          taint effects.
+                                        type: string
+                                      key:
+                                        description: Key is the taint key that the toleration applies to. Empty means
+                                          match all taint keys.
+                                        type: string
+                                      operator:
+                                        description: Operator represents a key's relationship to the value.
+                                        type: string
+                                      tolerationSeconds:
+                                        description: >-
+                                          TolerationSeconds represents the
+                                          period of time the toleration (which
+                                          must be
+
+                                          of effect NoExecute,...
+                                        format: int64
+                                        type: integer
+                                      value:
+                                        description: Value is the taint value the toleration matches to.
+                                        type: string
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologySpreadConstraints:
+                                  description: >-
+                                    TopologySpreadConstraints describes how a
+                                    group of pods ought to spread across
+                                    topology
+
+                                    domains.
+                                  items:
+                                    description: TopologySpreadConstraint specifies how to spread matching pods
+                                      among the given topology.
+                                    properties:
+                                      labelSelector:
+                                        description: LabelSelector is used to find matching pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement is a selector that contains values, a
+                                                key, and an operator that...
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value} pairs.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: >-
+                                          MatchLabelKeys is a set of pod label
+                                          keys to select the pods over which
+
+                                          spreading will be...
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      maxSkew:
+                                        description: MaxSkew describes the degree to which pods may be unevenly
+                                          distributed.
+                                        format: int32
+                                        type: integer
+                                      minDomains:
+                                        description: MinDomains indicates a minimum number of eligible domains.
+                                        format: int32
+                                        type: integer
+                                      nodeAffinityPolicy:
+                                        description: >-
+                                          NodeAffinityPolicy indicates how we
+                                          will treat Pod's
+                                          nodeAffinity/nodeSelector
+
+                                          when calculating pod...
+                                        type: string
+                                      nodeTaintsPolicy:
+                                        description: >-
+                                          NodeTaintsPolicy indicates how we will
+                                          treat node taints when calculating
+
+                                          pod topology spread skew.
+                                        type: string
+                                      topologyKey:
+                                        description: TopologyKey is the key of node labels.
+                                        type: string
+                                      whenUnsatisfiable:
+                                        description: >-
+                                          WhenUnsatisfiable indicates how to
+                                          deal with a pod if it doesn't satisfy
+
+                                          the spread constraint.
+                                        type: string
+                                    required:
+                                      - maxSkew
+                                      - topologyKey
+                                      - whenUnsatisfiable
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - topologyKey
+                                    - whenUnsatisfiable
+                                  x-kubernetes-list-type: map
+                                volumes:
+                                  description: List of volumes that can be mounted by containers belonging to the
+                                    pod.
+                                  items:
+                                    description: Volume represents a named volume in a pod that may be accessed by
+                                      any container in the pod.
+                                    properties:
+                                      awsElasticBlockStore:
+                                        description: >-
+                                          awsElasticBlockStore represents an AWS
+                                          Disk resource that is attached to a
+
+                                          kubelet's host machine...
+                                        properties:
+                                          fsType:
+                                            description: fsType is the filesystem type of the volume that you want to mount.
+                                            type: string
+                                          partition:
+                                            description: partition is the partition in the volume that you want to mount.
+                                            format: int32
+                                            type: integer
+                                          readOnly:
+                                            description: >-
+                                              readOnly value true will force the
+                                              readOnly setting in VolumeMounts.
+
+                                              More info: https://kubernetes.
+                                            type: boolean
+                                          volumeID:
+                                            description: volumeID is unique ID of the persistent disk resource in AWS
+                                              (Amazon EBS volume).
+                                            type: string
+                                        required:
+                                          - volumeID
+                                        type: object
+                                      azureDisk:
+                                        description: azureDisk represents an Azure Data Disk mount on the host and bind
+                                          mount to the pod.
+                                        properties:
+                                          cachingMode:
+                                            description: "cachingMode is the Host Caching mode: None, Read Only, Read
+                                              Write."
+                                            type: string
+                                          diskName:
+                                            description: diskName is the Name of the data disk in the blob storage
+                                            type: string
+                                          diskURI:
+                                            description: diskURI is the URI of data disk in the blob storage
+                                            type: string
+                                          fsType:
+                                            default: ext4
+                                            description: fsType is Filesystem type to mount.
+                                            type: string
+                                          kind:
+                                            description: "kind expected values are Shared: multiple blob disks per storage
+                                              account  Dedicated: single
+                                              blob..."
+                                            type: string
+                                          readOnly:
+                                            default: false
+                                            description: readOnly Defaults to false (read/write).
+                                            type: boolean
+                                        required:
+                                          - diskName
+                                          - diskURI
+                                        type: object
+                                      azureFile:
+                                        description: azureFile represents an Azure File Service mount on the host and
+                                          bind mount to the pod.
+                                        properties:
+                                          readOnly:
+                                            description: readOnly defaults to false (read/write).
+                                            type: boolean
+                                          secretName:
+                                            description: secretName is the  name of secret that contains Azure Storage
+                                              Account Name and Key
+                                            type: string
+                                          shareName:
+                                            description: shareName is the azure share Name
+                                            type: string
+                                        required:
+                                          - secretName
+                                          - shareName
+                                        type: object
+                                      cephfs:
+                                        description: cephFS represents a Ceph FS mount on the host that shares a pod's
+                                          lifetime.
+                                        properties:
+                                          monitors:
+                                            description: >-
+                                              monitors is Required: Monitors is
+                                              a collection of Ceph monitors
+
+                                              More info: https://examples.k8s.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: "path is Optional: Used as the mounted root, rather than the full
+                                              Ceph tree, default is /"
+                                            type: string
+                                          readOnly:
+                                            description: "readOnly is Optional: Defaults to false (read/write)."
+                                            type: boolean
+                                          secretFile:
+                                            description: "secretFile is Optional: SecretFile is the path to key ring for
+                                              User, default is /etc/ceph/user."
+                                            type: string
+                                          secretRef:
+                                            description: "secretRef is Optional: SecretRef is reference to the
+                                              authentication secret for User,
+                                              default is..."
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: Name of the referent.
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          user:
+                                            description: >-
+                                              user is optional: User is the
+                                              rados user name, default is admin
+
+                                              More info: https://examples.k8s.
+                                            type: string
+                                        required:
+                                          - monitors
+                                        type: object
+                                      cinder:
+                                        description: cinder represents a cinder volume attached and mounted on kubelets
+                                          host machine.
+                                        properties:
+                                          fsType:
+                                            description: fsType is the filesystem type to mount.
+                                            type: string
+                                          readOnly:
+                                            description: readOnly defaults to false (read/write).
+                                            type: boolean
+                                          secretRef:
+                                            description: >-
+                                              secretRef is optional: points to a
+                                              secret object containing
+                                              parameters used to connect
+
+                                              to OpenStack.
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: Name of the referent.
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          volumeID:
+                                            description: >-
+                                              volumeID used to identify the
+                                              volume in cinder.
+
+                                              More info: https://examples.k8s.
+                                            type: string
+                                        required:
+                                          - volumeID
+                                        type: object
+                                      configMap:
+                                        description: configMap represents a configMap that should populate this volume
+                                        properties:
+                                          defaultMode:
+                                            description: "defaultMode is optional: mode bits used to set permissions on
+                                              created files by default."
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            description: >-
+                                              items if unspecified, each
+                                              key-value pair in the Data field
+                                              of the referenced
+
+                                              ConfigMap will be...
+                                            items:
+                                              description: Maps a string key to a path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: "mode is Optional: mode bits used to set permissions on this file."
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: >-
+                                                    path is the relative path of
+                                                    the file to map the key to.
+
+                                                    May not be an absolute path.
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            description: Name of the referent.
+                                            type: string
+                                          optional:
+                                            description: optional specify whether the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      csi:
+                                        description: csi (Container Storage Interface) represents ephemeral storage that
+                                          is handled by certain external...
+                                        properties:
+                                          driver:
+                                            description: driver is the name of the CSI driver that handles this volume.
+                                            type: string
+                                          fsType:
+                                            description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                            type: string
+                                          nodePublishSecretRef:
+                                            description: >-
+                                              nodePublishSecretRef is a
+                                              reference to the secret object
+                                              containing
+
+                                              sensitive information to pass...
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: Name of the referent.
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          readOnly:
+                                            description: >-
+                                              readOnly specifies a read-only
+                                              configuration for the volume.
+
+                                              Defaults to false (read/write).
+                                            type: boolean
+                                          volumeAttributes:
+                                            additionalProperties:
+                                              type: string
+                                            description: >-
+                                              volumeAttributes stores
+                                              driver-specific properties that
+                                              are passed to the CSI
+
+                                              driver.
+                                            type: object
+                                        required:
+                                          - driver
+                                        type: object
+                                      downwardAPI:
+                                        description: downwardAPI represents downward API about the pod that should
+                                          populate this volume
+                                        properties:
+                                          defaultMode:
+                                            description: "Optional: mode bits to use on created files by default."
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            description: Items is a list of downward API volume file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents information to create the file
+                                                containing the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: "Required: Selects a field of the pod: only annotations, labels,
+                                                    name, namespace and uid
+                                                    are..."
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the schema the FieldPath is written in terms of,
+                                                        defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field to select in the specified API version.
+                                                      type: string
+                                                  required:
+                                                    - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  description: >-
+                                                    Optional: mode bits used to
+                                                    set permissions on this
+                                                    file, must be an octal value
+
+                                                    between 0000 and...
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: "Required: Path is  the relative path name of the file to be
+                                                    created."
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: >-
+                                                    Selects a resource of the
+                                                    container: only resources
+                                                    limits and requests
+
+                                                    (limits.cpu, limits.
+                                                  properties:
+                                                    containerName:
+                                                      description: "Container name: required for volumes, optional for env vars"
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      description: Specifies the output format of the exposed resources, defaults to
+                                                        "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: "Required: resource to select"
+                                                      type: string
+                                                  required:
+                                                    - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      emptyDir:
+                                        description: emptyDir represents a temporary directory that shares a pod's
+                                          lifetime.
+                                        properties:
+                                          medium:
+                                            description: medium represents what type of storage medium should back this
+                                              directory.
+                                            type: string
+                                          sizeLimit:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: sizeLimit is the total amount of local storage required for this
+                                              EmptyDir volume.
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                        type: object
+                                      ephemeral:
+                                        description: ephemeral represents a volume that is handled by a cluster storage
+                                          driver.
+                                        properties:
+                                          volumeClaimTemplate:
+                                            description: Will be used to create a stand-alone PVC to provision the volume.
+                                            properties:
+                                              metadata:
+                                                description: >-
+                                                  May contain labels and
+                                                  annotations that will be
+                                                  copied into the PVC
+
+                                                  when creating it.
+                                                type: object
+                                              spec:
+                                                description: The specification for the PersistentVolumeClaim.
+                                                properties:
+                                                  accessModes:
+                                                    description: >-
+                                                      accessModes contains the
+                                                      desired access modes the
+                                                      volume should have.
+
+                                                      More info:
+                                                      https://kubernetes.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  dataSource:
+                                                    description: >-
+                                                      dataSource field can be
+                                                      used to specify either:
+
+                                                      * An existing
+                                                      VolumeSnapshot object
+                                                      (snapshot.
+                                                    properties:
+                                                      apiGroup:
+                                                        description: APIGroup is the group for the resource being referenced.
+                                                        type: string
+                                                      kind:
+                                                        description: Kind is the type of resource being referenced
+                                                        type: string
+                                                      name:
+                                                        description: Name is the name of resource being referenced
+                                                        type: string
+                                                    required:
+                                                      - kind
+                                                      - name
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  dataSourceRef:
+                                                    description: dataSourceRef specifies the object from which to populate the
+                                                      volume with data, if a
+                                                      non-empty...
+                                                    properties:
+                                                      apiGroup:
+                                                        description: APIGroup is the group for the resource being referenced.
+                                                        type: string
+                                                      kind:
+                                                        description: Kind is the type of resource being referenced
+                                                        type: string
+                                                      name:
+                                                        description: Name is the name of resource being referenced
+                                                        type: string
+                                                      namespace:
+                                                        description: >-
+                                                          Namespace is the
+                                                          namespace of resource
+                                                          being referenced
+
+                                                          Note that when a
+                                                          namespace is
+                                                          specified, a...
+                                                        type: string
+                                                    required:
+                                                      - kind
+                                                      - name
+                                                    type: object
+                                                  resources:
+                                                    description: resources represents the minimum resources the volume should have.
+                                                    properties:
+                                                      limits:
+                                                        additionalProperties:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        description: >-
+                                                          Limits describes the
+                                                          maximum amount of
+                                                          compute resources
+                                                          allowed.
+
+                                                          More info:
+                                                          https://kubernetes.
+                                                        type: object
+                                                      requests:
+                                                        additionalProperties:
+                                                          anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        description: Requests describes the minimum amount of compute resources
+                                                          required.
+                                                        type: object
+                                                    type: object
+                                                  selector:
+                                                    description: selector is a label query over volumes to consider for binding.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The
+                                                          requirements are
+                                                          ANDed.
+                                                        items:
+                                                          description: A label selector requirement is a selector that contains values, a
+                                                            key, and an operator
+                                                            that...
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents a key's relationship to a set of values.
+                                                              type: string
+                                                            values:
+                                                              description: values is an array of string values.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: matchLabels is a map of {key,value} pairs.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  storageClassName:
+                                                    description: storageClassName is the name of the StorageClass required by the
+                                                      claim.
+                                                    type: string
+                                                  volumeAttributesClassName:
+                                                    description: volumeAttributesClassName may be used to set the
+                                                      VolumeAttributesClass used
+                                                      by this claim.
+                                                    type: string
+                                                  volumeMode:
+                                                    description: volumeMode defines what type of volume is required by the claim.
+                                                    type: string
+                                                  volumeName:
+                                                    description: volumeName is the binding reference to the PersistentVolume backing
+                                                      this claim.
+                                                    type: string
+                                                type: object
+                                            required:
+                                              - spec
+                                            type: object
+                                        type: object
+                                      fc:
+                                        description: fc represents a Fibre Channel resource that is attached to a
+                                          kubelet's host machine and then...
+                                        properties:
+                                          fsType:
+                                            description: fsType is the filesystem type to mount.
+                                            type: string
+                                          lun:
+                                            description: "lun is Optional: FC target lun number"
+                                            format: int32
+                                            type: integer
+                                          readOnly:
+                                            description: "readOnly is Optional: Defaults to false (read/write)."
+                                            type: boolean
+                                          targetWWNs:
+                                            description: "targetWWNs is Optional: FC target worldwide names (WWNs)"
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          wwids:
+                                            description: >-
+                                              wwids Optional: FC volume world
+                                              wide identifiers (wwids)
+
+                                              Either wwids or combination of
+                                              targetWWNs...
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      flexVolume:
+                                        description: >-
+                                          flexVolume represents a generic volume
+                                          resource that is
+
+                                          provisioned/attached using an exec
+                                          based...
+                                        properties:
+                                          driver:
+                                            description: driver is the name of the driver to use for this volume.
+                                            type: string
+                                          fsType:
+                                            description: fsType is the filesystem type to mount.
+                                            type: string
+                                          options:
+                                            additionalProperties:
+                                              type: string
+                                            description: "options is Optional: this field holds extra command options if
+                                              any."
+                                            type: object
+                                          readOnly:
+                                            description: "readOnly is Optional: defaults to false (read/write)."
+                                            type: boolean
+                                          secretRef:
+                                            description: >-
+                                              secretRef is Optional: secretRef
+                                              is reference to the secret object
+                                              containing
+
+                                              sensitive information...
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: Name of the referent.
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        required:
+                                          - driver
+                                        type: object
+                                      flocker:
+                                        description: flocker represents a Flocker volume attached to a kubelet's host
+                                          machine.
+                                        properties:
+                                          datasetName:
+                                            description: >-
+                                              datasetName is Name of the dataset
+                                              stored as metadata -> name on the
+                                              dataset for Flocker
+
+                                              should be...
+                                            type: string
+                                          datasetUUID:
+                                            description: datasetUUID is the UUID of the dataset. This is unique identifier
+                                              of a Flocker dataset
+                                            type: string
+                                        type: object
+                                      gcePersistentDisk:
+                                        description: >-
+                                          gcePersistentDisk represents a GCE
+                                          Disk resource that is attached to a
+
+                                          kubelet's host machine and...
+                                        properties:
+                                          fsType:
+                                            description: fsType is filesystem type of the volume that you want to mount.
+                                            type: string
+                                          partition:
+                                            description: partition is the partition in the volume that you want to mount.
+                                            format: int32
+                                            type: integer
+                                          pdName:
+                                            description: pdName is unique name of the PD resource in GCE. Used to identify
+                                              the disk in GCE.
+                                            type: string
+                                          readOnly:
+                                            description: >-
+                                              readOnly here will force the
+                                              ReadOnly setting in VolumeMounts.
+
+                                              Defaults to false.
+                                            type: boolean
+                                        required:
+                                          - pdName
+                                        type: object
+                                      gitRepo:
+                                        description: >-
+                                          gitRepo represents a git repository at
+                                          a particular revision.
+
+                                          Deprecated: GitRepo is deprecated.
+                                        properties:
+                                          directory:
+                                            description: >-
+                                              directory is the target directory
+                                              name.
+
+                                              Must not contain or start with
+                                              '..'.  If '.
+                                            type: string
+                                          repository:
+                                            description: repository is the URL
+                                            type: string
+                                          revision:
+                                            description: revision is the commit hash for the specified revision.
+                                            type: string
+                                        required:
+                                          - repository
+                                        type: object
+                                      glusterfs:
+                                        description: glusterfs represents a Glusterfs mount on the host that shares a
+                                          pod's lifetime.
+                                        properties:
+                                          endpoints:
+                                            description: endpoints is the endpoint name that details Glusterfs topology.
+                                            type: string
+                                          path:
+                                            description: |-
+                                              path is the Glusterfs volume path.
+                                              More info: https://examples.k8s.io/volumes/glusterfs/README.
+                                            type: string
+                                          readOnly:
+                                            description: readOnly here will force the Glusterfs volume to be mounted with
+                                              read-only permissions.
+                                            type: boolean
+                                        required:
+                                          - endpoints
+                                          - path
+                                        type: object
+                                      hostPath:
+                                        description: >-
+                                          hostPath represents a pre-existing
+                                          file or directory on the host
+
+                                          machine that is directly exposed...
+                                        properties:
+                                          path:
+                                            description: path of the directory on the host.
+                                            type: string
+                                          type:
+                                            description: |-
+                                              type for HostPath Volume
+                                              Defaults to ""
+                                              More info: https://kubernetes.
+                                            type: string
+                                        required:
+                                          - path
+                                        type: object
+                                      image:
+                                        description: image represents an OCI object (a container image or artifact)
+                                          pulled and mounted on the kubelet's...
+                                        properties:
+                                          pullPolicy:
+                                            description: Policy for pulling OCI objects.
+                                            type: string
+                                          reference:
+                                            description: >-
+                                              Required: Image or artifact
+                                              reference to be used.
+
+                                              Behaves in the same way as
+                                              pod.spec.containers[*].
+                                            type: string
+                                        type: object
+                                      iscsi:
+                                        description: >-
+                                          iscsi represents an ISCSI Disk
+                                          resource that is attached to a
+
+                                          kubelet's host machine and then...
+                                        properties:
+                                          chapAuthDiscovery:
+                                            description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP
+                                              authentication
+                                            type: boolean
+                                          chapAuthSession:
+                                            description: chapAuthSession defines whether support iSCSI Session CHAP
+                                              authentication
+                                            type: boolean
+                                          fsType:
+                                            description: fsType is the filesystem type of the volume that you want to mount.
+                                            type: string
+                                          initiatorName:
+                                            description: initiatorName is the custom iSCSI Initiator Name.
+                                            type: string
+                                          iqn:
+                                            description: iqn is the target iSCSI Qualified Name.
+                                            type: string
+                                          iscsiInterface:
+                                            default: default
+                                            description: >-
+                                              iscsiInterface is the interface
+                                              Name that uses an iSCSI transport.
+
+                                              Defaults to 'default' (tcp).
+                                            type: string
+                                          lun:
+                                            description: lun represents iSCSI Target Lun number.
+                                            format: int32
+                                            type: integer
+                                          portals:
+                                            description: portals is the iSCSI Target Portal List.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          readOnly:
+                                            description: >-
+                                              readOnly here will force the
+                                              ReadOnly setting in VolumeMounts.
+
+                                              Defaults to false.
+                                            type: boolean
+                                          secretRef:
+                                            description: secretRef is the CHAP Secret for iSCSI target and initiator
+                                              authentication
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: Name of the referent.
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          targetPortal:
+                                            description: targetPortal is iSCSI Target Portal.
+                                            type: string
+                                        required:
+                                          - iqn
+                                          - lun
+                                          - targetPortal
+                                        type: object
+                                      name:
+                                        description: >-
+                                          name of the volume.
+
+                                          Must be a DNS_LABEL and unique within
+                                          the pod.
+
+                                          More info: https://kubernetes.
+                                        type: string
+                                      nfs:
+                                        description: >-
+                                          nfs represents an NFS mount on the
+                                          host that shares a pod's lifetime
+
+                                          More info: https://kubernetes.
+                                        properties:
+                                          path:
+                                            description: >-
+                                              path that is exported by the NFS
+                                              server.
+
+                                              More info: https://kubernetes.
+                                            type: string
+                                          readOnly:
+                                            description: >-
+                                              readOnly here will force the NFS
+                                              export to be mounted with
+                                              read-only permissions.
+
+                                              Defaults to false.
+                                            type: boolean
+                                          server:
+                                            description: >-
+                                              server is the hostname or IP
+                                              address of the NFS server.
+
+                                              More info: https://kubernetes.
+                                            type: string
+                                        required:
+                                          - path
+                                          - server
+                                        type: object
+                                      persistentVolumeClaim:
+                                        description: >-
+                                          persistentVolumeClaimVolumeSource
+                                          represents a reference to a
+
+                                          PersistentVolumeClaim in the same...
+                                        properties:
+                                          claimName:
+                                            description: claimName is the name of a PersistentVolumeClaim in the same
+                                              namespace as the pod using this
+                                              volume.
+                                            type: string
+                                          readOnly:
+                                            description: >-
+                                              readOnly Will force the ReadOnly
+                                              setting in VolumeMounts.
+
+                                              Default false.
+                                            type: boolean
+                                        required:
+                                          - claimName
+                                        type: object
+                                      photonPersistentDisk:
+                                        description: photonPersistentDisk represents a PhotonController persistent disk
+                                          attached and mounted on kubelets...
+                                        properties:
+                                          fsType:
+                                            description: fsType is the filesystem type to mount.
+                                            type: string
+                                          pdID:
+                                            description: pdID is the ID that identifies Photon Controller persistent disk
+                                            type: string
+                                        required:
+                                          - pdID
+                                        type: object
+                                      portworxVolume:
+                                        description: portworxVolume represents a portworx volume attached and mounted on
+                                          kubelets host machine.
+                                        properties:
+                                          fsType:
+                                            description: >-
+                                              fSType represents the filesystem
+                                              type to mount
+
+                                              Must be a filesystem type
+                                              supported by the host...
+                                            type: string
+                                          readOnly:
+                                            description: readOnly defaults to false (read/write).
+                                            type: boolean
+                                          volumeID:
+                                            description: volumeID uniquely identifies a Portworx volume
+                                            type: string
+                                        required:
+                                          - volumeID
+                                        type: object
+                                      projected:
+                                        description: projected items for all in one resources secrets, configmaps, and
+                                          downward API
+                                        properties:
+                                          defaultMode:
+                                            description: defaultMode are the mode bits used to set permissions on created
+                                              files by default.
+                                            format: int32
+                                            type: integer
+                                          sources:
+                                            description: >-
+                                              sources is the list of volume
+                                              projections. Each entry in this
+                                              list
+
+                                              handles one source.
+                                            items:
+                                              description: Projection that may be projected along with other supported volume
+                                                types.
+                                              properties:
+                                                clusterTrustBundle:
+                                                  description: ClusterTrustBundle allows a pod to access the `.spec.
+                                                  properties:
+                                                    labelSelector:
+                                                      description: Select all ClusterTrustBundles that match this label selector.
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions is a list of label selector requirements. The
+                                                            requirements are
+                                                            ANDed.
+                                                          items:
+                                                            description: A label selector requirement is a selector that contains values, a
+                                                              key, and an operator
+                                                              that...
+                                                            properties:
+                                                              key:
+                                                                description: key is the label key that the selector applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator represents a key's relationship to a set of values.
+                                                                type: string
+                                                              values:
+                                                                description: values is an array of string values.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            required:
+                                                              - key
+                                                              - operator
+                                                            type: object
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels is a map of {key,value} pairs.
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    name:
+                                                      description: Select a single ClusterTrustBundle by object name.
+                                                      type: string
+                                                    optional:
+                                                      description: >-
+                                                        If true, don't block pod
+                                                        startup if the
+                                                        referenced
+                                                        ClusterTrustBundle(s)
+
+                                                        aren't available.
+                                                      type: boolean
+                                                    path:
+                                                      description: Relative path from the volume root to write the bundle.
+                                                      type: string
+                                                    signerName:
+                                                      description: >-
+                                                        Select all
+                                                        ClusterTrustBundles that
+                                                        match this signer name.
+
+                                                        Mutually-exclusive with
+                                                        name.
+                                                      type: string
+                                                  required:
+                                                    - path
+                                                  type: object
+                                                configMap:
+                                                  description: configMap information about the configMap data to project
+                                                  properties:
+                                                    items:
+                                                      description: >-
+                                                        items if unspecified,
+                                                        each key-value pair in
+                                                        the Data field of the
+                                                        referenced
+
+                                                        ConfigMap will be...
+                                                      items:
+                                                        description: Maps a string key to a path within a volume.
+                                                        properties:
+                                                          key:
+                                                            description: key is the key to project.
+                                                            type: string
+                                                          mode:
+                                                            description: "mode is Optional: mode bits used to set permissions on this file."
+                                                            format: int32
+                                                            type: integer
+                                                          path:
+                                                            description: >-
+                                                              
+                                                              path is the
+                                                              relative path of the
+                                                              file to map the key
+                                                              to.
+
+                                                              May not be an
+                                                              absolute path.
+                                                            type: string
+                                                        required:
+                                                          - key
+                                                          - path
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    name:
+                                                      default: ""
+                                                      description: Name of the referent.
+                                                      type: string
+                                                    optional:
+                                                      description: optional specify whether the ConfigMap or its keys must be defined
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                downwardAPI:
+                                                  description: downwardAPI information about the downwardAPI data to project
+                                                  properties:
+                                                    items:
+                                                      description: Items is a list of DownwardAPIVolume file
+                                                      items:
+                                                        description: DownwardAPIVolumeFile represents information to create the file
+                                                          containing the pod
+                                                          field
+                                                        properties:
+                                                          fieldRef:
+                                                            description: "Required: Selects a field of the pod: only annotations, labels,
+                                                              name, namespace and
+                                                              uid are..."
+                                                            properties:
+                                                              apiVersion:
+                                                                description: Version of the schema the FieldPath is written in terms of,
+                                                                  defaults to "v1".
+                                                                type: string
+                                                              fieldPath:
+                                                                description: Path of the field to select in the specified API version.
+                                                                type: string
+                                                            required:
+                                                              - fieldPath
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                          mode:
+                                                            description: >-
+                                                              
+                                                              Optional: mode
+                                                              bits used to set
+                                                              permissions on this
+                                                              file, must be an
+                                                              octal value
+
+                                                              between 0000 and...
+                                                            format: int32
+                                                            type: integer
+                                                          path:
+                                                            description: "Required: Path is  the relative path name of the file to be
+                                                              created."
+                                                            type: string
+                                                          resourceFieldRef:
+                                                            description: >-
+                                                              
+                                                              Selects a resource
+                                                              of the container:
+                                                              only resources
+                                                              limits and requests
+
+                                                              (limits.cpu, limits.
+                                                            properties:
+                                                              containerName:
+                                                                description: "Container name: required for volumes, optional for env vars"
+                                                                type: string
+                                                              divisor:
+                                                                anyOf:
+                                                                  - type: integer
+                                                                  - type: string
+                                                                description: Specifies the output format of the exposed resources, defaults to
+                                                                  "1"
+                                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                x-kubernetes-int-or-string: true
+                                                              resource:
+                                                                description: "Required: resource to select"
+                                                                type: string
+                                                            required:
+                                                              - resource
+                                                            type: object
+                                                            x-kubernetes-map-type: atomic
+                                                        required:
+                                                          - path
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  type: object
+                                                podCertificate:
+                                                  description: >-
+                                                    Projects an auto-rotating
+                                                    credential bundle (private
+                                                    key and certificate
+
+                                                    chain) that the pod can...
+                                                  properties:
+                                                    certificateChainPath:
+                                                      description: Write the certificate chain at this path in the projected volume.
+                                                      type: string
+                                                    credentialBundlePath:
+                                                      description: Write the credential bundle at this path in the projected volume.
+                                                      type: string
+                                                    keyPath:
+                                                      description: Write the key at this path in the projected volume.
+                                                      type: string
+                                                    keyType:
+                                                      description: The type of keypair Kubelet will generate for the pod.
+                                                      type: string
+                                                    maxExpirationSeconds:
+                                                      description: >-
+                                                        maxExpirationSeconds is
+                                                        the maximum lifetime
+                                                        permitted for the
+
+                                                        certificate.
+                                                      format: int32
+                                                      type: integer
+                                                    signerName:
+                                                      description: Kubelet's generated CSRs will be addressed to this signer.
+                                                      type: string
+                                                    userAnnotations:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: >-
+                                                        userAnnotations allow
+                                                        pod authors to pass
+                                                        additional information
+                                                        to
+
+                                                        the signer
+                                                        implementation.
+                                                      type: object
+                                                  required:
+                                                    - keyType
+                                                    - signerName
+                                                  type: object
+                                                secret:
+                                                  description: secret information about the secret data to project
+                                                  properties:
+                                                    items:
+                                                      description: >-
+                                                        items if unspecified,
+                                                        each key-value pair in
+                                                        the Data field of the
+                                                        referenced
+
+                                                        Secret will be...
+                                                      items:
+                                                        description: Maps a string key to a path within a volume.
+                                                        properties:
+                                                          key:
+                                                            description: key is the key to project.
+                                                            type: string
+                                                          mode:
+                                                            description: "mode is Optional: mode bits used to set permissions on this file."
+                                                            format: int32
+                                                            type: integer
+                                                          path:
+                                                            description: >-
+                                                              
+                                                              path is the
+                                                              relative path of the
+                                                              file to map the key
+                                                              to.
+
+                                                              May not be an
+                                                              absolute path.
+                                                            type: string
+                                                        required:
+                                                          - key
+                                                          - path
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    name:
+                                                      default: ""
+                                                      description: Name of the referent.
+                                                      type: string
+                                                    optional:
+                                                      description: optional field specify whether the Secret or its key must be
+                                                        defined
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                serviceAccountToken:
+                                                  description: serviceAccountToken is information about the serviceAccountToken
+                                                    data to project
+                                                  properties:
+                                                    audience:
+                                                      description: audience is the intended audience of the token.
+                                                      type: string
+                                                    expirationSeconds:
+                                                      description: >-
+                                                        expirationSeconds is the
+                                                        requested duration of
+                                                        validity of the service
+
+                                                        account token.
+                                                      format: int64
+                                                      type: integer
+                                                    path:
+                                                      description: >-
+                                                        path is the path
+                                                        relative to the mount
+                                                        point of the file to
+                                                        project the
+
+                                                        token into.
+                                                      type: string
+                                                  required:
+                                                    - path
+                                                  type: object
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      quobyte:
+                                        description: quobyte represents a Quobyte mount on the host that shares a pod's
+                                          lifetime.
+                                        properties:
+                                          group:
+                                            description: |-
+                                              group to map volume access to
+                                              Default is no group
+                                            type: string
+                                          readOnly:
+                                            description: readOnly here will force the Quobyte volume to be mounted with
+                                              read-only permissions.
+                                            type: boolean
+                                          registry:
+                                            description: >-
+                                              registry represents a single or
+                                              multiple Quobyte Registry services
+
+                                              specified as a string as...
+                                            type: string
+                                          tenant:
+                                            description: >-
+                                              tenant owning the given Quobyte
+                                              volume in the Backend
+
+                                              Used with dynamically provisioned
+                                              Quobyte...
+                                            type: string
+                                          user:
+                                            description: |-
+                                              user to map volume access to
+                                              Defaults to serivceaccount user
+                                            type: string
+                                          volume:
+                                            description: volume is a string that references an already created Quobyte
+                                              volume by name.
+                                            type: string
+                                        required:
+                                          - registry
+                                          - volume
+                                        type: object
+                                      rbd:
+                                        description: rbd represents a Rados Block Device mount on the host that shares a
+                                          pod's lifetime.
+                                        properties:
+                                          fsType:
+                                            description: fsType is the filesystem type of the volume that you want to mount.
+                                            type: string
+                                          image:
+                                            description: |-
+                                              image is the rados image name.
+                                              More info: https://examples.k8s.io/volumes/rbd/README.
+                                            type: string
+                                          keyring:
+                                            default: /etc/ceph/keyring
+                                            description: >-
+                                              keyring is the path to key ring
+                                              for RBDUser.
+
+                                              Default is /etc/ceph/keyring.
+                                            type: string
+                                          monitors:
+                                            description: |-
+                                              monitors is a collection of Ceph monitors.
+                                              More info: https://examples.k8s.io/volumes/rbd/README.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          pool:
+                                            default: rbd
+                                            description: |-
+                                              pool is the rados pool name.
+                                              Default is rbd.
+                                              More info: https://examples.k8s.io/volumes/rbd/README.
+                                            type: string
+                                          readOnly:
+                                            description: >-
+                                              readOnly here will force the
+                                              ReadOnly setting in VolumeMounts.
+
+                                              Defaults to false.
+                                            type: boolean
+                                          secretRef:
+                                            description: >-
+                                              secretRef is name of the
+                                              authentication secret for RBDUser.
+                                              If provided
+
+                                              overrides keyring.
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: Name of the referent.
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          user:
+                                            default: admin
+                                            description: |-
+                                              user is the rados user name.
+                                              Default is admin.
+                                              More info: https://examples.k8s.
+                                            type: string
+                                        required:
+                                          - image
+                                          - monitors
+                                        type: object
+                                      scaleIO:
+                                        description: scaleIO represents a ScaleIO persistent volume attached and mounted
+                                          on Kubernetes nodes.
+                                        properties:
+                                          fsType:
+                                            default: xfs
+                                            description: fsType is the filesystem type to mount.
+                                            type: string
+                                          gateway:
+                                            description: gateway is the host address of the ScaleIO API Gateway.
+                                            type: string
+                                          protectionDomain:
+                                            description: protectionDomain is the name of the ScaleIO Protection Domain for
+                                              the configured storage.
+                                            type: string
+                                          readOnly:
+                                            description: readOnly Defaults to false (read/write).
+                                            type: boolean
+                                          secretRef:
+                                            description: >-
+                                              secretRef references to the secret
+                                              for ScaleIO user and other
+
+                                              sensitive information.
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: Name of the referent.
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          sslEnabled:
+                                            description: sslEnabled Flag enable/disable SSL communication with Gateway,
+                                              default false
+                                            type: boolean
+                                          storageMode:
+                                            default: ThinProvisioned
+                                            description: storageMode indicates whether the storage for a volume should be
+                                              ThickProvisioned or...
+                                            type: string
+                                          storagePool:
+                                            description: storagePool is the ScaleIO Storage Pool associated with the
+                                              protection domain.
+                                            type: string
+                                          system:
+                                            description: system is the name of the storage system as configured in ScaleIO.
+                                            type: string
+                                          volumeName:
+                                            description: >-
+                                              volumeName is the name of a volume
+                                              already created in the ScaleIO
+                                              system
+
+                                              that is associated with...
+                                            type: string
+                                        required:
+                                          - gateway
+                                          - secretRef
+                                          - system
+                                        type: object
+                                      secret:
+                                        description: >-
+                                          secret represents a secret that should
+                                          populate this volume.
+
+                                          More info: https://kubernetes.
+                                        properties:
+                                          defaultMode:
+                                            description: "defaultMode is Optional: mode bits used to set permissions on
+                                              created files by default."
+                                            format: int32
+                                            type: integer
+                                          items:
+                                            description: >-
+                                              items If unspecified, each
+                                              key-value pair in the Data field
+                                              of the referenced
+
+                                              Secret will be...
+                                            items:
+                                              description: Maps a string key to a path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: "mode is Optional: mode bits used to set permissions on this file."
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: >-
+                                                    path is the relative path of
+                                                    the file to map the key to.
+
+                                                    May not be an absolute path.
+                                                  type: string
+                                              required:
+                                                - key
+                                                - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          optional:
+                                            description: optional field specify whether the Secret or its keys must be
+                                              defined
+                                            type: boolean
+                                          secretName:
+                                            description: >-
+                                              secretName is the name of the
+                                              secret in the pod's namespace to
+                                              use.
+
+                                              More info: https://kubernetes.
+                                            type: string
+                                        type: object
+                                      storageos:
+                                        description: storageOS represents a StorageOS volume attached and mounted on
+                                          Kubernetes nodes.
+                                        properties:
+                                          fsType:
+                                            description: fsType is the filesystem type to mount.
+                                            type: string
+                                          readOnly:
+                                            description: readOnly defaults to false (read/write).
+                                            type: boolean
+                                          secretRef:
+                                            description: >-
+                                              secretRef specifies the secret to
+                                              use for obtaining the StorageOS
+                                              API
+
+                                              credentials.
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: Name of the referent.
+                                                type: string
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          volumeName:
+                                            description: volumeName is the human-readable name of the StorageOS volume.
+                                            type: string
+                                          volumeNamespace:
+                                            description: volumeNamespace specifies the scope of the volume within StorageOS.
+                                            type: string
+                                        type: object
+                                      vsphereVolume:
+                                        description: vsphereVolume represents a vSphere volume attached and mounted on
+                                          kubelets host machine.
+                                        properties:
+                                          fsType:
+                                            description: fsType is filesystem type to mount.
+                                            type: string
+                                          storagePolicyID:
+                                            description: storagePolicyID is the storage Policy Based Management (SPBM)
+                                              profile ID associated with the...
+                                            type: string
+                                          storagePolicyName:
+                                            description: storagePolicyName is the storage Policy Based Management (SPBM)
+                                              profile name.
+                                            type: string
+                                          volumePath:
+                                            description: volumePath is the path that identifies vSphere volume vmdk
+                                            type: string
+                                        required:
+                                          - volumePath
+                                        type: object
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                workloadRef:
+                                  description: WorkloadRef provides a reference to the Workload object that this
+                                    Pod belongs to.
+                                  properties:
+                                    name:
+                                      description: Name defines the name of the Workload object this Pod belongs to.
+                                      type: string
+                                    podGroup:
+                                      description: >-
+                                        PodGroup is the name of the PodGroup
+                                        within the Workload that this Pod
+
+                                        belongs to.
+                                      type: string
+                                    podGroupReplicaKey:
+                                      description: >-
+                                        PodGroupReplicaKey specifies the replica
+                                        key of the PodGroup to which this
+
+                                        Pod belongs.
+                                      type: string
+                                  required:
+                                    - name
+                                    - podGroup
+                                  type: object
+                              required:
+                                - containers
+                              type: object
+                          type: object
+                      type: object
+                    podDisruptionBudget:
+                      description: Use this field to configure a PodDisruptionBudget for the Gateway.
+                      properties:
+                        enabled:
+                          default: false
+                          description: Use this field to enable PodDisruptionBudget reconciliation for the
+                            Gateway.
+                          type: boolean
+                        maxUnavailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: The maximum number of pods that can be unavailable after an
+                            eviction.
+                          x-kubernetes-int-or-string: true
+                        minAvailable:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: The minimum number of pods that must be available after an
+                            eviction.
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    service:
+                      description: >-
+                        Use this field to customize the Kubernetes Service that
+                        exposes the Gateway
+
+                        by adding labels and...
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        externalTrafficPolicy:
+                          default: Cluster
+                          description: >-
+                            ServiceExternalTrafficPolicy describes how nodes
+                            distribute service traffic they
+
+                            receive on one of...
+                          type: string
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        loadBalancerClass:
+                          type: string
+                        type:
+                          default: LoadBalancer
+                          description: Service Type string describes ingress methods for a service
+                          type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              properties:
+                conditions:
+                  items:
+                    description: Condition contains details for one aspect of the current state of
+                      this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from
+                          one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the
+                          transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the
+                          condition was set based upon.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for
+                          the condition's last transition.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              required:
+                - conditions
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_groups.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_groups.yaml
@@ -1,0 +1,200 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    gravitee.io/operator.version: 4.11.1
+  name: groups.gravitee.io
+spec:
+  group: gravitee.io
+  names:
+    kind: Group
+    listKind: GroupList
+    plural: groups
+    singular: group
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The number of members added to the group
+          jsonPath: .status.members
+          name: Members at
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: APIVersion defines the versioned schema of this representation of
+                an object.
+              type: string
+            kind:
+              description: Kind is a string value representing the REST resource this object
+                represents.
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                contextRef:
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                id:
+                  type: string
+                members:
+                  items:
+                    properties:
+                      roles:
+                        additionalProperties:
+                          type: string
+                        default: {}
+                        type: object
+                      source:
+                        description: Member source
+                        example: gravitee
+                        type: string
+                      sourceId:
+                        description: Member source ID
+                        example: user@email.com
+                        type: string
+                    required:
+                      - source
+                      - sourceId
+                    type: object
+                  type: array
+                name:
+                  type: string
+                notifyMembers:
+                  default: true
+                  description: |-
+                    If true, new members added to the API spec will
+                    be notified when the API is synced with APIM.
+                  type: boolean
+              required:
+                - members
+                - name
+              type: object
+            status:
+              properties:
+                conditions:
+                  default: []
+                  description: Conditions describe the current conditions of the Group.
+                  items:
+                    description: Condition contains details for one aspect of the current state of
+                      this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from
+                          one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the
+                          transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the
+                          condition was set based upon.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for
+                          the condition's last transition.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 8
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                environmentId:
+                  description: The environment ID defined in the management context
+                  type: string
+                errors:
+                  description: >-
+                    When group has been created regardless of errors, this field
+                    is
+
+                    used to persist the error message...
+                  properties:
+                    severe:
+                      description: >-
+                        severe errors do not pass admission and will block
+                        reconcile
+
+                        hence, this field should always be...
+                      items:
+                        type: string
+                      type: array
+                    warning:
+                      description: |-
+                        warning errors do not block object reconciliation,
+                        most of the time because the value is ignored or...
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                id:
+                  description: The ID of the Group in the Gravitee API Management instance
+                  type: string
+                members:
+                  description: The number of members added to this group
+                  type: integer
+                organizationId:
+                  description: The organization ID defined in the management context
+                  type: string
+                processingStatus:
+                  description: The processing status of the Group. *** DEPRECATED ***
+                  type: string
+              required:
+                - members
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_kafkaroutes.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_kafkaroutes.yaml
@@ -1,0 +1,491 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    gravitee.io/extends: gateway.networking.k8s.io
+    gravitee.io/operator.version: 4.11.1
+  name: kafkaroutes.gravitee.io
+spec:
+  group: gravitee.io
+  names:
+    kind: KafkaRoute
+    listKind: KafkaRouteList
+    plural: kafkaroutes
+    singular: kafkaroute
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: APIVersion defines the versioned schema of this representation of
+                an object.
+              type: string
+            kind:
+              description: Kind is a string value representing the REST resource this object
+                represents.
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                backendRefs:
+                  description: BackendRefs defines the backend(s) where matching requests should
+                    be sent.
+                  items:
+                    description: >-
+                      This currently wraps the code gateway API
+                      BackendObjectReference type,
+
+                      leaving room for e.g.
+                    properties:
+                      group:
+                        default: ""
+                        description: Group is the group of the referent. For example,
+                          "gateway.networking.k8s.io".
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Service
+                        description: >-
+                          Kind is the Kubernetes resource kind of the referent.
+                          For example
+
+                          "Service".
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the referent.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: >-
+                          Namespace is the namespace of the backend. When
+                          unspecified, the local
+
+                          namespace is inferred.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                      port:
+                        description: Port specifies the destination port number to use for this
+                          resource.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                    required:
+                      - name
+                    type: object
+                    x-kubernetes-validations:
+                      - message: Must have port for Service reference
+                        rule: "(size(self.group) == 0 && self.kind == 'Service') ? has(self.port) :
+                          true"
+                  maxItems: 16
+                  minItems: 1
+                  type: array
+                filters:
+                  description: Filters define the filters that are applied to Kafka trafic
+                    matching this route.
+                  items:
+                    properties:
+                      acl:
+                        description: ACL defines a schema for a filter that enforce access controls on
+                          Kafka trafic.
+                        properties:
+                          rules:
+                            description: >-
+                              Rules define a set of rules that can be use to
+                              group a set of resources together with
+
+                              access...
+                            items:
+                              properties:
+                                options:
+                                  additionalProperties:
+                                    description: AnnotationValue is the value of an annotation in Gateway API.
+                                    maxLength: 4096
+                                    minLength: 0
+                                    type: string
+                                  description: >-
+                                    Options allow to specify implementation
+                                    specific behaviours
+
+                                    for a set of rules.
+                                  maxProperties: 16
+                                  type: object
+                                resources:
+                                  description: >-
+                                    A resource group together a type of matched
+                                    resource and a set of operations
+
+                                    to be granted by the...
+                                  items:
+                                    properties:
+                                      match:
+                                        description: Match describes how to select the resource that will be subject to
+                                          the access control.
+                                        properties:
+                                          type:
+                                            description: >-
+                                              Valid PathMatchType values, along
+                                              with their support levels, are:
+
+
+                                              * "Exact" Resources whose name...
+                                            enum:
+                                              - Exact
+                                              - Prefix
+                                              - RegularExpression
+                                            type: string
+                                          value:
+                                            description: Value of the resource to match against.
+                                            type: string
+                                        required:
+                                          - type
+                                          - value
+                                        type: object
+                                      operations:
+                                        description: >-
+                                          Operations specifies the set of
+                                          operations / verbs to allow for the
+                                          resource
+
+                                          under access control.
+                                        items:
+                                          enum:
+                                            - Create
+                                            - Read
+                                            - Write
+                                            - Delete
+                                            - Alter
+                                            - AlterConfigs
+                                            - Describe
+                                            - DescribeConfigs
+                                            - ClusterAction
+                                          type: string
+                                        type: array
+                                      type:
+                                        enum:
+                                          - Topic
+                                          - Cluster
+                                          - Group
+                                          - TransactionalIdentifier
+                                        type: string
+                                    required:
+                                      - operations
+                                      - type
+                                    type: object
+                                  minItems: 1
+                                  type: array
+                              required:
+                                - resources
+                              type: object
+                            maxItems: 16
+                            minItems: 1
+                            type: array
+                        required:
+                          - rules
+                        type: object
+                      extensionRef:
+                        description: >-
+                          LocalObjectReference identifies an API object within
+                          the namespace of the
+
+                          referrer.
+                        properties:
+                          group:
+                            description: Group is the group of the referent. For example,
+                              "gateway.networking.k8s.io".
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            description: Kind is kind of the referent. For example "HTTPRoute" or "Service".
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: Name is the name of the referent.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        required:
+                          - group
+                          - kind
+                          - name
+                        type: object
+                      type:
+                        description: Type identifies the type of filter to apply.
+                        enum:
+                          - ACL
+                          - ExtensionRef
+                        type: string
+                    required:
+                      - type
+                    type: object
+                  maxItems: 16
+                  type: array
+                hostname:
+                  description: Hostname is used to uniquely route clients to this API.
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                options:
+                  additionalProperties:
+                    description: AnnotationValue is the value of an annotation in Gateway API.
+                    maxLength: 4096
+                    minLength: 0
+                    type: string
+                  description: >-
+                    Options are a list of key/value pairs to enable extended
+                    configuration specific
+
+                    to an
+                  maxProperties: 16
+                  type: object
+                parentRefs:
+                  description: >-
+                    ParentRefs references the resources (usually Gateways) that
+                    a Route wants
+
+                    to be attached to.
+                  items:
+                    description: >-
+                      ParentReference identifies an API object (usually a
+                      Gateway) that can be considered
+
+                      a parent of...
+                    properties:
+                      group:
+                        default: gateway.networking.k8s.io
+                        description: >-
+                          Group is the group of the referent.
+
+                          When unspecified, "gateway.networking.k8s.io" is
+                          inferred.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Gateway
+                        description: Kind is kind of the referent.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the referent.
+
+                          Support: Core
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the referent.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                      port:
+                        description: Port is the network port this Route targets.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      sectionName:
+                        description: SectionName is the name of a section within the target resource.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-type: atomic
+                useDefaultGateways:
+                  description: >-
+                    UseDefaultGateways indicates the default Gateway scope to
+                    use for this
+
+                    Route.
+                  enum:
+                    - All
+                    - None
+                  type: string
+              type: object
+            status:
+              properties:
+                parents:
+                  description: >-
+                    Parents is a list of parent resources (usually Gateways)
+                    that are
+
+                    associated with the route, and...
+                  items:
+                    description: >-
+                      RouteParentStatus describes the status of a route with
+                      respect to an
+
+                      associated Parent.
+                    properties:
+                      conditions:
+                        description: Conditions describes the status of the route with respect to the
+                          Gateway.
+                        items:
+                          description: Condition contains details for one aspect of the current state of
+                            this API Resource.
+                          properties:
+                            lastTransitionTime:
+                              description: lastTransitionTime is the last time the condition transitioned from
+                                one status to another.
+                              format: date-time
+                              type: string
+                            message:
+                              description: message is a human readable message indicating details about the
+                                transition.
+                              maxLength: 32768
+                              type: string
+                            observedGeneration:
+                              description: observedGeneration represents the .metadata.generation that the
+                                condition was set based upon.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            reason:
+                              description: reason contains a programmatic identifier indicating the reason for
+                                the condition's last transition.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        maxItems: 8
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      controllerName:
+                        description: >-
+                          ControllerName is a domain/path string that indicates
+                          the name of the
+
+                          controller that wrote this...
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                        type: string
+                      parentRef:
+                        description: >-
+                          ParentRef corresponds with a ParentRef in the spec
+                          that this
+
+                          RouteParentStatus struct describes the...
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: >-
+                              Group is the group of the referent.
+
+                              When unspecified, "gateway.networking.k8s.io" is
+                              inferred.
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Gateway
+                            description: Kind is kind of the referent.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the referent.
+
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the referent.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: Port is the network port this Route targets.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          sectionName:
+                            description: SectionName is the name of a section within the target resource.
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                    required:
+                      - conditions
+                      - controllerName
+                      - parentRef
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-type: atomic
+              required:
+                - parents
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_managementcontexts.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_managementcontexts.yaml
@@ -1,0 +1,196 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    gravitee.io/operator.version: 4.11.1
+  name: managementcontexts.gravitee.io
+spec:
+  group: gravitee.io
+  names:
+    kind: ManagementContext
+    listKind: ManagementContextList
+    plural: managementcontexts
+    shortNames:
+      - graviteecontexts
+    singular: managementcontext
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.baseUrl
+          name: BaseUrl
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: APIVersion defines the versioned schema of this representation of
+                an object.
+              type: string
+            kind:
+              description: Kind is a string value representing the REST resource this object
+                represents.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ManagementContext represents the configuration for a specific
+                environment
+              properties:
+                auth:
+                  description: Auth defines the authentication method used to connect to the API
+                    Management.
+                  properties:
+                    bearerToken:
+                      description: >-
+                        The bearer token used to authenticate against the API
+                        Management instance
+
+                        (must be generated from...
+                      type: string
+                    credentials:
+                      description: The Basic credentials used to authenticate against the API
+                        Management instance.
+                      properties:
+                        password:
+                          type: string
+                        username:
+                          type: string
+                      required:
+                        - password
+                        - username
+                      type: object
+                    secretRef:
+                      description: >-
+                        A secret reference holding either a "bearerToken" key
+                        for bearer token authentication
+
+                        or "username"...
+                      properties:
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                      type: object
+                  type: object
+                baseUrl:
+                  description: The URL of a management API instance.
+                  type: string
+                cloud:
+                  description: Cloud when set (token or secretRef) this context will target
+                    Gravitee Cloud.
+                  properties:
+                    secretRef:
+                      description: SecretRef secret reference holding the Gravitee cloud token in the
+                        "cloudToken" key
+                      properties:
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    token:
+                      description: Token plain text Gravitee cloud token (JWT)
+                      type: string
+                  type: object
+                environmentId:
+                  description: An existing environment id targeted by the context within the
+                    organization.
+                  type: string
+                organizationId:
+                  description: An existing organization id targeted by the context on the
+                    management API instance.
+                  type: string
+                path:
+                  description: Allows to override the context path that will be appended to the
+                    baseURL.
+                  type: string
+              type: object
+            status:
+              description: ManagementContextStatus defines the observed state of an API
+                Context.
+              properties:
+                conditions:
+                  default: []
+                  description: Conditions describe the current conditions of the
+                    ManagementContext.
+                  items:
+                    description: Condition contains details for one aspect of the current state of
+                      this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from
+                          one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the
+                          transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the
+                          condition was set based upon.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for
+                          the condition's last transition.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 8
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_notifications.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_notifications.yaml
@@ -1,0 +1,204 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    gravitee.io/operator.version: 4.11.1
+  name: notifications.gravitee.io
+spec:
+  group: gravitee.io
+  names:
+    kind: Notification
+    listKind: NotificationList
+    plural: notifications
+    shortNames:
+      - graviteenotif
+    singular: notification
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Target
+          jsonPath: .spec.target
+          name: Target
+          type: string
+        - description: Event Type
+          jsonPath: .spec.eventType
+          name: Event Type
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Notification defines notification settings in Gravitee
+          properties:
+            apiVersion:
+              description: APIVersion defines the versioned schema of this representation of
+                an object.
+              type: string
+            kind:
+              description: Kind is a string value representing the REST resource this object
+                represents.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                NotificationSpec defines the desired state of a Notification.
+                It is to be referenced in an API.
+              properties:
+                console:
+                  default: {}
+                  description: >-
+                    Console is used when the target value is "console" and is
+                    meant
+
+                    to configure Gravitee console UI...
+                  properties:
+                    apiEvents:
+                      description: List events that will trigger a notification for an API.
+                      items:
+                        description: ApiEvent defines the events that can be sent to the console.
+                        enum:
+                          - APIKEY_EXPIRED
+                          - APIKEY_RENEWED
+                          - APIKEY_REVOKED
+                          - SUBSCRIPTION_NEW
+                          - SUBSCRIPTION_ACCEPTED
+                          - SUBSCRIPTION_CLOSED
+                          - SUBSCRIPTION_PAUSED
+                          - SUBSCRIPTION_RESUMED
+                          - SUBSCRIPTION_REJECTED
+                          - SUBSCRIPTION_TRANSFERRED
+                          - SUBSCRIPTION_FAILED
+                          - NEW_SUPPORT_TICKET
+                          - API_STARTED
+                          - API_STOPPED
+                          - API_UPDATED
+                          - API_DEPLOYED
+                          - NEW_RATING
+                          - NEW_RATING_ANSWER
+                          - MESSAGE
+                          - ASK_FOR_REVIEW
+                          - REVIEW_OK
+                          - REQUEST_FOR_CHANGES
+                          - API_DEPRECATED
+                          - NEW_SPEC_GENERATED
+                        type: string
+                      type: array
+                    groupRefs:
+                      description: List of group references associated with this console notification.
+                      items:
+                        properties:
+                          kind:
+                            type: string
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    groups:
+                      description: |-
+                        List of groups associated with the API.
+                        These groups are id to existing groups in APIM.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                eventType:
+                  default: api
+                  description: EventType defines the subject of those events.
+                  enum:
+                    - api
+                  type: string
+                target:
+                  default: console
+                  description: 'Target of the notification: "console" is for notifications in
+                    Gravitee console UI.'
+                  enum:
+                    - console
+                  type: string
+              required:
+                - eventType
+                - target
+              type: object
+            status:
+              description: NotificationStatus defines the observed state of the Notification.
+              properties:
+                conditions:
+                  default: []
+                  description: >-
+                    Conditions are the condition that must be met by the
+                    Notification
+
+                    "Accepted" condition is used to...
+                  items:
+                    description: Condition contains details for one aspect of the current state of
+                      this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from
+                          one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the
+                          transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the
+                          condition was set based upon.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for
+                          the condition's last transition.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+              required:
+                - conditions
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_sharedpolicygroups.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_sharedpolicygroups.yaml
@@ -1,0 +1,243 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    gravitee.io/operator.version: 4.11.1
+  name: sharedpolicygroups.gravitee.io
+spec:
+  group: gravitee.io
+  names:
+    kind: SharedPolicyGroup
+    listKind: SharedPolicyGroupList
+    plural: sharedpolicygroups
+    shortNames:
+      - sharedpolicygroups
+    singular: sharedpolicygroup
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.name
+          name: name
+          type: string
+        - jsonPath: .spec.description
+          name: description
+          type: string
+        - jsonPath: .spec.apiType
+          name: apiType
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: SharedPolicyGroup
+          properties:
+            apiVersion:
+              description: APIVersion defines the versioned schema of this representation of
+                an object.
+              type: string
+            kind:
+              description: Kind is a string value representing the REST resource this object
+                represents.
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SharedPolicyGroupSpec
+              properties:
+                apiType:
+                  description: Specify the SharedPolicyGroup ApiType
+                  enum:
+                    - MESSAGE
+                    - PROXY
+                    - NATIVE
+                  type: string
+                contextRef:
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                crossId:
+                  description: CrossID to export SharedPolicyGroup into different environments
+                  type: string
+                description:
+                  description: SharedPolicyGroup description
+                  type: string
+                name:
+                  description: SharedPolicyGroup name
+                  type: string
+                phase:
+                  description: SharedPolicyGroup phase
+                    (REQUEST;RESPONSE;INTERACT;CONNECT;PUBLISH;SUBSCRIBE)
+                  enum:
+                    - REQUEST
+                    - RESPONSE
+                    - INTERACT
+                    - CONNECT
+                    - PUBLISH
+                    - SUBSCRIBE
+                  type: string
+                prerequisiteMessage:
+                  description: SharedPolicyGroup prerequisite Message
+                  type: string
+                steps:
+                  description: SharedPolicyGroup Steps
+                  items:
+                    properties:
+                      condition:
+                        description: FlowStep condition
+                        type: string
+                      configuration:
+                        description: FlowStep configuration is a map of arbitrary key-values
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                      description:
+                        description: FlowStep description
+                        type: string
+                      enabled:
+                        default: true
+                        description: Indicate if this FlowStep is enabled or not
+                        type: boolean
+                      name:
+                        description: FlowStep name
+                        type: string
+                      policy:
+                        description: FlowStep policy
+                        type: string
+                    required:
+                      - enabled
+                    type: object
+                  type: array
+              required:
+                - apiType
+                - contextRef
+                - name
+                - phase
+              type: object
+            status:
+              description: SharedPolicyGroupSpecStatus defines the observed state of an API
+                Context.
+              properties:
+                conditions:
+                  default: []
+                  description: Conditions describe the current conditions of the
+                    SharedPolicyGroup.
+                  items:
+                    description: Condition contains details for one aspect of the current state of
+                      this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from
+                          one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the
+                          transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the
+                          condition was set based upon.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for
+                          the condition's last transition.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 8
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                crossId:
+                  description: The Cross ID is used to identify an SharedPolicyGroup that has been
+                    promoted from one environment...
+                  type: string
+                environmentId:
+                  description: The environment ID, if a management context has been defined to
+                    sync with an APIM instance
+                  type: string
+                errors:
+                  description: >-
+                    When SharedPolicyGroup has been created regardless of
+                    errors, this field is
+
+                    used to persist the...
+                  properties:
+                    severe:
+                      description: >-
+                        severe errors do not pass admission and will block
+                        reconcile
+
+                        hence, this field should always be...
+                      items:
+                        type: string
+                      type: array
+                    warning:
+                      description: |-
+                        warning errors do not block object reconciliation,
+                        most of the time because the value is ignored or...
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                id:
+                  description: The ID is used to identify an SharedPolicyGroup which is unique in
+                    any environment.
+                  type: string
+                organizationId:
+                  description: The organization ID, if a management context has been defined to
+                    sync with an APIM instance
+                  type: string
+                processingStatus:
+                  description: The processing status of the SharedPolicyGroup.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_subscriptions.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/manifests/gravitee.io_subscriptions.yaml
@@ -1,0 +1,166 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+    gravitee.io/operator.version: 4.11.1
+  name: subscriptions.gravitee.io
+spec:
+  group: gravitee.io
+  names:
+    kind: Subscription
+    listKind: SubscriptionList
+    plural: subscriptions
+    singular: subscription
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The date from when the subscription starts
+          jsonPath: .status.startedAt
+          name: Started at
+          type: string
+        - description: The date when the subscription expires
+          jsonPath: .status.endingAt
+          name: Ending at
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: APIVersion defines the versioned schema of this representation of
+                an object.
+              type: string
+            kind:
+              description: Kind is a string value representing the REST resource this object
+                represents.
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                api:
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                application:
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                    - name
+                  type: object
+                endingAt:
+                  format: date-time
+                  type: string
+                metadata:
+                  additionalProperties:
+                    type: string
+                  type: object
+                plan:
+                  type: string
+              required:
+                - api
+                - application
+                - plan
+              type: object
+            status:
+              properties:
+                conditions:
+                  default: []
+                  description: Conditions describe the current conditions of the Subscription.
+                  items:
+                    description: Condition contains details for one aspect of the current state of
+                      this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: lastTransitionTime is the last time the condition transitioned from
+                          one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: message is a human readable message indicating details about the
+                          transition.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the
+                          condition was set based upon.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: reason contains a programmatic identifier indicating the reason for
+                          the condition's last transition.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 8
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                endingAt:
+                  description: The expiry date for the subscription (no date means no expiry)
+                  type: string
+                id:
+                  description: Subscription ID
+                  type: string
+                processingStatus:
+                  description: This value is `Completed` if the sync with APIM succeeded, Failed
+                    otherwise. *** DEPRECATED ***
+                  type: string
+                startedAt:
+                  description: When the subscription was started and made available
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/operators/gravitee-kubernetes-operator/4.11.1/metadata/annotations.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/metadata/annotations.yaml
@@ -1,0 +1,21 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: gravitee-kubernetes-operator
+  operators.operatorframework.io.bundle.channels.v1: stable-v4.11,alpha
+  operators.operatorframework.io.bundle.channel.default.v1: stable-v4.11

--- a/operators/gravitee-kubernetes-operator/4.11.1/tests/scorecard/config.yaml
+++ b/operators/gravitee-kubernetes-operator/4.11.1/tests/scorecard/config.yaml
@@ -1,0 +1,35 @@
+# Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+  - parallel: true
+    tests:
+      - image: quay.io/operator-framework/scorecard-test:v1.26.0
+        entrypoint:
+          - scorecard-test
+          - basic-check-spec
+        labels:
+          suite: basic
+          test: basic-check-spec-test
+      - image: quay.io/operator-framework/scorecard-test:v1.26.0
+        entrypoint:
+          - scorecard-test
+          - olm-bundle-validation
+        labels:
+          suite: olm
+          test: olm-bundle-validation-test

--- a/operators/gravitee-kubernetes-operator/ci.yaml
+++ b/operators/gravitee-kubernetes-operator/ci.yaml
@@ -1,0 +1,3 @@
+reviewers:
+  - graviteeio
+updateGraph: semver-mode


### PR DESCRIPTION

### New submission

Submitting `gravitee-kubernetes-operator` version `4.11.1` to OperatorHub.

**Operator name:** gravitee-kubernetes-operator
**Operator version:** 4.11.1
**Channels:** stable-v4.11, alpha

This PR was generated automatically by the GKO release pipeline.
