### PR TITLE
operator [N] [CI] netheos (0.1.0)

### DIFF
--- a/operators/netheos/0.1.0/manifests/netheos.clusterserviceversion.yaml
+++ b/operators/netheos/0.1.0/manifests/netheos.clusterserviceversion.yaml
@@ -1,0 +1,243 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "netheos.netheos-io.io/v1alpha1",
+          "kind": "NetheosConfig",
+          "metadata": { "name": "cluster" },
+          "spec": {
+            "namespace": "netheos-system",
+            "aiAssistant": { "provider": "ollama", "model": "llama3.2:8b" },
+            "agent": { "sampleRate": 1, "dnsTracking": true, "firewallTracking": true },
+            "aggregator": { "replicas": 1, "retentionWindow": "1h" },
+            "webUI": { "serviceType": "ClusterIP" },
+            "audit": true
+          }
+        },
+        {
+          "apiVersion": "netheos.netheos-io.io/v1alpha1",
+          "kind": "NetheosAlert",
+          "metadata": { "name": "high-latency", "namespace": "netheos-system" },
+          "spec": {
+            "metric": "latency_p99_ms",
+            "operator": "Gt",
+            "threshold": 200,
+            "for": "2m",
+            "severity": "warning"
+          }
+        },
+        {
+          "apiVersion": "netheos.netheos-io.io/v1alpha1",
+          "kind": "NetheosInsight",
+          "metadata": { "name": "network-summary", "namespace": "netheos-system" },
+          "spec": {
+            "query": "Summarize the network health of the default namespace.",
+            "schedule": "*/30 * * * *"
+          }
+        },
+        {
+          "apiVersion": "netheos.netheos-io.io/v1alpha1",
+          "kind": "NetheosService",
+          "metadata": { "name": "frontend-tracking", "namespace": "netheos-system" },
+          "spec": {
+            "serviceRef": "frontend",
+            "displayName": "Frontend Service",
+            "latencyThresholdMs": 150,
+            "tags": ["critical"]
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Monitoring,Networking
+    containerImage: ghcr.io/rauldsl/netheos-operator:v0.1.0
+    createdAt: "2026-04-25T00:00:00Z"
+    description: >
+      Real-time Kubernetes observability operator with eBPF network capture,
+      interactive topology UI, and an embedded AI Assistant (Llama 3.2 / Ollama)
+      that runs entirely in-cluster — no data ever leaves your environment.
+    operators.operatorframework.io/builder: operator-sdk-v1.34.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/netheos-io/netheos
+    support: Netheos Community
+  name: netheos.v0.1.0
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Top-level CR — installs the full Netheos stack (aggregator, eBPF agent, WebUI, Ollama).
+      displayName: NetheosConfig
+      kind: NetheosConfig
+      name: netheosconfigs.netheos.netheos-io.io
+      version: v1alpha1
+    - description: Metric threshold alert rule with optional webhook notification.
+      displayName: NetheosAlert
+      kind: NetheosAlert
+      name: netheosalerts.netheos.netheos-io.io
+      version: v1alpha1
+    - description: Scheduled natural-language AI query whose results surface in the dashboard.
+      displayName: NetheosInsight
+      kind: NetheosInsight
+      name: netheosinsights.netheos.netheos-io.io
+      version: v1alpha1
+    - description: Service-level observability metadata and custom latency thresholds.
+      displayName: NetheosService
+      kind: NetheosService
+      name: netheosservices.netheos.netheos-io.io
+      version: v1alpha1
+  description: |
+    ## Netheos — Real-time Kubernetes Observability with AI
+
+    Netheos deploys eBPF probes on every node to capture real-time network flows
+    and exposes them through a **conversational topology dashboard** powered by
+    an embedded **Llama 3.2 8B model running inside your cluster**.
+
+    ### Features
+
+    - **eBPF-based capture** — Zero-instrumentation packet capture at kernel level
+    - **In-cluster AI Assistant** — Llama 3.2 8B via Ollama, or plug in OpenAI / Anthropic
+    - **Interactive topology** — Drag-and-drop namespace regions, live flow animations
+    - **Firewall monitoring** — iptables/nftables drops captured in real time
+    - **Alert rules** — `NetheosAlert` CRD for metric threshold rules
+    - **Scheduled insights** — `NetheosInsight` CRD for cron-based AI queries
+    - **Multi-cluster federation** — Federate multiple clusters into one dashboard
+    - **Prometheus integration** — ServiceMonitor included
+
+    ### Quick Start
+
+    Create a `NetheosConfig` to deploy the full stack:
+
+    ```yaml
+    apiVersion: netheos.netheos-io.io/v1alpha1
+    kind: NetheosConfig
+    metadata:
+      name: cluster
+    spec:
+      aiAssistant:
+        provider: ollama
+        model: "llama3.2:8b"
+    ```
+
+    ### Privacy
+
+    All data and AI inference run entirely inside your cluster.
+    No telemetry, no external calls unless you configure an external LLM provider.
+
+  displayName: Netheos
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj4KICA8cmVjdCB3aWR0aD0iMTAwIiBoZWlnaHQ9IjEwMCIgcng9IjEyIiBmaWxsPSIjMGYxNzJhIi8+CiAgPGNpcmNsZSBjeD0iNTAiIGN5PSI1MCIgcj0iOSIgZmlsbD0iIzIyZDNlZSIvPgogIDxjaXJjbGUgY3g9IjE4IiBjeT0iMTgiIHI9IjYiIGZpbGw9IiM3YzNhZWQiLz4KICA8Y2lyY2xlIGN4PSI4MiIgY3k9IjE4IiByPSI2IiBmaWxsPSIjN2MzYWVkIi8+CiAgPGNpcmNsZSBjeD0iMTgiIGN5PSI4MiIgcj0iNiIgZmlsbD0iIzFkNGVkOCIvPgogIDxjaXJjbGUgY3g9IjgyIiBjeT0iODIiIHI9IjYiIGZpbGw9IiMxZDRlZDgiLz4KICA8Y2lyY2xlIGN4PSI1MCIgY3k9IjE0IiByPSI1IiBmaWxsPSIjZjU5ZTBiIi8+CiAgPGxpbmUgeDE9IjUwIiB5MT0iNTAiIHgyPSIxOCIgeTI9IjE4IiBzdHJva2U9IiMyMmQzZWUiIHN0cm9rZS13aWR0aD0iMS41IiBvcGFjaXR5PSIwLjciLz4KICA8bGluZSB4MT0iNTAiIHkxPSI1MCIgeDI9IjgyIiB5Mj0iMTgiIHN0cm9rZT0iIzIyZDNlZSIgc3Ryb2tlLXdpZHRoPSIxLjUiIG9wYWNpdHk9IjAuNyIvPgogIDxsaW5lIHgxPSI1MCIgeTE9IjUwIiB4Mj0iMTgiIHkyPSI4MiIgc3Ryb2tlPSIjMjJkM2VlIiBzdHJva2Utd2lkdGg9IjEuNSIgb3BhY2l0eT0iMC43Ii8+CiAgPGxpbmUgeDE9IjUwIiB5MT0iNTAiIHgyPSI4MiIgeTI9IjgyIiBzdHJva2U9IiMyMmQzZWUiIHN0cm9rZS13aWR0aD0iMS41IiBvcGFjaXR5PSIwLjciLz4KICA8bGluZSB4MT0iNTAiIHkxPSI1MCIgeDI9IjUwIiB5Mj0iMTQiIHN0cm9rZT0iI2Y1OWUwYiIgc3Ryb2tlLXdpZHRoPSIxLjUiIG9wYWNpdHk9IjAuNyIvPgo8L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups: ["netheos.netheos-io.io"]
+          resources: ["netheosconfigs", "netheosalerts", "netheosinsights", "netheosservices"]
+          verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+        - apiGroups: ["netheos.netheos-io.io"]
+          resources: ["netheosconfigs/status", "netheosalerts/status", "netheosinsights/status", "netheosservices/status"]
+          verbs: ["get", "update", "patch"]
+        - apiGroups: ["netheos.netheos-io.io"]
+          resources: ["netheosconfigs/finalizers", "netheosalerts/finalizers", "netheosinsights/finalizers", "netheosservices/finalizers"]
+          verbs: ["update"]
+        - apiGroups: ["apps"]
+          resources: ["deployments", "daemonsets"]
+          verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+        - apiGroups: [""]
+          resources: ["services", "serviceaccounts", "namespaces", "configmaps", "secrets", "events"]
+          verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+          verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+        - apiGroups: ["networking.k8s.io"]
+          resources: ["ingresses"]
+          verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+        - apiGroups: ["coordination.k8s.io"]
+          resources: ["leases"]
+          verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+        serviceAccountName: netheos-operator
+      deployments:
+      - label:
+          app: netheos-operator
+          app.kubernetes.io/name: netheos-operator
+        name: netheos-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: netheos-operator
+          template:
+            metadata:
+              labels:
+                app: netheos-operator
+                app.kubernetes.io/name: netheos-operator
+            spec:
+              serviceAccountName: netheos-operator
+              securityContext:
+                runAsNonRoot: true
+              containers:
+              - name: operator
+                image: ghcr.io/rauldsl/netheos-operator:v0.1.0
+                imagePullPolicy: IfNotPresent
+                args:
+                - --leader-elect
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 128Mi
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+              terminationGracePeriodSeconds: 10
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - kubernetes
+  - observability
+  - networking
+  - ebpf
+  - topology
+  - ai
+  - llm
+  - monitoring
+  links:
+  - name: Documentation
+    url: https://github.com/netheos-io/netheos
+  - name: Source Code
+    url: https://github.com/netheos-io/netheos
+  maintainers:
+  - email: team@netheos.io
+    name: Netheos Community
+  maturity: alpha
+  minKubeVersion: 1.27.0
+  provider:
+    name: Netheos
+    url: https://github.com/netheos-io/netheos
+  version: 0.1.0

--- a/operators/netheos/0.1.0/manifests/netheos.netheos-io.io_netheosalerts.yaml
+++ b/operators/netheos/0.1.0/manifests/netheos.netheos-io.io_netheosalerts.yaml
@@ -1,0 +1,136 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: netheosalerts.netheos.netheos-io.io
+spec:
+  group: netheos.netheos-io.io
+  names:
+    kind: NetheosAlert
+    listKind: NetheosAlertList
+    plural: netheosalerts
+    shortNames:
+    - na
+    singular: netheosalert
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.metric
+      name: Metric
+      type: string
+    - jsonPath: .spec.severity
+      name: Severity
+      type: string
+    - jsonPath: .status.active
+      name: Active
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NetheosAlert defines a metric threshold rule.
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              for:
+                default: 1m
+                type: string
+              metric:
+                type: string
+              namespaces:
+                items:
+                  type: string
+                type: array
+              operator:
+                enum:
+                - Gt
+                - Lt
+                - Gte
+                - Lte
+                - Eq
+                type: string
+              selector:
+                additionalProperties:
+                  type: string
+                type: object
+              severity:
+                default: warning
+                enum:
+                - info
+                - warning
+                - critical
+                type: string
+              threshold:
+                type: number
+              webhook:
+                properties:
+                  secretRef:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  url:
+                    type: string
+                required:
+                - url
+                type: object
+            required:
+            - metric
+            - operator
+            - threshold
+            type: object
+          status:
+            properties:
+              active:
+                type: boolean
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      type: integer
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastFiredAt:
+                format: date-time
+                type: string
+              message:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/netheos/0.1.0/manifests/netheos.netheos-io.io_netheosconfigs.yaml
+++ b/operators/netheos/0.1.0/manifests/netheos.netheos-io.io_netheosconfigs.yaml
@@ -1,0 +1,269 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: netheosconfigs.netheos.netheos-io.io
+spec:
+  group: netheos.netheos-io.io
+  names:
+    kind: NetheosConfig
+    listKind: NetheosConfigList
+    plural: netheosconfigs
+    shortNames:
+    - nc
+    singular: netheosconfig
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.agentDaemonSetReady
+      name: Agent
+      type: boolean
+    - jsonPath: .status.aggregatorReady
+      name: Aggregator
+      type: boolean
+    - jsonPath: .status.webUIReady
+      name: WebUI
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NetheosConfig is the top-level CR that installs the full Netheos stack.
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              aiAssistant:
+                properties:
+                  apiKeySecret:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  endpoint:
+                    type: string
+                  gpuEnabled:
+                    default: false
+                    type: boolean
+                  model:
+                    default: llama3.2:8b
+                    type: string
+                  provider:
+                    default: ollama
+                    enum:
+                    - ollama
+                    - openai
+                    - anthropic
+                    - azure
+                    - vllm
+                    - custom
+                    - none
+                    type: string
+                  resources:
+                    properties:
+                      cpuLimit:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                      cpuRequest:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                      memoryLimit:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                      memoryRequest:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  systemPrompt:
+                    type: string
+                type: object
+              agent:
+                properties:
+                  dnsTracking:
+                    default: true
+                    type: boolean
+                  firewallTracking:
+                    default: true
+                    type: boolean
+                  image:
+                    type: string
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  sampleRate:
+                    default: 1
+                    format: int32
+                    type: integer
+                  tolerations:
+                    items:
+                      description: Toleration for node taints.
+                      properties:
+                        effect:
+                          type: string
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        tolerationSeconds:
+                          format: int64
+                          type: integer
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              aggregator:
+                properties:
+                  image:
+                    type: string
+                  prometheusExport:
+                    default: true
+                    type: boolean
+                  replicas:
+                    default: 1
+                    format: int32
+                    type: integer
+                  retentionWindow:
+                    default: 1h
+                    type: string
+                type: object
+              audit:
+                default: true
+                type: boolean
+              multiCluster:
+                items:
+                  properties:
+                    apiServer:
+                      type: string
+                    kubeconfigSecret:
+                      properties:
+                        key:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                    name:
+                      type: string
+                  required:
+                  - apiServer
+                  - kubeconfigSecret
+                  - name
+                  type: object
+                type: array
+              namespace:
+                default: netheos-system
+                type: string
+              rbac:
+                properties:
+                  adminGroups:
+                    items:
+                      type: string
+                    type: array
+                  tenantLabelKey:
+                    default: netheos.netheos-io.io/tenant
+                    type: string
+                type: object
+              webUI:
+                properties:
+                  image:
+                    type: string
+                  ingress:
+                    properties:
+                      enabled:
+                        type: boolean
+                      host:
+                        type: string
+                      ingressClassName:
+                        type: string
+                      tlsSecretName:
+                        type: string
+                    type: object
+                  nodePort:
+                    format: int32
+                    type: integer
+                  serviceType:
+                    default: ClusterIP
+                    enum:
+                    - ClusterIP
+                    - NodePort
+                    - LoadBalancer
+                    type: string
+                type: object
+            type: object
+          status:
+            properties:
+              agentDaemonSetReady:
+                type: boolean
+              aggregatorReady:
+                type: boolean
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      type: integer
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+              ollamaReady:
+                type: boolean
+              phase:
+                type: string
+              webUIReady:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/netheos/0.1.0/manifests/netheos.netheos-io.io_netheosinsights.yaml
+++ b/operators/netheos/0.1.0/manifests/netheos.netheos-io.io_netheosinsights.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: netheosinsights.netheos.netheos-io.io
+spec:
+  group: netheos.netheos-io.io
+  names:
+    kind: NetheosInsight
+    listKind: NetheosInsightList
+    plural: netheosinsights
+    shortNames:
+    - ni
+    singular: netheosinsight
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.schedule
+      name: Schedule
+      type: string
+    - jsonPath: .spec.suspend
+      name: Suspended
+      type: boolean
+    - jsonPath: .status.lastScheduleTime
+      name: LastRun
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NetheosInsight schedules recurring AI queries.
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              namespaces:
+                items:
+                  type: string
+                type: array
+              query:
+                type: string
+              schedule:
+                type: string
+              suspend:
+                default: false
+                type: boolean
+              ttl:
+                default: 168h
+                type: string
+            required:
+            - query
+            - schedule
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      type: integer
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastResult:
+                type: string
+              lastScheduleTime:
+                format: date-time
+                type: string
+              nextScheduleTime:
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/netheos/0.1.0/manifests/netheos.netheos-io.io_netheosservices.yaml
+++ b/operators/netheos/0.1.0/manifests/netheos.netheos-io.io_netheosservices.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: netheosservices.netheos.netheos-io.io
+spec:
+  group: netheos.netheos-io.io
+  names:
+    kind: NetheosService
+    listKind: NetheosServiceList
+    plural: netheosservices
+    shortNames:
+    - ns
+    singular: netheosservice
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.serviceRef
+      name: ServiceRef
+      type: string
+    - jsonPath: .status.health
+      name: Health
+      type: string
+    - jsonPath: .status.latencyP99Ms
+      name: LatencyP99
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: NetheosService annotates a Kubernetes Service with observability metadata.
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              displayName:
+                type: string
+              latencyThresholdMs:
+                format: int32
+                type: integer
+              namespace:
+                type: string
+              retransmitThresholdPct:
+                type: number
+              serviceRef:
+                type: string
+              tags:
+                items:
+                  type: string
+                type: array
+            required:
+            - serviceRef
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      type: integer
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              health:
+                type: string
+              lastUpdated:
+                format: date-time
+                type: string
+              latencyP99Ms:
+                type: number
+              retransmitPct:
+                type: number
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/netheos/0.1.0/metadata/annotations.yaml
+++ b/operators/netheos/0.1.0/metadata/annotations.yaml
@@ -1,0 +1,10 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: netheos
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4

--- a/operators/netheos/0.1.0/tests/scorecard/config.yaml
+++ b/operators/netheos/0.1.0/tests/scorecard/config.yaml
@@ -1,0 +1,35 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.34.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.34.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.34.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.34.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test

--- a/operators/netheos/ci.yaml
+++ b/operators/netheos/ci.yaml
@@ -3,6 +3,3 @@ addReviewers: true
 
 reviewers:
   - rauldsl
-
-updateGraph:
-  mode: semver

--- a/operators/netheos/ci.yaml
+++ b/operators/netheos/ci.yaml
@@ -1,0 +1,10 @@
+# community-operators ci.yaml
+# https://github.com/k8s-operatorhub/community-operators/blob/main/docs/contributing-via-ci.md
+---
+addReviewers: true
+
+reviewers:
+  - netheos-io
+
+updateGraph:
+  mode: semver

--- a/operators/netheos/ci.yaml
+++ b/operators/netheos/ci.yaml
@@ -1,10 +1,8 @@
-# community-operators ci.yaml
-# https://github.com/k8s-operatorhub/community-operators/blob/main/docs/contributing-via-ci.md
 ---
 addReviewers: true
 
 reviewers:
-  - netheos-io
+  - rauldsl
 
 updateGraph:
   mode: semver

--- a/operators/netheos/ci.yaml
+++ b/operators/netheos/ci.yaml
@@ -3,3 +3,5 @@ addReviewers: true
 
 reviewers:
   - rauldsl
+
+updateGraph: semver


### PR DESCRIPTION
## New operator submission: Netheos v0.1.0

**Description:**
Real-time Kubernetes observability operator with eBPF network capture, interactive topology UI, and an embedded AI Assistant (Llama 3.2 via Ollama) running entirely in-cluster.

**Features:**
- eBPF-based network flow capture (zero instrumentation)
- Interactive topology dashboard (namespace/pod/service graph)
- In-cluster AI Assistant (Ollama / OpenAI / Anthropic)
- Alert rules, scheduled AI insights, multi-cluster federation
- Prometheus ServiceMonitor included

**Images:** Published at `ghcr.io/rauldsl/netheos-*:v0.1.0` (public)

**Verification:**
- [ ] `operator-sdk bundle validate ./bundle` passes
- [ ] All 4 images publicly accessible on ghcr.io
- [ ] Tested on kind v1.29

/cc @operator-framework/community-operators-maintainers