### PR TITLE
operator [N] [CI] ntn-operators (0.4.0)

### DIFF
--- a/operators/ntn-operators/0.4.0/bundle.Dockerfile
+++ b/operators/ntn-operators/0.4.0/bundle.Dockerfile
@@ -1,0 +1,12 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=ntn-operators
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+
+COPY manifests /manifests/
+COPY metadata /metadata/
+COPY tests/scorecard /tests/scorecard/

--- a/operators/ntn-operators/0.4.0/manifests/ntn-operators.clusterserviceversion.yaml
+++ b/operators/ntn-operators/0.4.0/manifests/ntn-operators.clusterserviceversion.yaml
@@ -1,0 +1,231 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "ntn.operators.dev/v1alpha1",
+          "kind": "SatelliteEphemeris",
+          "metadata": {"name": "oneweb-constellation", "namespace": "ntn-system"},
+          "spec": {
+            "source": {"type": "CelesTrak", "url": "https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON"}
+          }
+        },
+        {
+          "apiVersion": "ntn.operators.dev/v1alpha1",
+          "kind": "GroundStationLifecycle",
+          "metadata": {"name": "gs-taipei-01", "namespace": "ntn-system"},
+          "spec": {
+            "hardware": {"vendor": "ennoconn", "model": "edge-box-01"},
+            "deployment": {"location": {"lat": "25.0330", "lon": "121.5654"}}
+          }
+        },
+        {
+          "apiVersion": "ntn.operators.dev/v1alpha1",
+          "kind": "NTNCellConfig",
+          "metadata": {"name": "cell-geo-01", "namespace": "ntn-system"},
+          "spec": {
+            "provider": {"type": "ocudu"},
+            "ntn": {
+              "cellSpecificKoffset": 150,
+              "ephemerisECEF": {"posX": 20922195, "posY": 1967783, "posZ": 19770302}
+            }
+          }
+        },
+        {
+          "apiVersion": "ntn.operators.dev/v1alpha1",
+          "kind": "NTNSlice",
+          "metadata": {"name": "enterprise-slice-01", "namespace": "ntn-system"},
+          "spec": {
+            "tenant": "acme-corp",
+            "terrestrialPath": {"provider": "chunghwa-telecom", "priority": "primary"},
+            "satellitePath": {"provider": "oneweb", "priority": "failover", "ephemerisRef": "oneweb-constellation"},
+            "failoverPolicy": {"triggers": ["rsrp < -120"]}
+          }
+        }
+      ]
+    categories: Networking
+    capabilities: Full Lifecycle
+    # certified: declares whether this is a Red-Hat-certified operator. For
+    # community submissions to k8s-operatorhub/community-operators (which
+    # power operatorhub.io) the canonical value is "false". Verified 2026-04
+    # against 100% of recent submissions (infinispan 2.5.7 / rabbitmq 1.19.1
+    # / clickhouse 0.26.3 all carry this annotation).
+    certified: "false"
+    containerImage: ghcr.io/thc1006/ntn-operators:v0.4.0
+    repository: https://github.com/thc1006/ntn-operators
+    # description: short tile text shown on operatorhub.io marketplace cards.
+    # Hard limit is 135 chars per k8s-operatorhub/community-operators
+    # packaging-required-fields. Long-form prose lives in spec.description.
+    description: "Kubernetes-native NTN: satellite ephemeris, ground station lifecycle, NTN cell config, terrestrial-satellite slice failover."
+    # createdAt: ISO-8601 timestamp of the bundle's published release. Tracks
+    # the v0.4.0 GitHub Release publish time (release.yml run 24963575814,
+    # 2026-04-26T18:12:49Z UTC). Bump on every version cut.
+    createdAt: "2026-04-26T18:12:49Z"
+    support: thc1006
+  name: ntn-operators.v0.4.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: Manages GP data fetching (CelesTrak/SpaceTrack), SGP4 propagation, and pass prediction for satellite constellations.
+        displayName: Satellite Ephemeris
+        kind: SatelliteEphemeris
+        name: satelliteephemeris.ntn.operators.dev
+        version: v1alpha1
+      - description: Manages ground station lifecycle including health monitoring, firmware OTA, and GitOps configuration.
+        displayName: Ground Station Lifecycle
+        kind: GroundStationLifecycle
+        name: groundstationlifecycles.ntn.operators.dev
+        version: v1alpha1
+      - description: Manages NTN cell parameters (SIB19, ephemeris, TA) and pushes configuration to gNB providers.
+        displayName: NTN Cell Config
+        kind: NTNCellConfig
+        name: ntncellconfigs.ntn.operators.dev
+        version: v1alpha1
+      - description: Manages terrestrial-satellite network slice failover, QoS mapping, and session continuity.
+        displayName: NTN Slice
+        kind: NTNSlice
+        name: ntnslices.ntn.operators.dev
+        version: v1alpha1
+  description: |
+    ## NTN Operators
+
+    Kubernetes Operators for Non-Terrestrial Network (NTN) management.
+
+    ### Features
+    - **SatelliteEphemeris**: Fetch GP data from CelesTrak/SpaceTrack, SGP4 propagation, pass prediction
+    - **GroundStationLifecycle**: Health monitoring, firmware OTA, GitOps configuration
+    - **NTNCellConfig**: SIB19 parameters, ephemeris push to gNB (OCUDU provider)
+    - **NTNSlice**: Terrestrial-satellite failover with hysteresis, QoS mapping
+
+    ### Prerequisites
+    - Kubernetes 1.29+
+    - cert-manager (optional, for webhook TLS)
+  displayName: NTN Operators
+  icon:
+    - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCI+PGNpcmNsZSBjeD0iMzIiIGN5PSIzMiIgcj0iMzAiIGZpbGw9IiMxYTczZTgiLz48dGV4dCB4PSIzMiIgeT0iNDAiIGZvbnQtc2l6ZT0iMjAiIGZpbGw9IndoaXRlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiI+TlROPC90ZXh0Pjwvc3ZnPg==
+      mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+        - rules:
+            - apiGroups: [""]
+              resources: [configmaps]
+              verbs: [create, delete, get, list, patch, update, watch]
+            - apiGroups: [""]
+              resources: [events]
+              verbs: [create, patch]
+            - apiGroups: [""]
+              resources: [nodes]
+              verbs: [get, list, watch]
+            - apiGroups: [""]
+              resources: [secrets]
+              verbs: [get]
+            - apiGroups: [ntn.operators.dev]
+              resources: [groundstationlifecycles, ntncellconfigs, ntnslices, satelliteephemeris]
+              verbs: [create, delete, get, list, patch, update, watch]
+            - apiGroups: [ntn.operators.dev]
+              resources: [groundstationlifecycles/finalizers, ntncellconfigs/finalizers, ntnslices/finalizers, satelliteephemeris/finalizers]
+              verbs: [update]
+            - apiGroups: [ntn.operators.dev]
+              resources: [groundstationlifecycles/status, ntncellconfigs/status, ntnslices/status, satelliteephemeris/status]
+              verbs: [get, patch, update]
+          serviceAccountName: ntn-operators-controller-manager
+      deployments:
+        - label:
+            app.kubernetes.io/name: ntn-operators
+            control-plane: controller-manager
+          name: ntn-operators-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+            template:
+              metadata:
+                labels:
+                  control-plane: controller-manager
+              spec:
+                containers:
+                  - name: manager
+                    image: ghcr.io/thc1006/ntn-operators:v0.4.0
+                    args:
+                      - --leader-elect
+                      - --health-probe-bind-address=:8081
+                    ports:
+                      - containerPort: 8081
+                        name: health
+                        protocol: TCP
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop: [ALL]
+                      readOnlyRootFilesystem: true
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: ntn-operators-controller-manager
+                terminationGracePeriodSeconds: 10
+    strategy: deployment
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  keywords:
+    - ntn
+    - satellite
+    - 5g
+    - non-terrestrial-network
+    - kubernetes
+    - operator
+    - sib19
+    - ephemeris
+  links:
+    - name: GitHub
+      url: https://github.com/thc1006/ntn-operators
+    - name: Documentation
+      url: https://github.com/thc1006/ntn-operators/tree/main/docs
+  maintainers:
+    - email: caake2025@gmail.com
+      name: thc1006
+  maturity: alpha
+  minKubeVersion: "1.29.0"
+  provider:
+    name: ntn-operators
+    url: https://github.com/thc1006/ntn-operators
+  # skipRange, not replaces: no v0.1.0 CSV was ever published to an
+  # OperatorHub catalog (the bundle infrastructure landed in PR #91,
+  # after the v0.1.0 tag). An explicit `replaces:` would therefore
+  # point OLM at a CSV it cannot find, failing the install. skipRange
+  # says "this CSV can take over from anything older than itself" and
+  # is safe whether or not an older CSV exists in the catalog.
+  skipRange: "<0.4.0"
+  version: 0.4.0

--- a/operators/ntn-operators/0.4.0/manifests/ntn.operators.dev_groundstationlifecycles.yaml
+++ b/operators/ntn-operators/0.4.0/manifests/ntn.operators.dev_groundstationlifecycles.yaml
@@ -1,0 +1,269 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: groundstationlifecycles.ntn.operators.dev
+spec:
+  group: ntn.operators.dev
+  names:
+    kind: GroundStationLifecycle
+    listKind: GroundStationLifecycleList
+    plural: groundstationlifecycles
+    shortNames:
+    - gs
+    singular: groundstationlifecycle
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.hardware.vendor
+      name: Vendor
+      type: string
+    - jsonPath: .status.k8sVersion
+      name: K8s
+      type: string
+    - jsonPath: .status.lastHealthCheck
+      name: Last Check
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          GroundStationLifecycle manages the lifecycle of a satellite ground station,
+          including health monitoring, firmware OTA, and GitOps-based configuration.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GroundStationLifecycleSpec defines the desired state of a
+              ground station.
+            properties:
+              deployment:
+                description: deployment defines the station deployment and location.
+                properties:
+                  gitopsRepo:
+                    description: gitopsRepo is the Git repository URL for GitOps-managed
+                      configuration.
+                    type: string
+                  k8sDistro:
+                    default: k3s
+                    description: k8sDistro is the Kubernetes distribution running
+                      on the edge box.
+                    enum:
+                    - k3s
+                    - microk8s
+                    - rke2
+                    type: string
+                  location:
+                    description: location is the geographic position of the ground
+                      station.
+                    properties:
+                      alt:
+                        description: alt is the altitude in meters above sea level
+                          (string, e.g., "15").
+                        type: string
+                      lat:
+                        description: lat is the latitude in decimal degrees (string,
+                          e.g., "25.0330").
+                        pattern: ^-?[0-9]+\.?[0-9]*$
+                        type: string
+                      lon:
+                        description: lon is the longitude in decimal degrees (string,
+                          e.g., "121.5654").
+                        pattern: ^-?[0-9]+\.?[0-9]*$
+                        type: string
+                    required:
+                    - lat
+                    - lon
+                    type: object
+                    x-kubernetes-validations:
+                    - message: lat must be between -90 and 90
+                      rule: double(self.lat) >= -90.0 && double(self.lat) <= 90.0
+                    - message: lon must be between -180 and 180
+                      rule: double(self.lon) >= -180.0 && double(self.lon) <= 180.0
+                required:
+                - location
+                type: object
+              firmware:
+                description: firmware defines OTA update configuration.
+                properties:
+                  autoUpdate:
+                    default: false
+                    description: autoUpdate enables automatic firmware updates.
+                    type: boolean
+                  channel:
+                    default: stable
+                    description: channel is the firmware update channel (e.g., "stable",
+                      "beta").
+                    type: string
+                  maintenanceWindow:
+                    description: |-
+                      maintenanceWindow is the time window for updates.
+                      Format: "HH:MM-HH:MM UTC" (e.g., "02:00-04:00 UTC").
+                    pattern: ^([01][0-9]|2[0-3]):[0-5][0-9]-([01][0-9]|2[0-3]):[0-5][0-9]\s+UTC$
+                    type: string
+                type: object
+              hardware:
+                description: hardware describes the ground station equipment.
+                properties:
+                  antennaType:
+                    description: antennaType is the antenna type (e.g., "flat-panel",
+                      "parabolic").
+                    type: string
+                  bands:
+                    description: bands lists the supported frequency bands (e.g.,
+                      ["Ka", "Ku", "S"]).
+                    items:
+                      type: string
+                    type: array
+                  model:
+                    description: model is the hardware model identifier.
+                    minLength: 1
+                    type: string
+                  vendor:
+                    description: vendor is the hardware manufacturer (e.g., "ennoconn").
+                    minLength: 1
+                    type: string
+                required:
+                - model
+                - vendor
+                type: object
+              monitoring:
+                description: monitoring defines health check parameters.
+                properties:
+                  endpoint:
+                    description: endpoint is the monitoring endpoint of the ground
+                      station agent.
+                    type: string
+                  healthCheckInterval:
+                    default: 30s
+                    description: healthCheckInterval is how often to check ground
+                      station health.
+                    type: string
+                type: object
+            required:
+            - deployment
+            - hardware
+            type: object
+          status:
+            description: GroundStationLifecycleStatus defines the observed state of
+              a ground station.
+            properties:
+              conditions:
+                description: conditions represent the current state of the ground
+                  station.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              firmwareUpdateStarted:
+                description: |-
+                  firmwareUpdateStarted is when the current firmware update began.
+                  Used for timeout detection.
+                format: date-time
+                type: string
+              firmwareVersion:
+                description: firmwareVersion is the currently running firmware version.
+                type: string
+              k8sVersion:
+                description: k8sVersion is the Kubernetes version running on the edge
+                  node.
+                type: string
+              lastHealthCheck:
+                description: lastHealthCheck is the timestamp of the last successful
+                  health check.
+                format: date-time
+                type: string
+              phase:
+                description: phase is the current lifecycle phase.
+                enum:
+                - Provisioning
+                - Running
+                - Degraded
+                - Offline
+                - Updating
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/ntn-operators/0.4.0/manifests/ntn.operators.dev_ntncellconfigs.yaml
+++ b/operators/ntn-operators/0.4.0/manifests/ntn.operators.dev_ntncellconfigs.yaml
@@ -1,0 +1,600 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: ntncellconfigs.ntn.operators.dev
+spec:
+  group: ntn.operators.dev
+  names:
+    kind: NTNCellConfig
+    listKind: NTNCellConfigList
+    plural: ntncellconfigs
+    shortNames:
+    - ntncc
+    singular: ntncellconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provider.type
+      name: Provider
+      type: string
+    - jsonPath: .spec.ntn.cellSpecificKoffset
+      name: Koffset
+      type: integer
+    - jsonPath: .spec.ntn.payloadType
+      name: Payload
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NTNCellConfig manages NTN-specific radio parameters for a gNB cell,
+          delegating configuration to the specified NTN backend provider.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NTNCellConfigSpec defines the desired NTN cell configuration.
+            properties:
+              cellOverrides:
+                description: cellOverrides allows fine-tuning PUCCH, PDSCH, PRACH,
+                  and RRC parameters.
+                properties:
+                  pdschMaxHarqRetxs:
+                    default: 0
+                    description: pdschMaxHarqRetxs sets the max HARQ retransmissions
+                      (0 = disabled for NTN).
+                    type: integer
+                  prachMaxMsg3HarqRetx:
+                    default: 0
+                    description: prachMaxMsg3HarqRetx sets the max msg3 HARQ retransmissions.
+                    type: integer
+                  rrcGuardTimeMs:
+                    default: 12800
+                    description: rrcGuardTimeMs sets the RRC procedure guard time
+                      in ms.
+                    type: integer
+                  sibSchedule:
+                    description: |-
+                      sibSchedule tunes SIB19 broadcast scheduling. Any unset sub-field
+                      falls back to the defaults (siWindowLength=5, siPeriod=16,
+                      siWindowPosition=1). Tune when PDCCH capacity is tight or when
+                      SIB19 broadcast cadence needs to track short ntn-UlSyncValidityDur.
+                    properties:
+                      siPeriod:
+                        description: |-
+                          siPeriod is the SIB19 broadcast period in radio frames.
+                          Shorter periods keep UEs' NTN assistance fresh but cost air time.
+                        enum:
+                        - 8
+                        - 16
+                        - 32
+                        - 64
+                        - 128
+                        - 256
+                        - 512
+                        type: integer
+                      siWindowLength:
+                        description: |-
+                          siWindowLength is the SI window length in slots. OCUDU accepts
+                          the standard set; picking a larger value increases PDCCH pressure.
+                        enum:
+                        - 5
+                        - 10
+                        - 20
+                        - 40
+                        - 80
+                        - 160
+                        - 320
+                        - 640
+                        - 1280
+                        type: integer
+                      siWindowPosition:
+                        description: |-
+                          siWindowPosition is the slot offset within the SI period. Adjust
+                          to avoid collision with SIB1/SIB2 scheduling windows. Pointer so 0
+                          (the first slot) can be distinguished from unset.
+                        maximum: 79
+                        minimum: 0
+                        type: integer
+                    type: object
+                type: object
+              ephemerisRef:
+                description: |-
+                  ephemerisRef is the name of a SatelliteEphemeris CR in the same namespace.
+                  When set, the controller re-reconciles this NTNCellConfig whenever the
+                  referenced SatelliteEphemeris is updated and invokes runtime ephemeris push
+                  on the provider reconcile path. The static ephemeris in spec.ntn
+                  (ephemerisECEF or ephemerisOrbital) remains required as the source payload.
+                minLength: 1
+                type: string
+              ntn:
+                description: ntn contains NTN-specific radio parameters per 3GPP TS
+                  38.213 / OCUDU geo_ntn.yml.
+                properties:
+                  cellSpecificKoffset:
+                    default: 150
+                    description: cellSpecificKoffset sets the cell-specific k-offset
+                      for NTN (0-1023).
+                    maximum: 1023
+                    minimum: 0
+                    type: integer
+                  distanceThreshold:
+                    description: |-
+                      distanceThreshold sets the distance threshold for cell
+                      selection in metres.
+                    minimum: 0
+                    type: integer
+                  ephemerisECEF:
+                    description: |-
+                      ephemerisECEF defines the satellite position and velocity in ECEF coordinates.
+                      Mutually exclusive with ephemerisOrbital.
+                    properties:
+                      posX:
+                        description: posX is the X position of the satellite (-67108864
+                          to 67108863).
+                        maximum: 67108863
+                        minimum: -67108864
+                        type: integer
+                      posY:
+                        description: posY is the Y position of the satellite (-67108864
+                          to 67108863).
+                        maximum: 67108863
+                        minimum: -67108864
+                        type: integer
+                      posZ:
+                        description: posZ is the Z position of the satellite (-67108864
+                          to 67108863).
+                        maximum: 67108863
+                        minimum: -67108864
+                        type: integer
+                      velX:
+                        default: 0
+                        description: velX is the X velocity of the satellite (0 for
+                          GEO).
+                        type: integer
+                      velY:
+                        default: 0
+                        description: velY is the Y velocity of the satellite (0 for
+                          GEO).
+                        type: integer
+                      velZ:
+                        default: 0
+                        description: velZ is the Z velocity of the satellite (0 for
+                          GEO).
+                        type: integer
+                    required:
+                    - posX
+                    - posY
+                    - posZ
+                    type: object
+                  ephemerisOrbital:
+                    description: |-
+                      ephemerisOrbital defines the satellite orbit using Keplerian elements.
+                      Mutually exclusive with ephemerisECEF. Preferred for LEO satellites
+                      where source data is in OMM/TLE form (CelesTrak, SpaceTrack).
+                    properties:
+                      argOfPeriapsis:
+                        description: argOfPeriapsis is the argument of periapsis in
+                          1e-4 degrees (0-3600000).
+                        maximum: 3600000
+                        minimum: 0
+                        type: integer
+                      eccentricity:
+                        description: eccentricity is the orbital eccentricity scaled
+                          by 1e6 (0-999999 for e < 1.0).
+                        maximum: 999999
+                        minimum: 0
+                        type: integer
+                      inclination:
+                        description: inclination is the orbital inclination in 1e-4
+                          degrees (0-1800000 = 0°-180°).
+                        maximum: 1800000
+                        minimum: 0
+                        type: integer
+                      meanAnomaly:
+                        description: meanAnomaly is the mean anomaly in 1e-4 degrees
+                          (0-3600000).
+                        maximum: 3600000
+                        minimum: 0
+                        type: integer
+                      rightAscension:
+                        description: rightAscension is the right ascension of the
+                          ascending node in 1e-4 degrees (0-3600000).
+                        maximum: 3600000
+                        minimum: 0
+                        type: integer
+                      semiMajorAxis:
+                        description: semiMajorAxis is the semi-major axis in metres.
+                        minimum: 6370000
+                        type: integer
+                    required:
+                    - argOfPeriapsis
+                    - eccentricity
+                    - inclination
+                    - meanAnomaly
+                    - rightAscension
+                    - semiMajorAxis
+                    type: object
+                  epochTime:
+                    description: epochTime defines the SFN/subframe reference for
+                      NTN timing alignment.
+                    properties:
+                      sfn:
+                        description: sfn is the System Frame Number (0-1023).
+                        maximum: 1023
+                        minimum: 0
+                        type: integer
+                      subframeNumber:
+                        description: subframeNumber is the subframe within the SFN
+                          (0-9).
+                        maximum: 9
+                        minimum: 0
+                        type: integer
+                    required:
+                    - sfn
+                    - subframeNumber
+                    type: object
+                  feederLinkInfo:
+                    description: feederLinkInfo provides feeder link parameters for
+                      Doppler compensation.
+                    properties:
+                      dlFreqHz:
+                        description: dlFreqHz is the downlink frequency in Hz. Required
+                          when feederLinkInfo is set.
+                        format: int64
+                        minimum: 1
+                        type: integer
+                      enableDopplerCompensation:
+                        description: enableDopplerCompensation enables feeder link
+                          Doppler compensation.
+                        type: boolean
+                      ulFreqHz:
+                        description: ulFreqHz is the uplink frequency in Hz. Required
+                          when feederLinkInfo is set.
+                        format: int64
+                        minimum: 1
+                        type: integer
+                    required:
+                    - dlFreqHz
+                    - enableDopplerCompensation
+                    - ulFreqHz
+                    type: object
+                  movingRefLocation:
+                    description: |-
+                      movingRefLocation defines the Earth-moving reference location for LEO NTN cells.
+                      3GPP Release 18 SIB19 field. Used by UEs for timing/Doppler estimation.
+                    properties:
+                      latitude:
+                        description: latitude in 1e-4 degrees (-900000 to 900000 =
+                          -90° to 90°).
+                        maximum: 900000
+                        minimum: -900000
+                        type: integer
+                      longitude:
+                        description: longitude in 1e-4 degrees (-1800000 to 1800000
+                          = -180° to 180°).
+                        maximum: 1800000
+                        minimum: -1800000
+                        type: integer
+                    required:
+                    - latitude
+                    - longitude
+                    type: object
+                  neighborCells:
+                    description: |-
+                      neighborCells lists neighbor NTN cells for measurement/handover.
+                      OCUDU YAML renders as "ncells:" for compatibility.
+                    items:
+                      description: NTNNeighborCell describes a neighbor NTN cell.
+                      properties:
+                        frequency:
+                          description: frequency is the neighbor cell's ARFCN (NR-ARFCN,
+                            always >= 1).
+                          minimum: 1
+                          type: integer
+                        physicalCellID:
+                          description: physicalCellID of the neighbor (0-1007).
+                          maximum: 1007
+                          minimum: 0
+                          type: integer
+                      required:
+                      - physicalCellID
+                      type: object
+                    type: array
+                  ntnGatewayLocation:
+                    description: ntnGatewayLocation specifies the NTN gateway (ground
+                      station) coordinates.
+                    properties:
+                      altitude:
+                        description: altitude in metres above sea level. Required
+                          when ntnGatewayLocation is set.
+                        type: integer
+                      latitude:
+                        description: latitude in 1e-4 degrees (-900000 to 900000).
+                        maximum: 900000
+                        minimum: -900000
+                        type: integer
+                      longitude:
+                        description: longitude in 1e-4 degrees (-1800000 to 1800000).
+                        maximum: 1800000
+                        minimum: -1800000
+                        type: integer
+                    required:
+                    - altitude
+                    - latitude
+                    - longitude
+                    type: object
+                  ntnUlSyncValidityDur:
+                    description: ntnUlSyncValidityDur sets the UL synchronization
+                      validity duration in seconds.
+                    enum:
+                    - 5
+                    - 10
+                    - 15
+                    - 20
+                    - 25
+                    - 30
+                    - 35
+                    - 40
+                    - 45
+                    - 50
+                    - 55
+                    - 60
+                    - 120
+                    - 180
+                    - 240
+                    - 900
+                    type: integer
+                  payloadType:
+                    default: transparent
+                    description: payloadType specifies the satellite payload architecture.
+                    enum:
+                    - transparent
+                    - regenerative
+                    type: string
+                  polarization:
+                    description: |-
+                      polarization specifies the antenna polarization for downlink and uplink.
+                      Per 3GPP TS 38.331 SIB19, ntn-PolarizationDL-r17 and ntn-PolarizationUL-r17
+                      are independent IEs. OCUDU collapses them under a single `polarization:` map
+                      with `dl:` / `ul:` sub-keys, matching this CRD layout.
+                    properties:
+                      dl:
+                        description: dl is the downlink polarization broadcast in
+                          SIB19 ntn-PolarizationDL-r17.
+                        enum:
+                        - rhcp
+                        - lhcp
+                        - linear
+                        type: string
+                      ul:
+                        description: ul is the uplink polarization broadcast in SIB19
+                          ntn-PolarizationUL-r17.
+                        enum:
+                        - rhcp
+                        - lhcp
+                        - linear
+                        type: string
+                    type: object
+                    x-kubernetes-validations:
+                    - message: at least one of dl or ul must be set
+                      rule: has(self.dl) || has(self.ul)
+                  referenceLocation:
+                    description: referenceLocation defines the NTN cell reference
+                      location.
+                    properties:
+                      latitude:
+                        description: latitude in 1e-4 degrees (-900000 to 900000).
+                        maximum: 900000
+                        minimum: -900000
+                        type: integer
+                      longitude:
+                        description: longitude in 1e-4 degrees (-1800000 to 1800000).
+                        maximum: 1800000
+                        minimum: -1800000
+                        type: integer
+                    required:
+                    - latitude
+                    - longitude
+                    type: object
+                  satSwitchWithResync:
+                    description: |-
+                      satSwitchWithResync provides satellite switch handover hints to UEs during
+                      satellite-to-satellite transitions. 3GPP Release 18 SIB19 field.
+                    properties:
+                      t304:
+                        description: t304 is the handover timer value in milliseconds
+                          per 3GPP TS 38.331.
+                        enum:
+                        - 50
+                        - 100
+                        - 150
+                        - 200
+                        - 500
+                        - 1000
+                        - 2000
+                        - 10000
+                        type: integer
+                      targetPCI:
+                        description: targetPCI is the Physical Cell Identity of the
+                          target cell after switch (0-1007).
+                        maximum: 1007
+                        minimum: 0
+                        type: integer
+                    required:
+                    - t304
+                    - targetPCI
+                    type: object
+                  tService:
+                    description: tService sets the expected NTN service duration in
+                      seconds.
+                    minimum: 1
+                    type: integer
+                  taCommon:
+                    default: 0
+                    description: taCommon sets the common Timing Advance value (0-66485757).
+                    maximum: 66485757
+                    minimum: 0
+                    type: integer
+                  taInfo:
+                    description: |-
+                      taInfo provides extended Timing Advance parameters per 3GPP TS 38.213.
+                      When set, taInfo.taCommon takes precedence over the top-level taCommon field.
+                    properties:
+                      taCommon:
+                        description: |-
+                          taCommon is the common Timing Advance value (0-66485757). Required when
+                          taInfo is set — explicitly provide 0 for GEO satellites.
+                        maximum: 66485757
+                        minimum: 0
+                        type: integer
+                      taCommonDrift:
+                        description: taCommonDrift is the TA drift rate.
+                        type: integer
+                      taCommonDriftVariant:
+                        description: taCommonDriftVariant is the TA drift rate variant.
+                        type: integer
+                      taCommonOffset:
+                        description: taCommonOffset is an additional TA offset.
+                        type: integer
+                    required:
+                    - taCommon
+                    type: object
+                  taReport:
+                    description: taReport enables UE TA reporting.
+                    type: boolean
+                type: object
+                x-kubernetes-validations:
+                - message: exactly one of ephemerisECEF or ephemerisOrbital must be
+                    set
+                  rule: has(self.ephemerisECEF) || has(self.ephemerisOrbital)
+                - message: ephemerisECEF and ephemerisOrbital are mutually exclusive
+                  rule: '!(has(self.ephemerisECEF) && has(self.ephemerisOrbital))'
+                - message: ephemerisECEF position must not be all zeros
+                  rule: '!has(self.ephemerisECEF) || self.ephemerisECEF.posX != 0
+                    || self.ephemerisECEF.posY != 0 || self.ephemerisECEF.posZ !=
+                    0'
+              provider:
+                description: provider specifies which NTN backend to configure.
+                properties:
+                  endpoint:
+                    description: endpoint is the provider-specific endpoint (e.g.,
+                      O1 NETCONF address).
+                    type: string
+                  namespace:
+                    description: namespace where the provider resources (e.g., OCUDU
+                      gNB) are deployed.
+                    type: string
+                  type:
+                    description: type is the provider type. Currently only "ocudu"
+                      is supported.
+                    enum:
+                    - ocudu
+                    type: string
+                required:
+                - type
+                type: object
+            required:
+            - ntn
+            - provider
+            type: object
+          status:
+            description: NTNCellConfigStatus defines the observed state of NTNCellConfig.
+            properties:
+              appliedKoffset:
+                description: appliedKoffset is the last successfully applied k-offset
+                  value.
+                type: integer
+              conditions:
+                description: conditions represent the current state of the resource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              configMapRef:
+                description: configMapRef is the name of the ConfigMap containing
+                  the generated config.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/ntn-operators/0.4.0/manifests/ntn.operators.dev_ntnslices.yaml
+++ b/operators/ntn-operators/0.4.0/manifests/ntn.operators.dev_ntnslices.yaml
@@ -1,0 +1,334 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: ntnslices.ntn.operators.dev
+spec:
+  group: ntn.operators.dev
+  names:
+    kind: NTNSlice
+    listKind: NTNSliceList
+    plural: ntnslices
+    shortNames:
+    - nts
+    singular: ntnslice
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.tenant
+      name: Tenant
+      type: string
+    - jsonPath: .status.activePathType
+      name: Active Path
+      type: string
+    - jsonPath: .status.failoverCount
+      name: Failovers
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          NTNSlice manages terrestrial-satellite network slice failover,
+          QoS mapping, and session continuity for NTN enterprise services.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              NTNSliceSpec defines the desired state of an NTN network slice
+              with terrestrial-satellite failover policy.
+            properties:
+              billing:
+                description: billing defines CDR generation parameters.
+                properties:
+                  satelliteRate:
+                    description: satelliteRate is the charging model for satellite
+                      path.
+                    enum:
+                    - per-volume
+                    - per-time
+                    - per-minute
+                    - flat
+                    type: string
+                  terrestrialRate:
+                    description: terrestrialRate is the charging model for terrestrial
+                      path.
+                    enum:
+                    - per-volume
+                    - per-time
+                    - flat
+                    type: string
+                type: object
+              failoverPolicy:
+                description: failoverPolicy defines when and how to switch between
+                  paths.
+                properties:
+                  hysteresisMargin:
+                    description: |-
+                      hysteresisMargin is a dead-band applied to trigger thresholds
+                      during switchback evaluation, preventing flapping when metrics
+                      oscillate near the threshold. The value uses the same unit as
+                      the trigger (dB for RSRP, ms for latency, percent for packetLoss).
+                      Example: with trigger "rsrp < -120" and hysteresisMargin "10",
+                      failover fires at RSRP < -120, but switchback requires RSRP >= -110.
+                    pattern: ^[0-9]+\.?[0-9]*$
+                    type: string
+                  sessionContinuity:
+                    default: true
+                    description: sessionContinuity preserves active sessions during
+                      failover.
+                    type: boolean
+                  switchbackDelay:
+                    default: 60s
+                    description: |-
+                      switchbackDelay is how long to wait after terrestrial recovers
+                      before switching back (prevents flapping).
+                    format: duration
+                    type: string
+                  triggers:
+                    description: |-
+                      triggers defines conditions that initiate failover (OR logic).
+                      Format: "metric operator value" (e.g., "rsrp < -120").
+                      Validated at runtime by the failover engine (pkg/slice.ParseTrigger).
+                      Order is intentionally not significant; set merge semantics are desired.
+                    items:
+                      type: string
+                    maxItems: 10
+                    minItems: 1
+                    type: array
+                    x-kubernetes-list-type: set
+                required:
+                - triggers
+                type: object
+              qosMapping:
+                description: qosMapping defines QoS parameter mapping between paths.
+                properties:
+                  maxLatencyBudget:
+                    default: 150ms
+                    description: |-
+                      maxLatencyBudget is the maximum acceptable latency including
+                      satellite propagation delay.
+                    format: duration
+                    type: string
+                  satelliteQCI:
+                    default: best-effort
+                    description: satelliteQCI is the QoS class for the satellite path.
+                    enum:
+                    - conversational
+                    - streaming
+                    - interactive
+                    - background
+                    - best-effort
+                    type: string
+                  terrestrial5QI:
+                    description: terrestrial5QI is the 5G QoS Identifier for the terrestrial
+                      path.
+                    maximum: 255
+                    minimum: 1
+                    type: integer
+                type: object
+              satellitePath:
+                description: satellitePath defines the failover satellite connectivity.
+                properties:
+                  apn:
+                    description: apn is the Access Point Name.
+                    type: string
+                  ephemerisRef:
+                    description: |-
+                      ephemerisRef is the name of the SatelliteEphemeris resource
+                      used to determine satellite pass availability.
+                    minLength: 1
+                    type: string
+                  priority:
+                    description: priority is the path priority.
+                    enum:
+                    - primary
+                    - failover
+                    type: string
+                  provider:
+                    description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    minLength: 1
+                    type: string
+                required:
+                - ephemerisRef
+                - priority
+                - provider
+                type: object
+              security:
+                description: security defines handover security requirements.
+                properties:
+                  authOnHandover:
+                    default: re-authenticate
+                    description: authOnHandover defines authentication behavior during
+                      path switch.
+                    enum:
+                    - re-authenticate
+                    - continue
+                    type: string
+                  encryptionLevel:
+                    default: AES-256
+                    description: encryptionLevel specifies the encryption standard.
+                    enum:
+                    - AES-128
+                    - AES-256
+                    - SNOW3G
+                    - ZUC
+                    type: string
+                type: object
+              tenant:
+                description: tenant is the organization or entity that owns this slice.
+                minLength: 1
+                type: string
+              terrestrialPath:
+                description: terrestrialPath defines the primary terrestrial connectivity.
+                properties:
+                  apn:
+                    description: apn is the Access Point Name.
+                    type: string
+                  priority:
+                    description: priority is the path priority.
+                    enum:
+                    - primary
+                    - failover
+                    type: string
+                  provider:
+                    description: provider is the network operator name (e.g., "chunghwa-telecom").
+                    minLength: 1
+                    type: string
+                required:
+                - priority
+                - provider
+                type: object
+            required:
+            - failoverPolicy
+            - satellitePath
+            - tenant
+            - terrestrialPath
+            type: object
+            x-kubernetes-validations:
+            - message: terrestrialPath.priority must be 'primary'
+              rule: self.terrestrialPath.priority == 'primary'
+            - message: satellitePath.priority must be 'failover'
+              rule: self.satellitePath.priority == 'failover'
+          status:
+            description: NTNSliceStatus defines the observed state of NTNSlice.
+            properties:
+              activePathType:
+                description: activePathType is the currently active network path.
+                enum:
+                - terrestrial
+                - satellite
+                - unavailable
+                type: string
+              appliedEncryption:
+                description: appliedEncryption is the encryption level in effect for
+                  the current path.
+                type: string
+              appliedQoS:
+                description: appliedQoS summarizes the QoS mapping in effect for the
+                  current path.
+                type: string
+              billingMode:
+                description: billingMode is the billing model active for the current
+                  path.
+                type: string
+              conditions:
+                description: conditions represent the current state of the slice.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              failoverCount:
+                description: failoverCount is the total number of failover events
+                  since creation.
+                type: integer
+              lastFailover:
+                description: lastFailover is the timestamp of the last failover event.
+                format: date-time
+                type: string
+              sessionCount:
+                description: sessionCount is the number of active sessions on this
+                  slice.
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/ntn-operators/0.4.0/manifests/ntn.operators.dev_satelliteephemeris.yaml
+++ b/operators/ntn-operators/0.4.0/manifests/ntn.operators.dev_satelliteephemeris.yaml
@@ -1,0 +1,263 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: satelliteephemeris.ntn.operators.dev
+spec:
+  group: ntn.operators.dev
+  names:
+    kind: SatelliteEphemeris
+    listKind: SatelliteEphemerisList
+    plural: satelliteephemeris
+    shortNames:
+    - sateph
+    singular: satelliteephemeris
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.satelliteCount
+      name: Satellites
+      type: integer
+    - jsonPath: .status.lastUpdated
+      name: Last Updated
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          SatelliteEphemeris manages GP data fetching (OMM JSON from CelesTrak/SpaceTrack),
+          orbital propagation (SGP4 via akhenakh/sgp4), and pass prediction for a set of
+          satellites against ground stations.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SatelliteEphemerisSpec defines the desired state of SatelliteEphemeris.
+            properties:
+              passPrediction:
+                description: passPrediction configures automatic pass window computation.
+                properties:
+                  groundStations:
+                    description: |-
+                      groundStations is a list of GroundStationLifecycle resource names
+                      to compute pass windows against.
+                    items:
+                      type: string
+                    minItems: 1
+                    type: array
+                  horizon:
+                    default: 24h
+                    description: horizon is how far into the future to predict passes.
+                    type: string
+                  minElevation:
+                    default: "10"
+                    description: minElevation is the minimum elevation angle in degrees
+                      (string, e.g., "10").
+                    pattern: ^-?[0-9]+\.?[0-9]*$
+                    type: string
+                required:
+                - groundStations
+                type: object
+              satellites:
+                description: satellites filters which satellites to track from the
+                  source.
+                properties:
+                  constellation:
+                    description: constellation filters by constellation name (e.g.,
+                      "oneweb", "starlink").
+                    type: string
+                  noradIDs:
+                    description: noradIDs is an explicit list of NORAD catalog IDs
+                      to track.
+                    items:
+                      type: integer
+                    type: array
+                type: object
+              source:
+                description: source defines where to fetch GP (General Perturbations)
+                  data.
+                properties:
+                  credentials:
+                    description: |-
+                      credentials is a reference to a Secret containing auth credentials
+                      (required for SpaceTrack, optional for CelesTrak).
+                    properties:
+                      key:
+                        default: password
+                        description: key within the Secret data.
+                        type: string
+                      name:
+                        description: name of the Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  refreshInterval:
+                    default: 4h
+                    description: |-
+                      refreshInterval is how often to re-fetch GP data.
+                      CelesTrak updates every 2 hours; setting this below 2h wastes bandwidth.
+                    format: duration
+                    type: string
+                  type:
+                    description: 'type is the source type. Supported: "CelesTrak",
+                      "SpaceTrack".'
+                    enum:
+                    - CelesTrak
+                    - SpaceTrack
+                    type: string
+                  url:
+                    description: |-
+                      url is the endpoint to fetch GP data from.
+                      For CelesTrak: https://celestrak.org/NORAD/elements/gp.php?GROUP=oneweb&FORMAT=JSON
+                      For SpaceTrack: https://www.space-track.org/basicspacedata/query/class/gp/...
+                    minLength: 1
+                    pattern: ^https?://
+                    type: string
+                required:
+                - refreshInterval
+                - type
+                - url
+                type: object
+                x-kubernetes-validations:
+                - message: SpaceTrack source type requires credentials (spec.source.credentials)
+                  rule: self.type != 'SpaceTrack' || has(self.credentials)
+            required:
+            - source
+            type: object
+          status:
+            description: SatelliteEphemerisStatus defines the observed state of SatelliteEphemeris.
+            properties:
+              conditions:
+                description: conditions represent the current state of the resource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastUpdated:
+                description: lastUpdated is when the GP data was last successfully
+                  fetched.
+                format: date-time
+                type: string
+              nextPassWindows:
+                description: nextPassWindows contains upcoming contact opportunities.
+                items:
+                  description: PassWindow represents a predicted contact opportunity
+                    between a satellite and ground station.
+                  properties:
+                    aos:
+                      description: aos is the Acquisition of Signal time (satellite
+                        rises above minElevation).
+                      format: date-time
+                      type: string
+                    groundStation:
+                      description: groundStation is the name of the GroundStationLifecycle
+                        resource.
+                      type: string
+                    los:
+                      description: los is the Loss of Signal time (satellite drops
+                        below minElevation).
+                      format: date-time
+                      type: string
+                    maxElevation:
+                      description: maxElevation is the peak elevation angle during
+                        the pass in degrees (string, e.g., "72.5").
+                      pattern: ^-?[0-9]+\.?[0-9]*$
+                      type: string
+                    satellite:
+                      description: satellite is the name or NORAD ID of the satellite.
+                      type: string
+                  required:
+                  - aos
+                  - groundStation
+                  - los
+                  - maxElevation
+                  - satellite
+                  type: object
+                type: array
+              satelliteCount:
+                description: satelliteCount is the number of satellites currently
+                  tracked.
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/ntn-operators/0.4.0/metadata/annotations.yaml
+++ b/operators/ntn-operators/0.4.0/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: ntn-operators
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha

--- a/operators/ntn-operators/0.4.0/tests/scorecard/config.yaml
+++ b/operators/ntn-operators/0.4.0/tests/scorecard/config.yaml
@@ -1,0 +1,38 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+  - parallel: true
+    tests:
+      - entrypoint:
+          - scorecard-test
+          - basic-check-spec
+        image: quay.io/operator-framework/scorecard-test:v1.38.0
+        labels:
+          suite: basic
+          test: basic-check-spec-test
+      - entrypoint:
+          - scorecard-test
+          - olm-bundle-validation
+        image: quay.io/operator-framework/scorecard-test:v1.38.0
+        labels:
+          suite: olm
+          test: olm-bundle-validation-test
+      - entrypoint:
+          - scorecard-test
+          - olm-crds-have-validation
+        image: quay.io/operator-framework/scorecard-test:v1.38.0
+        labels:
+          suite: olm
+          test: olm-crds-have-validation-test
+      - entrypoint:
+          - scorecard-test
+          - olm-crds-have-resources
+        image: quay.io/operator-framework/scorecard-test:v1.38.0
+        labels:
+          suite: olm
+          test: olm-crds-have-resources-test
+      # olm-spec-descriptors and olm-status-descriptors omitted:
+      # CSV does not yet include specDescriptors/statusDescriptors.
+      # Add them when CRD descriptions are enriched.

--- a/operators/ntn-operators/ci.yaml
+++ b/operators/ntn-operators/ci.yaml
@@ -1,0 +1,11 @@
+---
+# Per-operator CI policy for community-operators (k8s-operatorhub).
+# Verified 2026-04 against infinispan, rabbitmq-messaging-topology-operator
+# convention. semver-mode is the canonical choice for new operators with
+# no prior CSV history in this catalog (see CSV spec.skipRange: <0.4.0
+# for the non-Helm-managed upgrade story).
+
+updateGraph: semver-mode
+
+reviewers:
+  - thc1006


### PR DESCRIPTION
Initial submission of `ntn-operators` 0.4.0 for inclusion on operatorhub.io.

## What is this operator?

`ntn-operators` provides Kubernetes-native management of Non-Terrestrial Network deployments. Four CRDs:

- `SatelliteEphemeris` fetches GP data (CelesTrak / SpaceTrack), runs SGP4 propagation, predicts pass windows.
- `GroundStationLifecycle` manages edge ground station nodes (health checks, firmware OTA with timeout, K8s integration).
- `NTNCellConfig` configures NTN gNB cells via OCUDU provider (generates ConfigMap with OwnerReference).
- `NTNSlice` manages terrestrial-satellite slice failover, QoS mapping, security policy, billing.

## Reproducibility / supply chain

- Source: https://github.com/thc1006/ntn-operators (Apache 2.0)
- Image: `ghcr.io/thc1006/ntn-operators@sha256:24fb644f64ffd80490207c19273124185454ff113c28a76e59a4855a0f106674` (multi-arch amd64+arm64), public registry, anonymous `cosign verify` succeeds.
- Signed via cosign keyless OIDC at release time. Rekor public log entries: `1391582441`, `1391582548`, `1391582642`, plus SBOM attestation `1391582962`. Verification:

  ```bash
  cosign verify ghcr.io/thc1006/ntn-operators:v0.4.0 \
    --certificate-identity-regexp 'https://github.com/thc1006/ntn-operators/.*' \
    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com'
  ```

- SBOM (SPDX JSON) attached as cosign attestation to the image index digest, also as a Release asset.

## Testing posture

- Default install mode: AllNamespaces.
- 11 CEL `XValidation` rules across the 4 CRDs (lat/lon range, path priority consistency, MetricsSource shape, ECEF non-zero, SpaceTrack credentials when used).
- Validating admission webhook for `NTNSlice.spec.failoverPolicy.triggers` syntax (off by default in chart; runtime fall-through still catches invalid triggers).
- ~340 Ginkgo `It` blocks, ~510 `func Test*`, core package coverage 82-100% on `make test`.

## License + maintainer

Apache License 2.0. Maintainer: thc1006.

## Checklist

- [x] Operator name unique (no prior `operators/ntn-operators/` in this catalog)
- [x] CSV bundle format
- [x] `description` annotation 124 chars (under 2026-04 observed max of 152)
- [x] `certified: "false"` declared (community submission)
- [x] `createdAt` matches actual GH Release publish time (`2026-04-26T18:12:49Z` UTC)
- [x] `bundle.Dockerfile` COPY paths use the in-`0.4.0/` layout
- [x] Image is publicly pullable (anonymous `docker pull` succeeds)
- [x] Cosign verify passes anonymously
- [x] DCO sign-off on commit
