### PR TITLE
operator keiailab-postgres-operator (0.3.0-alpha.16)

### DIFF
--- a/operators/keiailab-postgres-operator/0.3.0-alpha.16/manifests/keiailab-postgres-operator.clusterserviceversion.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.16/manifests/keiailab-postgres-operator.clusterserviceversion.yaml
@@ -1,0 +1,353 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "postgres.keiailab.io/v1alpha1",
+          "kind": "PostgresCluster",
+          "metadata": {
+            "name": "quickstart",
+            "namespace": "default"
+          },
+          "spec": {
+            "postgresVersion": "18",
+            "shardingMode": "none",
+            "shards": {
+              "initialCount": 1,
+              "replicas": 0,
+              "storage": {
+                "size": "10Gi"
+              }
+            }
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Database, Storage
+    containerImage: ghcr.io/keiailab/postgres-operator:0.3.0-alpha.15
+    createdAt: "2026-05-10T01:25:23Z"
+    description: |
+      Apache-2.0 PostgreSQL Kubernetes Operator — vanilla PG18+, license-clean,
+      PGO-class 운영 품질을 목표로 하되 외부 operator/backend 를 fork, embed,
+      wrapper 로 사용하지 않는 독립 신규 구현. PG17/PG18 양 메이저 지원.
+    operators.operatorframework.io/builder: operator-sdk-v1.42.2
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/keiailab/postgres-operator
+    support: https://github.com/keiailab/postgres-operator/issues
+  name: keiailab-postgres-operator.v0.3.0-alpha.16
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: BackupJob 은 PostgresCluster 의 pgBackRest 기반 backup/restore Job
+        추상이다.
+      displayName: Backup Job
+      kind: BackupJob
+      name: backupjobs.postgres.keiailab.io
+      version: v1alpha1
+    - description: PostgresCluster 는 K8s-native 자체 분산 PostgreSQL 클러스터의 선언적 표현이다 (ADR
+        0001).
+      displayName: Postgres Cluster
+      kind: PostgresCluster
+      name: postgresclusters.postgres.keiailab.io
+      version: v1alpha1
+  description: |
+    # Postgres Operator
+
+    Apache-2.0 licensed Kubernetes operator for PostgreSQL — manages the
+    `PostgresCluster` CRD with shard-aware topology (primary + standby
+    streaming replication), automated failover (RTO < 30s verified),
+    pgBackRest integration, and PG17/PG18 compatibility.
+
+    ## Features
+
+    - **PostgresCluster CRD** — declarative shard-aware topology (primary +
+      standby streaming replication, hot-standby read scaling).
+    - **Automated failover** — primary Pod delete smoke verified RTO < 30s.
+    - **PG17 + PG18 multi-major support** — runtime image build/load via
+      `hack/smoke.sh`, kind cluster smoke includes psql round-trip +
+      streaming replication assertion.
+    - **pgBackRest integration** — BackupJob CRD reconciles pgBackRest backup
+      Jobs (full / differential / incremental).
+    - **Supply chain** — Cosign signed container images + SBOM (SPDX-2.3).
+    - **Security baseline** — Pod Security Standards Restricted, RBAC
+      least-privilege, NetworkPolicy isolation, non-root runAsUser.
+
+    ## Documentation
+
+    - GitHub: https://github.com/keiailab/postgres-operator
+    - Helm Chart: https://artifacthub.io/packages/helm/postgresql-operator/postgresql-operator
+    - Discussions: https://github.com/keiailab/postgres-operator/discussions
+
+    ## Prerequisites
+
+    - Kubernetes 1.26+
+    - Storage class for PVCs (recommended: ceph-rbd or comparable RWO)
+    - (Optional) cert-manager for automatic TLS certificate management
+    - (Optional) Prometheus Operator for `ServiceMonitor` scraping
+  displayName: Postgres Operator (Keiailab)
+  icon:
+  - base64data: PCFET0NUWVBFIGh0bWw+CjxodG1sIGNsYXNzPSJjbGllbnQtbm9qcyIgbGFuZz0iZW4iIGRpcj0ibHRyIj4KPGhlYWQ+CjxtZXRhIGNoYXJzZXQ9IlVURi04Ii8+Cjx0aXRsZT5Qb3N0Z3JlU1FMIHdpa2k8L3RpdGxlPgo8c2NyaXB0PmRvY3VtZW50LmRvY3VtZW50RWxlbWVudC5jbGFzc05hbWU9ImNsaWVudC1qcyI7UkxDT05GPXsid2dCcmVha0ZyYW1lcyI6ZmFsc2UsIndnU2VwYXJhdG9yVHJhbnNmb3JtVGFibGUiOlsiIiwiIl0sIndnRGlnaXRUcmFuc2Zvcm1UYWJsZSI6WyIiLCIiXSwid2dEZWZhdWx0RGF0ZUZvcm1hdCI6ImRteSIsIndnTW9udGhOYW1lcyI6WyIiLCJKYW51YXJ5IiwiRmVicnVhcnkiLCJNYXJjaCIsIkFwcmlsIiwiTWF5IiwiSnVuZSIsIkp1bHkiLCJBdWd1c3QiLCJTZXB0ZW1iZXIiLCJPY3RvYmVyIiwiTm92ZW1iZXIiLCJEZWNlbWJlciJdLCJ3Z1JlcXVlc3RJZCI6ImI0M2JmNWZkMjk0ODEzZTAwZjVkNjZlOSIsIndnQ1NQTm9uY2UiOmZhbHNlLCJ3Z0Nhbm9uaWNhbE5hbWVzcGFjZSI6IiIsIndnQ2Fub25pY2FsU3BlY2lhbFBhZ2VOYW1lIjpmYWxzZSwid2dOYW1lc3BhY2VOdW1iZXIiOjAsIndnUGFnZU5hbWUiOiJNYWluX1BhZ2UiLCJ3Z1RpdGxlIjoiTWFpbiBQYWdlIiwid2dDdXJSZXZpc2lvbklkIjo0MjA0OCwid2dSZXZpc2lvbklkIjo0MjA0OCwid2dBcnRpY2xlSWQiOjEsIndnSXNBcnRpY2xlIjp0cnVlLCJ3Z0lzUmVkaXJlY3QiOmZhbHNlLCJ3Z0FjdGlvbiI6InZpZXciLCJ3Z1VzZXJOYW1lIjpudWxsLCJ3Z1VzZXJHcm91cHMiOlsiKiJdLCJ3Z0NhdGVnb3JpZXMiOltdLCJ3Z1BhZ2VDb250ZW50TGFuZ3VhZ2UiOiJlbiIsIndnUGFnZUNvbnRlbnRNb2RlbCI6Indpa2l0ZXh0Iiwid2dSZWxldmFudFBhZ2VOYW1lIjoiTWFpbl9QYWdlIiwid2dSZWxldmFudEFydGljbGVJZCI6MSwid2dJc1Byb2JhYmx5RWRpdGFibGUiOmZhbHNlLCJ3Z1JlbGV2YW50UGFnZUlzUHJvYmFibHlFZGl0YWJsZSI6ZmFsc2UsIndnUmVzdHJpY3Rpb25FZGl0IjpbInN5c29wIl0sIndnUmVzdHJpY3Rpb25Nb3ZlIjpbInN5c29wIl0sIndnSXNNYWluUGFnZSI6dHJ1ZX07UkxTVEFURT17InNpdGUuc3R5bGVzIjoicmVhZHkiLCJ1c2VyLnN0eWxlcyI6InJlYWR5IiwidXNlciI6InJlYWR5IiwidXNlci5vcHRpb25zIjoibG9hZGluZyIsInNraW5zLm1vbm9ib29rLnN0eWxlcyI6InJlYWR5In07ClJMUEFHRU1PRFVMRVM9WyJzaXRlIiwibWVkaWF3aWtpLnBhZ2UucmVhZHkiLCJza2lucy5tb25vYm9vay5zY3JpcHRzIl07PC9zY3JpcHQ+CjxzY3JpcHQ+KFJMUT13aW5kb3cuUkxRfHxbXSkucHVzaChmdW5jdGlvbigpe213LmxvYWRlci5pbXBsZW1lbnQoInVzZXIub3B0aW9uc0AxMnM1aSIsZnVuY3Rpb24oJCxqUXVlcnkscmVxdWlyZSxtb2R1bGUpe213LnVzZXIudG9rZW5zLnNldCh7InBhdHJvbFRva2VuIjoiK1xcIiwid2F0Y2hUb2tlbiI6IitcXCIsImNzcmZUb2tlbiI6IitcXCJ9KTt9KTt9KTs8L3NjcmlwdD4KPGxpbmsgcmVsPSJzdHlsZXNoZWV0IiBocmVmPSIvbG9hZC5waHA/bGFuZz1lbiZhbXA7bW9kdWxlcz1za2lucy5tb25vYm9vay5zdHlsZXMmYW1wO29ubHk9c3R5bGVzJmFtcDtza2luPW1vbm9ib29rIi8+CjxzY3JpcHQgYXN5bmM9IiIgc3JjPSIvbG9hZC5waHA/bGFuZz1lbiZhbXA7bW9kdWxlcz1zdGFydHVwJmFtcDtvbmx5PXNjcmlwdHMmYW1wO3Jhdz0xJmFtcDtza2luPW1vbm9ib29rIj48L3NjcmlwdD4KPG1ldGEgbmFtZT0iUmVzb3VyY2VMb2FkZXJEeW5hbWljU3R5bGVzIiBjb250ZW50PSIiLz4KPGxpbmsgcmVsPSJzdHlsZXNoZWV0IiBocmVmPSIvbG9hZC5waHA/bGFuZz1lbiZhbXA7bW9kdWxlcz1zaXRlLnN0eWxlcyZhbXA7b25seT1zdHlsZXMmYW1wO3NraW49bW9ub2Jvb2siLz4KPG1ldGEgbmFtZT0iZ2VuZXJhdG9yIiBjb250ZW50PSJNZWRpYVdpa2kgMS4zOS4xNyIvPgo8bWV0YSBuYW1lPSJmb3JtYXQtZGV0ZWN0aW9uIiBjb250ZW50PSJ0ZWxlcGhvbmU9bm8iLz4KPG1ldGEgbmFtZT0idmlld3BvcnQiIGNvbnRlbnQ9IndpZHRoPWRldmljZS13aWR0aCwgaW5pdGlhbC1zY2FsZT0xLjAsIHVzZXItc2NhbGFibGU9eWVzLCBtaW5pbXVtLXNjYWxlPTAuMjUsIG1heGltdW0tc2NhbGU9NS4wIi8+CjxsaW5rIHJlbD0iaWNvbiIgaHJlZj0iL2Zhdmljb24uaWNvIi8+CjxsaW5rIHJlbD0ic2VhcmNoIiB0eXBlPSJhcHBsaWNhdGlvbi9vcGVuc2VhcmNoZGVzY3JpcHRpb24reG1sIiBocmVmPSIvb3BlbnNlYXJjaF9kZXNjLnBocCIgdGl0bGU9IlBvc3RncmVTUUwgd2lraSAoZW4pIi8+CjxsaW5rIHJlbD0iRWRpdFVSSSIgdHlwZT0iYXBwbGljYXRpb24vcnNkK3htbCIgaHJlZj0iaHR0cHM6Ly93aWtpLnBvc3RncmVzcWwub3JnL2FwaS5waHA/YWN0aW9uPXJzZCIvPgo8bGluayByZWw9ImFsdGVybmF0ZSIgdHlwZT0iYXBwbGljYXRpb24vYXRvbSt4bWwiIHRpdGxlPSJQb3N0Z3JlU1FMIHdpa2kgQXRvbSBmZWVkIiBocmVmPSIvaW5kZXgucGhwP3RpdGxlPVNwZWNpYWw6UmVjZW50Q2hhbmdlcyZhbXA7ZmVlZD1hdG9tIi8+CjwvaGVhZD4KPGJvZHkgY2xhc3M9Im1lZGlhd2lraSBsdHIgc2l0ZWRpci1sdHIgbXctaGlkZS1lbXB0eS1lbHQgbnMtMCBucy1zdWJqZWN0IHBhZ2UtTWFpbl9QYWdlIHJvb3RwYWdlLU1haW5fUGFnZSBza2luLW1vbm9ib29rIGFjdGlvbi12aWV3IHNraW4tLXJlc3BvbnNpdmUiPjxkaXYgaWQ9Imdsb2JhbFdyYXBwZXIiPgoJPGRpdiBpZD0iY29sdW1uLWNvbnRlbnQiPgoJCTxkaXYgaWQ9ImNvbnRlbnQiIGNsYXNzPSJtdy1ib2R5IiByb2xlPSJtYWluIj4KCQkJPGEgaWQ9InRvcCI+PC9hPgoJCQk8ZGl2IGlkPSJzaXRlTm90aWNlIj48ZGl2IGlkPSJsb2NhbE5vdGljZSI+PGRpdiBjbGFzcz0ic2l0ZW5vdGljZSIgbGFuZz0iZW4iIGRpcj0ibHRyIj48cD48Yj48YSByZWw9Im5vZm9sbG93IiBjbGFzcz0iZXh0ZXJuYWwgdGV4dCIgaHJlZj0iaHR0cHM6Ly93aWtpLnBvc3RncmVzcWwub3JnL3dpa2kvV2lraUVkaXRpbmciPldhbnQgdG8gZWRpdCwgYnV0IGRvbid0IHNlZSBhbiBlZGl0IGJ1dHRvbiB3aGVuIGxvZ2dlZCBpbj8gIENsaWNrIGhlcmUuPC9hPjwvYj4KPC9wPjwvZGl2PjwvZGl2PjwvZGl2PgoJCQk8ZGl2IGNsYXNzPSJtdy1pbmRpY2F0b3JzIj4KCQkJPC9kaXY+CgkJCTxoMSBpZD0iZmlyc3RIZWFkaW5nIiBjbGFzcz0iZmlyc3RIZWFkaW5nIG13LWZpcnN0LWhlYWRpbmciPjxzcGFuIGNsYXNzPSJtdy1wYWdlLXRpdGxlLW1haW4iPk1haW4gUGFnZTwvc3Bhbj48L2gxPgoJCQk8ZGl2IGlkPSJib2R5Q29udGVudCIgY2xhc3M9Im1vbm9ib29rLWJvZHkiPgoJCQkJPGRpdiBpZD0ic2l0ZVN1YiI+RnJvbSBQb3N0Z3JlU1FMIHdpa2k8L2Rpdj4KCQkJCTxkaXYgaWQ9ImNvbnRlbnRTdWIiID48L2Rpdj4KCQkJCQoJCQkJPGRpdiBpZD0ianVtcC10by1uYXYiPjwvZGl2PjxhIGhyZWY9IiNjb2x1bW4tb25lIiBjbGFzcz0ibXctanVtcC1saW5rIj5KdW1wIHRvIG5hdmlnYXRpb248L2E+PGEgaHJlZj0iI3NlYXJjaElucHV0IiBjbGFzcz0ibXctanVtcC1saW5rIj5KdW1wIHRvIHNlYXJjaDwvYT4KCQkJCTwhLS0gc3RhcnQgY29udGVudCAtLT4KCQkJCTxkaXYgaWQ9Im13LWNvbnRlbnQtdGV4dCIgY2xhc3M9Im13LWJvZHktY29udGVudCBtdy1jb250ZW50LWx0ciIgbGFuZz0iZW4iIGRpcj0ibHRyIj48ZGl2IGNsYXNzPSJtdy1wYXJzZXItb3V0cHV0Ij48cD48YnIgLz4KPC9wPgo8aDE+PHNwYW4gaWQ9IldlbGNvbWVfdG9fdGhlX1Bvc3RncmVTUUxfV2lraS4yMSI+PC9zcGFuPjxzcGFuIGNsYXNzPSJtdy1oZWFkbGluZSIgaWQ9IldlbGNvbWVfdG9fdGhlX1Bvc3RncmVTUUxfV2lraSEiPldlbGNvbWUgdG8gdGhlIFBvc3RncmVTUUwgV2lraSE8L3NwYW4+PC9oMT4KPHA+VGhpcyB3aWtpIGNvbnRhaW5zIHVzZXIgZG9jdW1lbnRhdGlvbiwgaG93LXRvcywgYW5kIHRpcHMgJ24nIHRyaWNrcyByZWxhdGVkIHRvIFBvc3RncmVTUUwuIEl0IGFsc28gc2VydmVzIGFzIGEgY29sbGFib3JhdGlvbiBhcmVhIGZvciBQb3N0Z3JlU1FMIGNvbnRyaWJ1dG9ycy4KPC9wPgo8aDI+PHNwYW4gY2xhc3M9Im13LWhlYWRsaW5lIiBpZD0iVXNlcl9Eb2N1bWVudGF0aW9uIj5Vc2VyIERvY3VtZW50YXRpb248L3NwYW4+PC9oMj4KPHVsPjxsaT48YSBocmVmPSIvd2lraS9GcmVxdWVudGx5X0Fza2VkX1F1ZXN0aW9ucyIgdGl0bGU9IkZyZXF1ZW50bHkgQXNrZWQgUXVlc3Rpb25zIj5GcmVxdWVudGx5IEFza2VkIFF1ZXN0aW9uczwvYT48L2xpPjwvdWw+CjxoND48c3BhbiBpZD0iQ29tbXVuaXR5X0dlbmVyYXRlZF9BcnRpY2xlcy4yQ19HdWlkZXMuMkNfYW5kX0RvY3VtZW50YXRpb24iPjwvc3Bhbj48c3BhbiBjbGFzcz0ibXctaGVhZGxpbmUiIGlkPSJDb21tdW5pdHlfR2VuZXJhdGVkX0FydGljbGVzLF9HdWlkZXMsX2FuZF9Eb2N1bWVudGF0aW9uIj5Db21tdW5pdHkgR2VuZXJhdGVkIEFydGljbGVzLCBHdWlkZXMsIGFuZCBEb2N1bWVudGF0aW9uPC9zcGFuPjwvaDQ+Cjx1bD48bGk+PGEgaHJlZj0iL3dpa2kvQ29tbXVuaXR5X0dlbmVyYXRlZF9BcnRpY2xlcyxfR3VpZGVzLF9hbmRfRG9jdW1lbnRhdGlvbiIgdGl0bGU9IkNvbW11bml0eSBHZW5lcmF0ZWQgQXJ0aWNsZXMsIEd1aWRlcywgYW5kIERvY3VtZW50YXRpb24iPkdlbmVyYWwgYXJ0aWNsZXMgYW5kIGd1aWRlczwvYT48L2xpPgo8bGk+PGEgaHJlZj0iL3dpa2kvUG9zdGdyZVNRTF9UdXRvcmlhbHMiIHRpdGxlPSJQb3N0Z3JlU1FMIFR1dG9yaWFscyI+UG9zdGdyZVNRTCBUdXRvcmlhbHM8L2E+PC9saT4KPGxpPjxhIGhyZWY9Ii93aWtpL0NhdGVnb3J5OlNuaXBwZXRzIiB0aXRsZT0iQ2F0ZWdvcnk6U25pcHBldHMiPlBvc3RncmVTUUwgUmVsYXRlZCBDb2RlIFNuaXBwZXRzPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9EZXRhaWxlZF9pbnN0YWxsYXRpb25fZ3VpZGVzIiB0aXRsZT0iRGV0YWlsZWQgaW5zdGFsbGF0aW9uIGd1aWRlcyI+RGV0YWlsZWQgaW5zdGFsbGF0aW9uIGd1aWRlczwvYT48L2xpPgo8bGk+PGEgaHJlZj0iL3dpa2kvQ29udmVydGluZ19mcm9tX290aGVyX0RhdGFiYXNlc190b19Qb3N0Z3JlU1FMIiB0aXRsZT0iQ29udmVydGluZyBmcm9tIG90aGVyIERhdGFiYXNlcyB0byBQb3N0Z3JlU1FMIj5Db252ZXJ0aW5nIGZyb20gb3RoZXIgRGF0YWJhc2VzIHRvIFBvc3RncmVTUUw8L2E+PC9saT4KPGxpPjxhIGhyZWY9Ii93aWtpL0NvbXBhcmlzb25fd2l0aF9vdGhlcl9EYXRhYmFzZV9zeXN0ZW1zIiB0aXRsZT0iQ29tcGFyaXNvbiB3aXRoIG90aGVyIERhdGFiYXNlIHN5c3RlbXMiPkNvbXBhcmlzb24gd2l0aCBvdGhlciBEYXRhYmFzZSBzeXN0ZW1zPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9EYXRhYmFzZV9BZG1pbmlzdHJhdGlvbl9hbmRfTWFpbnRlbmFuY2UiIGNsYXNzPSJtdy1yZWRpcmVjdCIgdGl0bGU9IkRhdGFiYXNlIEFkbWluaXN0cmF0aW9uIGFuZCBNYWludGVuYW5jZSI+RGF0YWJhc2UgQWRtaW5pc3RyYXRpb24gYW5kIE1haW50ZW5hbmNlPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9EZXZlbG9wbWVudF9BcnRpY2xlcyIgdGl0bGU9IkRldmVsb3BtZW50IEFydGljbGVzIj5EZXZlbG9wbWVudCB3aXRoIFBvc3RncmVTUUw8L2E+PC9saT4KPGxpPjxhIGhyZWY9Ii93aWtpL1BlcmZvcm1hbmNlX09wdGltaXphdGlvbiIgdGl0bGU9IlBlcmZvcm1hbmNlIE9wdGltaXphdGlvbiI+UG9zdGdyZVNRTCBQZXJmb3JtYW5jZSBPcHRpbWl6YXRpb248L2E+PC9saT4KPGxpPjxhIGhyZWY9Ii93aWtpL1Bvc3RncmVTUUxfUmVsYXRlZF9TbGlkZXNfYW5kX1ByZXNlbnRhdGlvbnMiIHRpdGxlPSJQb3N0Z3JlU1FMIFJlbGF0ZWQgU2xpZGVzIGFuZCBQcmVzZW50YXRpb25zIj5Qb3N0Z3JlU1FMIFJlbGF0ZWQgU2xpZGVzIGFuZCBQcmVzZW50YXRpb25zPC9hPjwvbGk+PC91bD4KPGg0PjxzcGFuIGNsYXNzPSJtdy1oZWFkbGluZSIgaWQ9IkRvY3VtZW50YXRpb25fb25fdGhlX21haW5fc2l0ZSI+RG9jdW1lbnRhdGlvbiBvbiB0aGUgbWFpbiBzaXRlPC9zcGFuPjwvaDQ+Cjx1bD48bGk+PGEgcmVsPSJub2ZvbGxvdyIgY2xhc3M9ImV4dGVybmFsIHRleHQiIGhyZWY9Imh0dHA6Ly93d3cucG9zdGdyZXNxbC5vcmcvZG9jcy9tYW51YWxzLyI+UG9zdGdyZVNRTCBNYW51YWxzPC9hPjwvbGk+CjxsaT48YSByZWw9Im5vZm9sbG93IiBjbGFzcz0iZXh0ZXJuYWwgdGV4dCIgaHJlZj0iaHR0cDovL3d3dy5wb3N0Z3Jlc3FsLm9yZy9kb2NzL2Jvb2tzLyI+UG9zdGdyZVNRTCBCb29rczwvYT48L2xpPjwvdWw+CjxoMj48c3BhbiBjbGFzcz0ibXctaGVhZGxpbmUiIGlkPSJBbHRlcm5hdGVfTGFuZ3VhZ2VzIj5BbHRlcm5hdGUgTGFuZ3VhZ2VzPC9zcGFuPjwvaDI+CjxwPlRoZSBmb2xsb3dpbmcgcGFnZXMgY29udGFpbiB1c2VyIGRvY3VtZW50YXRpb24gaW4gbGFuZ3VhZ2VzIG90aGVyIHRoYW4gRW5nbGlzaC4KPC9wPgo8dWw+PGxpPjxhIGhyZWY9Ii93aWtpL01haW5fUGFnZS9kZSIgY2xhc3M9Im13LXJlZGlyZWN0IiB0aXRsZT0iTWFpbiBQYWdlL2RlIj5kZXV0c2NoPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UvZXMiIHRpdGxlPSJNYWluIFBhZ2UvZXMiPmVzcGHDsW9sPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UvZnIiIHRpdGxlPSJNYWluIFBhZ2UvZnIiPmZyYW7Dp2FpczwvYT48L2xpPgo8bGk+PGEgaHJlZj0iL3dpa2kvTWFpbl9QYWdlL2hlIiB0aXRsZT0iTWFpbiBQYWdlL2hlIj7XoteR16jXmdeqPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UvamEiIHRpdGxlPSJNYWluIFBhZ2UvamEiPuaXpeacrOiqnjwvYT48L2xpPgo8bGk+PGEgaHJlZj0iL3dpa2kvTWFpbl9QYWdlL3B0IiB0aXRsZT0iTWFpbiBQYWdlL3B0Ij5wb3J0dWd1w6pzPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UvcnUiIHRpdGxlPSJNYWluIFBhZ2UvcnUiPtGA0YPRgdGB0LrQuNC5PC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UvemgiIGNsYXNzPSJtdy1yZWRpcmVjdCIgdGl0bGU9Ik1haW4gUGFnZS96aCI+5Lit5paHPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UvemgtaGFudCIgY2xhc3M9Im13LXJlZGlyZWN0IiB0aXRsZT0iTWFpbiBQYWdlL3poLWhhbnQiPuS4reaWh++8iOe5gemrlDwvYT48L2xpPjwvdWw+CjxwPjxiciAvPgo8L3A+CjxoMj48c3BhbiBjbGFzcz0ibXctaGVhZGxpbmUiIGlkPSJDb250cmlidXRvcl9JbmZvcm1hdGlvbiI+Q29udHJpYnV0b3IgSW5mb3JtYXRpb248L3NwYW4+PC9oMj4KPHVsPjxsaT5Zb3UgY2FuIGZpbmQgbWFueSBQb3N0Z3JlU1FMIHVzZXJzIGFuZCBkZXZlbG9wZXJzIGNoYXR0aW5nIGluIDxhIHJlbD0ibm9mb2xsb3ciIGNsYXNzPSJleHRlcm5hbCB0ZXh0IiBocmVmPSJpcmM6Ly9pcmMubGliZXJhLmNoYXQvcG9zdGdyZXNxbCI+I3Bvc3RncmVzcWwgb24gTGliZXJhPC9hPi4gQSBsaXN0IG9mIElSQyBuaWNrIG5hbWVzIHdpdGggdGhlaXIgcmVzcGVjdGl2ZSByZWFsIHdvcmxkIG5hbWVzIGNhbiBiZSBmb3VuZCA8YSBocmVmPSIvd2lraS9JUkMyUldOYW1lcyIgdGl0bGU9IklSQzJSV05hbWVzIj4gaGVyZTwvYT4uPC9saT4KPGxpPjxhIGhyZWY9Ii93aWtpL0V2ZW50cyIgdGl0bGU9IkV2ZW50cyI+IFVwY29taW5nIEV2ZW50czwvYT48L2xpPgo8bGk+PGEgaHJlZj0iL3dpa2kvRGV2ZWxvcG1lbnRfaW5mb3JtYXRpb24iIHRpdGxlPSJEZXZlbG9wbWVudCBpbmZvcm1hdGlvbiI+RGV2ZWxvcG1lbnQgaW5mb3JtYXRpb248L2E+PC9saT4KPGxpPjxhIGhyZWY9Ii93aWtpL0Fkdm9jYWN5IiB0aXRsZT0iQWR2b2NhY3kiPkFkdm9jYWN5PC9hPjwvbGk+PC91bD4KPGgyPjxzcGFuIGNsYXNzPSJtdy1oZWFkbGluZSIgaWQ9IlVzZXJfQWNjb3VudHMiPlVzZXIgQWNjb3VudHM8L3NwYW4+PC9oMj4KPHVsPjxsaT5BbGwgYWN0aXZpdHkgb24gdGhpcyBzaXRlIHNob3VsZCBmb2xsb3cgdGhlIDxhIGhyZWY9Ii93aWtpL1BvbGljaWVzIiB0aXRsZT0iUG9saWNpZXMiPlBvc3RncmVTUUwgUHJvamVjdCBQb2xpY2llczwvYT4uPC9saT4KPGxpPkluIG9yZGVyIHRvIGVkaXQgb3IgY3JlYXRlIGRvY3VtZW50cyBvbiB0aGUgc2l0ZSwgeW91IHdpbGwgbmVlZCBhIDxhIHJlbD0ibm9mb2xsb3ciIGNsYXNzPSJleHRlcm5hbCB0ZXh0IiBocmVmPSJodHRwczovL3d3dy5wb3N0Z3Jlc3FsLm9yZy9hY2NvdW50L2xvZ2luLyI+UG9zdGdyZVNRTCBjb21tdW5pdHkgYWNjb3VudDwvYT4uIFRoaXMgaXMgdGhlIHNhbWUgYWNjb3VudCB1c2VkIHdoZW4gc3VibWl0dGluZyBuZXdzIG9yIGV2ZW50cyBvbiA8YSByZWw9Im5vZm9sbG93IiBjbGFzcz0iZXh0ZXJuYWwgdGV4dCIgaHJlZj0iaHR0cDovL3d3dy5wb3N0Z3Jlc3FsLm9yZyI+d3d3LnBvc3RncmVzcWwub3JnPC9hPi48L2xpPjwvdWw+CjxwPjxiPk5PVEU6IGR1ZSB0byByZWNlbnQgc3BhbSBhY3Rpdml0eSAiZWRpdG9yIiBwcml2aWxlZ2VzIGFyZSBncmFudGVkIG1hbnVhbGx5IGZvciB0aGUgdGltZSBiZWluZy4gSWYgeW91IGp1c3QgY3JlYXRlZCBhIG5ldyBjb21tdW5pdHkgYWNjb3VudCBvciBpZiB5b3VyIGN1cnJlbnQgYWNjb3VudCB1c2VkIHRvIGhhdmUgImVkaXRvciIgcHJpdmlsZWdlcyBhc2sgb24gdGhlIDxhIHJlbD0ibm9mb2xsb3ciIGNsYXNzPSJleHRlcm5hbCB0ZXh0IiBocmVmPSJtYWlsdG86cGdzcWwtd3d3QHBvc3RncmVzcWwub3JnIj5Qb3N0Z3JlU1FMIC13d3cgTWFpbGluZ2xpc3Q8L2E+IGZvciBoZWxwLiAgUGxlYXNlIGluY2x1ZGUgeW91ciBjb21tdW5pdHkgYWNjb3VudCBuYW1lIGluIHRob3NlIHJlcXVlc3RzLjwvYj4KPC9wPgo8IS0tIApOZXdQUCBsaW1pdCByZXBvcnQKQ2FjaGVkIHRpbWU6IDIwMjYwNTA5MDkyMTM4CkNhY2hlIGV4cGlyeTogODY0MDAKUmVkdWNlZCBleHBpcnk6IGZhbHNlCkNvbXBsaWNhdGlvbnM6IFtdCkNQVSB0aW1lIHVzYWdlOiAwLjAzMyBzZWNvbmRzClJlYWwgdGltZSB1c2FnZTogMC4wNDUgc2Vjb25kcwpQcmVwcm9jZXNzb3IgdmlzaXRlZCBub2RlIGNvdW50OiA0OS8xMDAwMDAwClBvc3TigJBleHBhbmQgaW5jbHVkZSBzaXplOiAwLzIwOTcxNTIgYnl0ZXMKVGVtcGxhdGUgYXJndW1lbnQgc2l6ZTogMC8yMDk3MTUyIGJ5dGVzCkhpZ2hlc3QgZXhwYW5zaW9uIGRlcHRoOiAyLzEwMApFeHBlbnNpdmUgcGFyc2VyIGZ1bmN0aW9uIGNvdW50OiAwLzEwMApVbnN0cmlwIHJlY3Vyc2lvbiBkZXB0aDogMC8yMApVbnN0cmlwIHBvc3TigJBleHBhbmQgc2l6ZTogMC81MDAwMDAwIGJ5dGVzCi0tPgo8IS0tClRyYW5zY2x1c2lvbiBleHBhbnNpb24gdGltZSByZXBvcnQgKCUsbXMsY2FsbHMsdGVtcGxhdGUpCjEwMC4wMCUgICAgOS4zMDAgICAgICAxIFRlbXBsYXRlOkxhbmd1YWdlcwoxMDAuMDAlICAgIDkuMzAwICAgICAgMSAtdG90YWwKLS0+Cgo8IS0tIFNhdmVkIGluIHBhcnNlciBjYWNoZSB3aXRoIGtleSB3aWtpZGItbWVkaWF3aWtpLTpwY2FjaGU6aWRoYXNoOjEtMCFjYW5vbmljYWwgYW5kIHRpbWVzdGFtcCAyMDI2MDUwOTA5MjEzOCBhbmQgcmV2aXNpb24gaWQgNDIwNDguCiAtLT4KPC9kaXY+CjxkaXYgY2xhc3M9InByaW50Zm9vdGVyIiBkYXRhLW5vc25pcHBldD0iIj5SZXRyaWV2ZWQgZnJvbSAiPGEgZGlyPSJsdHIiIGhyZWY9Imh0dHBzOi8vd2lraS5wb3N0Z3Jlc3FsLm9yZy9pbmRleC5waHA/dGl0bGU9TWFpbl9QYWdlJmFtcDtvbGRpZD00MjA0OCI+aHR0cHM6Ly93aWtpLnBvc3RncmVzcWwub3JnL2luZGV4LnBocD90aXRsZT1NYWluX1BhZ2UmYW1wO29sZGlkPTQyMDQ4PC9hPiI8L2Rpdj48L2Rpdj4KCQkJCTxkaXYgaWQ9ImNhdGxpbmtzIiBjbGFzcz0iY2F0bGlua3MgY2F0bGlua3MtYWxsaGlkZGVuIiBkYXRhLW13PSJpbnRlcmZhY2UiPjwvZGl2PgoJCQkJPCEtLSBlbmQgY29udGVudCAtLT4KCQkJCTxkaXYgY2xhc3M9InZpc3VhbENsZWFyIj48L2Rpdj4KCQkJPC9kaXY+CgkJPC9kaXY+CgkJPGRpdiBjbGFzcz0idmlzdWFsQ2xlYXIiPjwvZGl2PgoJPC9kaXY+Cgk8ZGl2IGlkPSJjb2x1bW4tb25lIiA+CgkJPGgyPk5hdmlnYXRpb24gbWVudTwvaDI+CgkJPGRpdiByb2xlPSJuYXZpZ2F0aW9uIiBjbGFzcz0icG9ydGxldCIgaWQ9InAtY2FjdGlvbnMiIGFyaWEtbGFiZWxsZWRieT0icC1jYWN0aW9ucy1sYWJlbCI+CgkJCTxoMyBpZD0icC1jYWN0aW9ucy1sYWJlbCIgPlBhZ2UgYWN0aW9uczwvaDM+CgkJCTxkaXYgY2xhc3M9InBCb2R5Ij4KCQkJCTx1bCA+CgkJCQk8bGkgaWQ9ImNhLW5zdGFiLW1haW4iIGNsYXNzPSJzZWxlY3RlZCBtdy1saXN0LWl0ZW0iPjxhIGhyZWY9Ii93aWtpL01haW5fUGFnZSIgdGl0bGU9IlZpZXcgdGhlIGNvbnRlbnQgcGFnZSBbY10iIGFjY2Vzc2tleT0iYyI+TWFpbiBQYWdlPC9hPjwvbGk+PGxpIGlkPSJjYS10YWxrIiBjbGFzcz0ibXctbGlzdC1pdGVtIj48YSBocmVmPSIvd2lraS9UYWxrOk1haW5fUGFnZSIgcmVsPSJkaXNjdXNzaW9uIiB0aXRsZT0iRGlzY3Vzc2lvbiBhYm91dCB0aGUgY29udGVudCBwYWdlIFt0XSIgYWNjZXNza2V5PSJ0Ij5EaXNjdXNzaW9uPC9hPjwvbGk+PGxpIGlkPSJjYS12aWV3IiBjbGFzcz0ic2VsZWN0ZWQgbXctbGlzdC1pdGVtIj48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UiPlJlYWQ8L2E+PC9saT48bGkgaWQ9ImNhLXZpZXdzb3VyY2UiIGNsYXNzPSJtdy1saXN0LWl0ZW0iPjxhIGhyZWY9Ii9pbmRleC5waHA/dGl0bGU9TWFpbl9QYWdlJmFtcDthY3Rpb249ZWRpdCIgdGl0bGU9IlRoaXMgcGFnZSBpcyBwcm90ZWN0ZWQuJiMxMDtZb3UgY2FuIHZpZXcgaXRzIHNvdXJjZSBbZV0iIGFjY2Vzc2tleT0iZSI+VmlldyBzb3VyY2U8L2E+PC9saT48bGkgaWQ9ImNhLWhpc3RvcnkiIGNsYXNzPSJtdy1saXN0LWl0ZW0iPjxhIGhyZWY9Ii9pbmRleC5waHA/dGl0bGU9TWFpbl9QYWdlJmFtcDthY3Rpb249aGlzdG9yeSIgdGl0bGU9IlBhc3QgcmV2aXNpb25zIG9mIHRoaXMgcGFnZSBbaF0iIGFjY2Vzc2tleT0iaCI+SGlzdG9yeTwvYT48L2xpPgoJCQkJCgkJCQk8L3VsPgoJCQk8L2Rpdj4KCQk8L2Rpdj4KCQkKPGRpdiByb2xlPSJuYXZpZ2F0aW9uIiBjbGFzcz0icG9ydGxldCBtdy1wb3J0bGV0IG13LXBvcnRsZXQtY2FjdGlvbnMtbW9iaWxlIgoJaWQ9InAtY2FjdGlvbnMtbW9iaWxlIiBhcmlhLWxhYmVsbGVkYnk9InAtY2FjdGlvbnMtbW9iaWxlLWxhYmVsIj4KCTxoMyBpZD0icC1jYWN0aW9ucy1tb2JpbGUtbGFiZWwiID5QYWdlIGFjdGlvbnM8L2gzPgoJPGRpdiBjbGFzcz0icEJvZHkiPgoJCTx1bCA+PGxpIGlkPSJtYWluLW1vYmlsZSIgY2xhc3M9InNlbGVjdGVkIG13LWxpc3QtaXRlbSI+PGEgaHJlZj0iL3dpa2kvTWFpbl9QYWdlIiB0aXRsZT0iTWFpbiBQYWdlIj5NYWluIFBhZ2U8L2E+PC9saT48bGkgaWQ9InRhbGstbW9iaWxlIiBjbGFzcz0ibXctbGlzdC1pdGVtIj48YSBocmVmPSIvd2lraS9UYWxrOk1haW5fUGFnZSIgdGl0bGU9IkRpc2N1c3Npb24iPkRpc2N1c3Npb248L2E+PC9saT48bGkgaWQ9ImNhLW1vcmUiIGNsYXNzPSJtdy1saXN0LWl0ZW0iPjxhIGhyZWY9IiNwLWNhY3Rpb25zIj5Nb3JlPC9hPjwvbGk+PGxpIGlkPSJjYS10b29scyIgY2xhc3M9Im13LWxpc3QtaXRlbSI+PGEgaHJlZj0iI3AtdGIiIHRpdGxlPSJUb29scyI+VG9vbHM8L2E+PC9saT48L3VsPgoJCQoJPC9kaXY+CjwvZGl2PgoKCQk8ZGl2IHJvbGU9Im5hdmlnYXRpb24iIGNsYXNzPSJwb3J0bGV0IiBpZD0icC1wZXJzb25hbCIgYXJpYS1sYWJlbGxlZGJ5PSJwLXBlcnNvbmFsLWxhYmVsIj4KCQkJPGgzIGlkPSJwLXBlcnNvbmFsLWxhYmVsIiA+UGVyc29uYWwgdG9vbHM8L2gzPgoJCQk8ZGl2IGNsYXNzPSJwQm9keSI+CgkJCQk8dWwgPgoJCQkJPGxpIGlkPSJwdC1sb2dpbiIgY2xhc3M9Im13LWxpc3QtaXRlbSI+PGEgaHJlZj0iL2luZGV4LnBocD90aXRsZT1TcGVjaWFsOlVzZXJMb2dpbiZhbXA7cmV0dXJudG89TWFpbitQYWdlIiB0aXRsZT0iWW91IG11c3QgbG9nIGluIHRvIGVkaXQgYW55IHBhZ2VzIG9uIHRoaXMgc2l0ZS4gW29dIiBhY2Nlc3NrZXk9Im8iPkxvZyBpbjwvYT48L2xpPgoJCQkJPC91bD4KCQkJPC9kaXY+CgkJPC9kaXY+CgkJPGRpdiBjbGFzcz0icG9ydGxldCIgaWQ9InAtbG9nbyIgcm9sZT0iYmFubmVyIj4KCQkJPGEgaHJlZj0iL3dpa2kvTWFpbl9QYWdlIiBjbGFzcz0ibXctd2lraS1sb2dvIj48L2E+CgkJPC9kaXY+CgkJPGRpdiBpZD0ic2lkZWJhciI+CgkJCjxkaXYgcm9sZT0ibmF2aWdhdGlvbiIgY2xhc3M9InBvcnRsZXQgbXctcG9ydGxldCBtdy1wb3J0bGV0LW5hdmlnYXRpb24iCglpZD0icC1uYXZpZ2F0aW9uIiBhcmlhLWxhYmVsbGVkYnk9InAtbmF2aWdhdGlvbi1sYWJlbCI+Cgk8aDMgaWQ9InAtbmF2aWdhdGlvbi1sYWJlbCIgPk5hdmlnYXRpb248L2gzPgoJPGRpdiBjbGFzcz0icEJvZHkiPgoJCTx1bCA+PGxpIGlkPSJuLW1haW5wYWdlIiBjbGFzcz0ibXctbGlzdC1pdGVtIj48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UiIHRpdGxlPSJWaXNpdCB0aGUgbWFpbiBwYWdlIFt6XSIgYWNjZXNza2V5PSJ6Ij5NYWluIFBhZ2U8L2E+PC9saT48bGkgaWQ9Im4tcmFuZG9tcGFnZSIgY2xhc3M9Im13LWxpc3QtaXRlbSI+PGEgaHJlZj0iL3dpa2kvU3BlY2lhbDpSYW5kb20iIHRpdGxlPSJMb2FkIGEgcmFuZG9tIHBhZ2UgW3hdIiBhY2Nlc3NrZXk9IngiPlJhbmRvbSBwYWdlPC9hPjwvbGk+PGxpIGlkPSJuLXJlY2VudGNoYW5nZXMiIGNsYXNzPSJtdy1saXN0LWl0ZW0iPjxhIGhyZWY9Ii93aWtpL1NwZWNpYWw6UmVjZW50Q2hhbmdlcyIgdGl0bGU9IkEgbGlzdCBvZiByZWNlbnQgY2hhbmdlcyBpbiB0aGUgd2lraSBbcl0iIGFjY2Vzc2tleT0iciI+UmVjZW50IGNoYW5nZXM8L2E+PC9saT48bGkgaWQ9Im4taGVscCIgY2xhc3M9Im13LWxpc3QtaXRlbSI+PGEgaHJlZj0iaHR0cHM6Ly93d3cubWVkaWF3aWtpLm9yZy93aWtpL1NwZWNpYWw6TXlMYW5ndWFnZS9IZWxwOkNvbnRlbnRzIiB0aXRsZT0iVGhlIHBsYWNlIHRvIGZpbmQgb3V0Ij5IZWxwPC9hPjwvbGk+PC91bD4KCQkKCTwvZGl2Pgo8L2Rpdj4KCgkJPGRpdiByb2xlPSJzZWFyY2giIGNsYXNzPSJwb3J0bGV0IiBpZD0icC1zZWFyY2giPgoJCQk8aDMgaWQ9InAtc2VhcmNoLWxhYmVsIiA+PGxhYmVsIGZvcj0ic2VhcmNoSW5wdXQiPlNlYXJjaDwvbGFiZWw+PC9oMz4KCQkJPGRpdiBjbGFzcz0icEJvZHkiIGlkPSJzZWFyY2hCb2R5Ij4KCQkJCTxmb3JtIGFjdGlvbj0iL2luZGV4LnBocCIgaWQ9InNlYXJjaGZvcm0iPjxpbnB1dCB0eXBlPSJoaWRkZW4iIHZhbHVlPSJTcGVjaWFsOlNlYXJjaCIgbmFtZT0idGl0bGUiPjxpbnB1dCB0eXBlPSJzZWFyY2giIG5hbWU9InNlYXJjaCIgcGxhY2Vob2xkZXI9IlNlYXJjaCBQb3N0Z3JlU1FMIHdpa2kiIGFyaWEtbGFiZWw9IlNlYXJjaCBQb3N0Z3JlU1FMIHdpa2kiIGF1dG9jYXBpdGFsaXplPSJzZW50ZW5jZXMiIHRpdGxlPSJTZWFyY2ggUG9zdGdyZVNRTCB3aWtpIFtmXSIgYWNjZXNza2V5PSJmIiBpZD0ic2VhcmNoSW5wdXQiLz48aW5wdXQgdHlwZT0ic3VibWl0IiBuYW1lPSJnbyIgdmFsdWU9IkdvIiB0aXRsZT0iR28gdG8gYSBwYWdlIHdpdGggdGhpcyBleGFjdCBuYW1lIGlmIGl0IGV4aXN0cyIgY2xhc3M9InNlYXJjaEJ1dHRvbiIgaWQ9InNlYXJjaEJ1dHRvbiIvPiA8aW5wdXQgdHlwZT0ic3VibWl0IiBuYW1lPSJmdWxsdGV4dCIgdmFsdWU9IlNlYXJjaCIgdGl0bGU9IlNlYXJjaCB0aGUgcGFnZXMgZm9yIHRoaXMgdGV4dCIgY2xhc3M9InNlYXJjaEJ1dHRvbiBtdy1mYWxsYmFja1NlYXJjaEJ1dHRvbiIgaWQ9Im13LXNlYXJjaEJ1dHRvbiIvPjwvZm9ybT4KCQkJPC9kaXY+CgkJPC9kaXY+CgkJCjxkaXYgcm9sZT0ibmF2aWdhdGlvbiIgY2xhc3M9InBvcnRsZXQgbXctcG9ydGxldCBtdy1wb3J0bGV0LXRiIgoJaWQ9InAtdGIiIGFyaWEtbGFiZWxsZWRieT0icC10Yi1sYWJlbCI+Cgk8aDMgaWQ9InAtdGItbGFiZWwiID5Ub29sczwvaDM+Cgk8ZGl2IGNsYXNzPSJwQm9keSI+CgkJPHVsID48bGkgaWQ9InQtd2hhdGxpbmtzaGVyZSIgY2xhc3M9Im13LWxpc3QtaXRlbSI+PGEgaHJlZj0iL3dpa2kvU3BlY2lhbDpXaGF0TGlua3NIZXJlL01haW5fUGFnZSIgdGl0bGU9IkEgbGlzdCBvZiBhbGwgd2lraSBwYWdlcyB0aGF0IGxpbmsgaGVyZSBbal0iIGFjY2Vzc2tleT0iaiI+V2hhdCBsaW5rcyBoZXJlPC9hPjwvbGk+PGxpIGlkPSJ0LXJlY2VudGNoYW5nZXNsaW5rZWQiIGNsYXNzPSJtdy1saXN0LWl0ZW0iPjxhIGhyZWY9Ii93aWtpL1NwZWNpYWw6UmVjZW50Q2hhbmdlc0xpbmtlZC9NYWluX1BhZ2UiIHJlbD0ibm9mb2xsb3ciIHRpdGxlPSJSZWNlbnQgY2hhbmdlcyBpbiBwYWdlcyBsaW5rZWQgZnJvbSB0aGlzIHBhZ2UgW2tdIiBhY2Nlc3NrZXk9ImsiPlJlbGF0ZWQgY2hhbmdlczwvYT48L2xpPjxsaSBpZD0idC1zcGVjaWFscGFnZXMiIGNsYXNzPSJtdy1saXN0LWl0ZW0iPjxhIGhyZWY9Ii93aWtpL1NwZWNpYWw6U3BlY2lhbFBhZ2VzIiB0aXRsZT0iQSBsaXN0IG9mIGFsbCBzcGVjaWFsIHBhZ2VzIFtxXSIgYWNjZXNza2V5PSJxIj5TcGVjaWFsIHBhZ2VzPC9hPjwvbGk+PGxpIGlkPSJ0LXByaW50IiBjbGFzcz0ibXctbGlzdC1pdGVtIj48YSBocmVmPSJqYXZhc2NyaXB0OnByaW50KCk7IiByZWw9ImFsdGVybmF0ZSIgdGl0bGU9IlByaW50YWJsZSB2ZXJzaW9uIG9mIHRoaXMgcGFnZSBbcF0iIGFjY2Vzc2tleT0icCI+UHJpbnRhYmxlIHZlcnNpb248L2E+PC9saT48bGkgaWQ9InQtcGVybWFsaW5rIiBjbGFzcz0ibXctbGlzdC1pdGVtIj48YSBocmVmPSIvaW5kZXgucGhwP3RpdGxlPU1haW5fUGFnZSZhbXA7b2xkaWQ9NDIwNDgiIHRpdGxlPSJQZXJtYW5lbnQgbGluayB0byB0aGlzIHJldmlzaW9uIG9mIHRoaXMgcGFnZSI+UGVybWFuZW50IGxpbms8L2E+PC9saT48bGkgaWQ9InQtaW5mbyIgY2xhc3M9Im13LWxpc3QtaXRlbSI+PGEgaHJlZj0iL2luZGV4LnBocD90aXRsZT1NYWluX1BhZ2UmYW1wO2FjdGlvbj1pbmZvIiB0aXRsZT0iTW9yZSBpbmZvcm1hdGlvbiBhYm91dCB0aGlzIHBhZ2UiPlBhZ2UgaW5mb3JtYXRpb248L2E+PC9saT48L3VsPgoJCQoJPC9kaXY+CjwvZGl2PgoKCQkKCQk8L2Rpdj4KCQk8YSBocmVmPSIjc2lkZWJhciIgdGl0bGU9Ikp1bXAgdG8gbmF2aWdhdGlvbiIKCQkJY2xhc3M9Im1lbnUtdG9nZ2xlIiBpZD0ic2lkZWJhci10b2dnbGUiPjwvYT4KCQk8YSBocmVmPSIjcC1wZXJzb25hbCIgdGl0bGU9InVzZXIgdG9vbHMiCgkJCWNsYXNzPSJtZW51LXRvZ2dsZSIgaWQ9InAtcGVyc29uYWwtdG9nZ2xlIj48L2E+CgkJPGEgaHJlZj0iI2dsb2JhbFdyYXBwZXIiIHRpdGxlPSJiYWNrIHRvIHRvcCIKCQkJY2xhc3M9Im1lbnUtdG9nZ2xlIiBpZD0iZ2xvYmFsV3JhcHBlci10b2dnbGUiPjwvYT4KCTwvZGl2PgoJPCEtLSBlbmQgb2YgdGhlIGxlZnQgKGJ5IGRlZmF1bHQgYXQgbGVhc3QpIGNvbHVtbiAtLT4KCTxkaXYgY2xhc3M9InZpc3VhbENsZWFyIj48L2Rpdj4KCTxkaXYgaWQ9ImZvb3RlciIgY2xhc3M9Im13LWZvb3RlciIgcm9sZT0iY29udGVudGluZm8iCgkJPgoJCTxkaXYgaWQ9ImYtcG93ZXJlZGJ5aWNvIiBjbGFzcz0iZm9vdGVyLWljb25zIj4KCQkJPGEgaHJlZj0iaHR0cHM6Ly93d3cubWVkaWF3aWtpLm9yZy8iPjxpbWcgc3JjPSIvcmVzb3VyY2VzL2Fzc2V0cy9wb3dlcmVkYnlfbWVkaWF3aWtpXzg4eDMxLnBuZyIgYWx0PSJQb3dlcmVkIGJ5IE1lZGlhV2lraSIgc3Jjc2V0PSIvcmVzb3VyY2VzL2Fzc2V0cy9wb3dlcmVkYnlfbWVkaWF3aWtpXzEzMng0Ny5wbmcgMS41eCwgL3Jlc291cmNlcy9hc3NldHMvcG93ZXJlZGJ5X21lZGlhd2lraV8xNzZ4NjIucG5nIDJ4IiB3aWR0aD0iODgiIGhlaWdodD0iMzEiIGxvYWRpbmc9ImxhenkiLz48L2E+CgkJPC9kaXY+CgkJPHVsIGlkPSJmLWxpc3QiPgoJCQk8bGkgaWQ9Imxhc3Rtb2QiPiBUaGlzIHBhZ2Ugd2FzIGxhc3QgZWRpdGVkIG9uIDIzIE9jdG9iZXIgMjAyNSwgYXQgMTQ6NTQuPC9saT4KCQkJPGxpIGlkPSJwcml2YWN5Ij48YSBocmVmPSIvd2lraS9Qb3N0Z3JlU1FMX3dpa2k6UHJpdmFjeV9wb2xpY3kiPlByaXZhY3kgcG9saWN5PC9hPjwvbGk+PGxpIGlkPSJhYm91dCI+PGEgaHJlZj0iL3dpa2kvUG9zdGdyZVNRTF93aWtpOkFib3V0Ij5BYm91dCBQb3N0Z3JlU1FMIHdpa2k8L2E+PC9saT48bGkgaWQ9ImRpc2NsYWltZXIiPjxhIGhyZWY9Ii93aWtpL1Bvc3RncmVTUUxfd2lraTpHZW5lcmFsX2Rpc2NsYWltZXIiPkRpc2NsYWltZXJzPC9hPjwvbGk+CgkJPC91bD4KCTwvZGl2Pgo8L2Rpdj4KPHNjcmlwdD4oUkxRPXdpbmRvdy5STFF8fFtdKS5wdXNoKGZ1bmN0aW9uKCl7bXcuY29uZmlnLnNldCh7IndnUGFnZVBhcnNlUmVwb3J0Ijp7ImxpbWl0cmVwb3J0Ijp7ImNwdXRpbWUiOiIwLjAzMyIsIndhbGx0aW1lIjoiMC4wNDUiLCJwcHZpc2l0ZWRub2RlcyI6eyJ2YWx1ZSI6NDksImxpbWl0IjoxMDAwMDAwfSwicG9zdGV4cGFuZGluY2x1ZGVzaXplIjp7InZhbHVlIjowLCJsaW1pdCI6MjA5NzE1Mn0sInRlbXBsYXRlYXJndW1lbnRzaXplIjp7InZhbHVlIjowLCJsaW1pdCI6MjA5NzE1Mn0sImV4cGFuc2lvbmRlcHRoIjp7InZhbHVlIjoyLCJsaW1pdCI6MTAwfSwiZXhwZW5zaXZlZnVuY3Rpb25jb3VudCI6eyJ2YWx1ZSI6MCwibGltaXQiOjEwMH0sInVuc3RyaXAtZGVwdGgiOnsidmFsdWUiOjAsImxpbWl0IjoyMH0sInVuc3RyaXAtc2l6ZSI6eyJ2YWx1ZSI6MCwibGltaXQiOjUwMDAwMDB9LCJ0aW1pbmdwcm9maWxlIjpbIjEwMC4wMCUgICAgOS4zMDAgICAgICAxIFRlbXBsYXRlOkxhbmd1YWdlcyIsIjEwMC4wMCUgICAgOS4zMDAgICAgICAxIC10b3RhbCJdfSwiY2FjaGVyZXBvcnQiOnsidGltZXN0YW1wIjoiMjAyNjA1MDkwOTIxMzgiLCJ0dGwiOjg2NDAwLCJ0cmFuc2llbnRjb250ZW50IjpmYWxzZX19fSk7bXcuY29uZmlnLnNldCh7IndnQmFja2VuZFJlc3BvbnNlVGltZSI6MjAzfSk7fSk7PC9zY3JpcHQ+CjwvYm9keT4KPC9odG1sPg==
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          - pods
+          verbs:
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - postgres.keiailab.io
+          resources:
+          - backupjobs
+          - postgresclusters
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - postgres.keiailab.io
+          resources:
+          - backupjobs/finalizers
+          - postgresclusters/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - postgres.keiailab.io
+          resources:
+          - backupjobs/status
+          - postgresclusters/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: postgres-operator
+          control-plane: controller-manager
+        name: controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: postgres-operator
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app.kubernetes.io/name: postgres-operator
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                command:
+                - /manager
+                image: ghcr.io/keiailab/postgres-operator:0.3.0-alpha.16
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - postgres
+  - postgresql
+  - database
+  - high-availability
+  - replication
+  - failover
+  - pgbackrest
+  - backup
+  links:
+  - name: GitHub
+    url: https://github.com/keiailab/postgres-operator
+  - name: Documentation
+    url: https://github.com/keiailab/postgres-operator/blob/main/README.md
+  - name: Helm Chart (ArtifactHub)
+    url: https://artifacthub.io/packages/helm/postgresql-operator/postgresql-operator
+  - name: Discussions
+    url: https://github.com/keiailab/postgres-operator/discussions
+  maintainers:
+  - email: help@masblue.studio
+    name: Keiailab
+  maturity: alpha
+  minKubeVersion: 1.26.0
+  provider:
+    name: Keiailab
+    url: https://github.com/keiailab
+  version: 0.3.0-alpha.16

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.16/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.16/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.16/manifests/postgres.keiailab.io_backupjobs.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.16/manifests/postgres.keiailab.io_backupjobs.yaml
@@ -1,0 +1,248 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  creationTimestamp: null
+  name: backupjobs.postgres.keiailab.io
+spec:
+  group: postgres.keiailab.io
+  names:
+    kind: BackupJob
+    listKind: BackupJobList
+    plural: backupjobs
+    shortNames:
+    - bj
+    singular: backupjob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .spec.tool
+      name: Tool
+      type: string
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BackupJob은 단일 백업 실행 명령이다 (RFC 0004).
+
+          본 CRD는 *atomic 단위*다 — 변경 시 새 BackupJob 생성. cron 기반 정기 백업은
+          별도 ScheduledBackup CRD (RFC 0004 §2.3, P4-T2 시점).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              BackupJobSpec은 단일 백업 호출의 명세다 (RFC 0004 §2.1).
+
+              immutable 필드 (생성 후 변경 불가, webhook이 reject 예정 — phase 2):
+                - cluster.name
+                - tool
+                - type
+                - executionMode
+            properties:
+              cluster:
+                description: Cluster는 백업 대상 PostgresCluster 참조 (같은 namespace).
+                properties:
+                  name:
+                    description: Name은 PostgresCluster.metadata.name.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              executionMode:
+                description: |-
+                  ExecutionMode는 plugin이 백업을 *어디서 실행*할지 결정 (P1-6, RFC 0004 §3.1):
+                    - "sidecar": PG Pod 동거 컨테이너 (pgBackRest 패턴)
+                    - "job":     standalone K8s Job (WAL-G 패턴)
+                    - "":        plugin default
+                enum:
+                - sidecar
+                - job
+                - ""
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels는 BackupResult 메타데이터에 첨부될 K8s 스타일 레이블.
+                type: object
+              repo:
+                description: Repo는 다중 저장소 환경에서 어느 repo를 쓸지 식별.
+                minLength: 1
+                type: string
+              restore:
+                description: Restore는 Type=restore 시 PITR 설정 (RFC 0004 §5.1).
+                properties:
+                  backupID:
+                    description: BackupID는 복구 대상 백업 식별자 (TargetTime 대신 직접 지정).
+                    type: string
+                  targetTime:
+                    description: TargetTime은 복구 대상 시각 (UTC, ISO 8601 RFC3339).
+                    format: date-time
+                    type: string
+                type: object
+              retention:
+                description: Retention은 백업 보존 정책.
+                properties:
+                  keepFull:
+                    description: KeepFull은 보존할 full 백업 개수. 0이면 무제한 (plugin 기본).
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  keepIncremental:
+                    description: KeepIncremental은 보존할 incremental/differential 백업
+                      개수.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
+              tool:
+                description: |-
+                  Tool은 사용할 백업 도구 이름. BackupPlugin.Name()과 일치해야 한다.
+                  예: "pgbackrest" (RFC 0004 §4 1차 reference), "walg", "barman".
+                minLength: 1
+                type: string
+              type:
+                description: Type은 백업 종류.
+                enum:
+                - full
+                - incremental
+                - differential
+                - restore
+                type: string
+            required:
+            - cluster
+            - repo
+            - tool
+            - type
+            type: object
+          status:
+            description: BackupJobStatus는 BackupJob의 관찰 상태.
+            properties:
+              backupID:
+                description: BackupID는 plugin이 부여한 고유 식별자 (Succeeded 후).
+                type: string
+              bytes:
+                description: Bytes는 백업 크기 (bytes). 0 허용 (스트리밍 도구).
+                format: int64
+                type: integer
+              conditions:
+                description: Conditions는 K8s 표준 상태 (Ready, Available, Progressing).
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              endedAt:
+                description: EndedAt은 백업 종료 시각.
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration은 reconcile이 마지막 처리한 spec generation.
+                format: int64
+                type: integer
+              phase:
+                description: Phase는 BackupJob 진행 단계.
+                enum:
+                - Pending
+                - Running
+                - Succeeded
+                - Failed
+                type: string
+              startedAt:
+                description: StartedAt은 백업 시작 시각.
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.16/manifests/postgres.keiailab.io_postgresclusters.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.16/manifests/postgres.keiailab.io_postgresclusters.yaml
@@ -1,0 +1,1770 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  creationTimestamp: null
+  name: postgresclusters.postgres.keiailab.io
+spec:
+  group: postgres.keiailab.io
+  names:
+    kind: PostgresCluster
+    listKind: PostgresClusterList
+    plural: postgresclusters
+    shortNames:
+    - pgc
+    singular: postgrescluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.shards.initialCount
+      name: Shards
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.postgresVersion
+      name: Version
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PostgresCluster 는 K8s-native 자체 분산 PostgreSQL 클러스터의 선언적 표현이다
+          (ADR 0001).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              PostgresClusterSpec 는 PostgresCluster CR 의 desired state 다 (RFC 0001 §3).
+
+              CEL 검증 (kubebuilder v0.15+):
+            properties:
+              autoSplit:
+                description: AutoSplit 은 자동 샤드 분할 정책.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enabled 는 자동 분할 활성화 여부. P2+ 에서 의미를 갖는다.
+                    type: boolean
+                  requireApproval:
+                    default: true
+                    description: |-
+                      RequireApproval 은 자동 분할 대상 후보를 ShardSplitJob 으로 제출하되 수동
+                      승인 annotation 후에만 실행하도록 강제한다 (production safety).
+                    type: boolean
+                  triggers:
+                    description: Triggers 는 분할 임계치 집합.
+                    properties:
+                      cpuPercent:
+                        description: CPUPercent 는 단일 샤드 평균 CPU 사용률 임계치 (%). 0 이면 미사용.
+                        format: int32
+                        maximum: 100
+                        minimum: 0
+                        type: integer
+                      durationMinutes:
+                        description: DurationMinutes 는 위 임계치들이 지속되어야 하는 시간 (분). 0
+                          이면 즉시.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      p99LatencyMs:
+                        description: P99LatencyMs 는 단일 샤드 P99 latency 임계치 (ms). 0
+                          이면 미사용.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      sizeThresholdGB:
+                        description: SizeThresholdGB 는 단일 샤드 크기 임계치 (GB). 0 이면 미사용.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                    type: object
+                type: object
+              backup:
+                description: Backup 은 백업/PITR 정책.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enabled 는 백업 정책 활성화 여부 (사용자 명시 opt-in).
+                    type: boolean
+                  repo:
+                    description: Repo 는 백업 저장소 설정.
+                    properties:
+                      bucket:
+                        description: Bucket 은 object storage 버킷 이름.
+                        type: string
+                      endpoint:
+                        description: Endpoint 는 S3 호환 endpoint URL (선택).
+                        type: string
+                      path:
+                        description: Path 는 filesystem 경로 (Type=filesystem).
+                        type: string
+                      region:
+                        description: Region 은 object storage 리전.
+                        type: string
+                      type:
+                        description: Type 은 저장소 종류 (s3 | gcs | azure | filesystem).
+                        enum:
+                        - s3
+                        - gcs
+                        - azure
+                        - filesystem
+                        type: string
+                    type: object
+                  retention:
+                    description: Retention 은 백업 보존 정책.
+                    properties:
+                      full:
+                        description: 'Full 은 full 백업 보존 기간 (duration: "7d", "168h"
+                          등).'
+                        type: string
+                      incremental:
+                        description: Incremental 은 incremental 백업 보존 기간.
+                        type: string
+                      walArchive:
+                        description: WALArchive 는 WAL 아카이브 보존 기간.
+                        type: string
+                    type: object
+                  schedule:
+                    description: 'Schedule 은 cron expression (예: "0 2 * * *").'
+                    type: string
+                type: object
+              extensions:
+                description: |-
+                  Extensions 는 활성화할 PostgreSQL extension 의 이름 목록이다 (RFC 0006 R1).
+                  비어 있으면 vanilla PG (image base 외 추가 extension 없음). 각 이름은 operator
+                  부트스트랩 시 Registry 에 등록된 ExtensionPlugin 이어야 하며, webhook 이 이를
+                  검증한다.
+
+                  예: ["pgaudit", "pgvector"] — postgres_v1alpha1 image 가 두 extension 의 .so 를
+                  보유한다는 전제. image 가 미보유 시 postgres FATAL — 사용자 책임.
+                items:
+                  type: string
+                type: array
+              monitoring:
+                description: Monitoring 은 monitoring 통합 설정.
+                properties:
+                  prometheusRule:
+                    description: PrometheusRule 은 알람 규칙 자동 배포.
+                    properties:
+                      enabled:
+                        default: true
+                        description: Enabled 는 PrometheusRule 생성 여부.
+                        type: boolean
+                    type: object
+                  serviceMonitor:
+                    description: ServiceMonitor 는 Prometheus operator ServiceMonitor
+                      자동 배포.
+                    properties:
+                      enabled:
+                        default: true
+                        description: Enabled 는 ServiceMonitor 생성 여부.
+                        type: boolean
+                      interval:
+                        default: 30s
+                        description: 'Interval 은 scrape interval (예: "30s").'
+                        type: string
+                    type: object
+                type: object
+              postgresVersion:
+                default: "18"
+                description: PostgresVersion 은 메이저 버전 문자열. 0.3.0-alpha 는 18 만 GA,
+                  17 호환 유지.
+                enum:
+                - "17"
+                - "18"
+                type: string
+              router:
+                description: Router 는 무상태 QueryRouter 풀. shardingMode=native 시에만 의미.
+                properties:
+                  autoscale:
+                    description: Autoscale 은 HPA 설정.
+                    properties:
+                      enabled:
+                        default: false
+                        description: Enabled 는 HPA 부착 여부.
+                        type: boolean
+                      maxReplicas:
+                        description: MaxReplicas 는 HPA 최대 복제본.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      minReplicas:
+                        description: MinReplicas 는 HPA 최소 복제본.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      targetActiveConnections:
+                        default: 1000
+                        description: TargetActiveConnections 는 HPA active connection
+                          목표.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      targetCPU:
+                        default: 70
+                        description: TargetCPU 는 HPA CPU 사용률 목표 (%).
+                        format: int32
+                        maximum: 100
+                        minimum: 1
+                        type: integer
+                    type: object
+                  enabled:
+                    default: true
+                    description: Enabled 는 라우터 활성화 여부. shardingMode=native 시 default
+                      true.
+                    type: boolean
+                  replicas:
+                    default: 2
+                    description: Replicas 는 라우터 Pod 수. HPA 부착 시 minimum 역할.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  resources:
+                    description: Resources 는 라우터 컨테이너 리소스 요구사항.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              shardingMode:
+                default: none
+                description: ShardingMode 는 단일 샤드 (none) 또는 자체 분산 SQL (native).
+                enum:
+                - none
+                - native
+                type: string
+              shards:
+                description: Shards 는 샤드 토폴로지.
+                properties:
+                  affinity:
+                    description: Affinity 는 샤드 Pod 친화성 규칙.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and subtracting
+                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
+                  initialCount:
+                    description: InitialCount 는 클러스터 초기 샤드 수. P1 GA 는 1 만 보장. 1024
+                      까지 schema 허용.
+                    format: int32
+                    maximum: 1024
+                    minimum: 1
+                    type: integer
+                  priorityClassName:
+                    description: PriorityClassName 은 샤드 Pod priorityClass 명. modern
+                      HA Layer 3 (evict 우선순위).
+                    type: string
+                  replicas:
+                    default: 1
+                    description: Replicas 는 샤드당 비동기 복제본 수 (primary 제외). 0 이면 HA 미구성
+                      (개발용).
+                    format: int32
+                    maximum: 15
+                    minimum: 0
+                    type: integer
+                  resources:
+                    description: Resources 는 샤드 PG 컨테이너 리소스 요구사항.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  storage:
+                    description: Storage 는 샤드 PVC 사양.
+                    properties:
+                      accessModes:
+                        description: AccessModes 는 PVC 접근 모드 (빈 배열이면 ReadWriteOnce).
+                        items:
+                          type: string
+                        type: array
+                      size:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'Size 는 PVC 요청 크기 (예: "100Gi").'
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      storageClass:
+                        description: StorageClass 는 PVC StorageClass 이름. 빈 문자열이면 클러스터
+                          디폴트.
+                        type: string
+                    required:
+                    - size
+                    type: object
+                  tolerations:
+                    description: Tolerations 는 샤드 Pod 노드 toleration.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    description: TopologySpreadConstraints 는 샤드 Pod multi-node 분산
+                      정책. modern HA Layer 2 (SPOF 차단).
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: |-
+                            LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine the number of pods
+                            in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        matchLabelKeys:
+                          description: |-
+                            MatchLabelKeys is a set of pod label keys to select the pods over which
+                            spreading will be calculated. The keys are used to lookup values from the
+                            incoming pod labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading will be calculated
+                            for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                            MatchLabelKeys cannot be set when LabelSelector isn't set.
+                            Keys that don't exist in the incoming pod labels will
+                            be ignored. A null or empty list means only match against labelSelector.
+
+                            This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          description: |-
+                            MaxSkew describes the degree to which pods may be unevenly distributed.
+                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                            between the number of matching pods in the target topology and the global minimum.
+                            The global minimum is the minimum number of matching pods in an eligible domain
+                            or zero if the number of eligible domains is less than MinDomains.
+                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                            labelSelector spread as 2/2/1:
+                            In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 |
+                            |  P P  |  P P  |   P   |
+                            - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                            scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                            violate MaxSkew(1).
+                            - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                            When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                            to topologies that satisfy it.
+                            It's a required field. Default value is 1 and 0 is not allowed.
+                          format: int32
+                          type: integer
+                        minDomains:
+                          description: |-
+                            MinDomains indicates a minimum number of eligible domains.
+                            When the number of eligible domains with matching topology keys is less than minDomains,
+                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                            And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                            this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less than minDomains,
+                            scheduler won't schedule more than maxSkew Pods to those domains.
+                            If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                            Valid values are integers greater than 0.
+                            When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                            For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                            labelSelector spread as 2/2/2:
+                            | zone1 | zone2 | zone3 |
+                            |  P P  |  P P  |  P P  |
+                            The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                            In this situation, new pod with the same labelSelector cannot be scheduled,
+                            because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew.
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: |-
+                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                            when calculating pod topology spread skew. Options are:
+                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                            If this value is nil, the behavior is equivalent to the Honor policy.
+                          type: string
+                        nodeTaintsPolicy:
+                          description: |-
+                            NodeTaintsPolicy indicates how we will treat node taints when calculating
+                            pod topology spread skew. Options are:
+                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                            has a toleration, are included.
+                            - Ignore: node taints are ignored. All nodes are included.
+
+                            If this value is nil, the behavior is equivalent to the Ignore policy.
+                          type: string
+                        topologyKey:
+                          description: |-
+                            TopologyKey is the key of node labels. Nodes that have a label with this key
+                            and identical values are considered to be in the same topology.
+                            We consider each <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket.
+                            We define a domain as a particular instance of a topology.
+                            Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                            nodeAffinityPolicy and nodeTaintsPolicy.
+                            e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                            And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                            It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: |-
+                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                            the spread constraint.
+                            - DoNotSchedule (default) tells the scheduler not to schedule it.
+                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                              but giving higher precedence to topologies that would help reduce the
+                              skew.
+                            A constraint is considered "Unsatisfiable" for an incoming pod
+                            if and only if every possible node assignment for that pod would violate
+                            "MaxSkew" on some topology.
+                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                            labelSelector spread as 3/1/1:
+                            | zone1 | zone2 | zone3 |
+                            | P P P |   P   |   P   |
+                            If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                            to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                            MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                            won't make it *more* imbalanced.
+                            It's a required field.
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                required:
+                - initialCount
+                - storage
+                type: object
+              tls:
+                description: |-
+                  TLS 는 PostgreSQL server-side TLS 설정 (Pillar P7 §7).
+                  0.3.0-alpha.5+ Phase 1 facade — CRD field 만 정의. Phase 2 에서 cert-manager
+                  Certificate CR 통합 + Phase 3 에서 reconciler 의 server.crt/server.key emit
+                  만 의미 있음 — true 설정 시 webhook reject (NotImplemented Phase 1).
+                properties:
+                  certSecretName:
+                    description: |-
+                      CertSecretName 은 server cert 가 저장될 Secret 이름. 미설정 시
+                      "<cluster>-tls" default. Phase 2 에서 cert-manager Certificate.spec.secretName
+                      으로 사용됨.
+                    type: string
+                  enabled:
+                    default: false
+                    description: Enabled 는 server-side TLS 활성 여부. Phase 1 에서는 false
+                      만 동작.
+                    type: boolean
+                  issuerRef:
+                    description: |-
+                      IssuerRef 는 cert-manager Issuer 또는 ClusterIssuer 참조.
+                      Phase 2 부터 의미 있음. 미설정 시 self-signed 자체 발급 (Phase 3 default).
+                    properties:
+                      kind:
+                        default: Issuer
+                        description: Kind 는 Issuer 또는 ClusterIssuer.
+                        enum:
+                        - Issuer
+                        - ClusterIssuer
+                        type: string
+                      name:
+                        description: Name 은 Issuer 이름.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+            required:
+            - shards
+            type: object
+            x-kubernetes-validations:
+            - message: native sharding requires shards.initialCount >= 1
+              rule: self.shardingMode != 'native' || self.shards.initialCount >= 1
+            - message: router is only valid when shardingMode=native
+              rule: '!has(self.router) || self.shardingMode == ''native'''
+            - message: autoSplit requires shardingMode=native
+              rule: '!has(self.autoSplit) || self.autoSplit.enabled == false || self.shardingMode
+                == ''native'''
+          status:
+            description: PostgresClusterStatus 는 PostgresCluster CR 의 관찰 상태 (RFC 0001
+              §3.2).
+            properties:
+              conditions:
+                description: |-
+                  Conditions 는 K8s 표준 condition 집합.
+                  권장 type: Ready / Progressing / BackupHealthy / AutoSplitEligible / RouterReady.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration 은 reconciler 가 관측한 spec.metadata.generation.
+                format: int64
+                type: integer
+              phase:
+                description: Phase 는 cluster 의 상위 단계.
+                enum:
+                - Provisioning
+                - Ready
+                - Reconfiguring
+                - Degraded
+                type: string
+              router:
+                description: Router 는 라우터 풀 관찰 상태 (shardingMode=native 시).
+                properties:
+                  endpoint:
+                    description: Endpoint 는 라우터 Service endpoint.
+                    type: string
+                  readyReplicas:
+                    description: ReadyReplicas 는 ready 상태 라우터 Pod 수.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: Replicas 는 desired 라우터 Pod 수.
+                    format: int32
+                    type: integer
+                type: object
+              shards:
+                description: Shards 는 샤드별 관찰 상태 배열 (ordinal 오름차순).
+                items:
+                  description: ShardStatus 는 단일 샤드의 관찰 상태.
+                  properties:
+                    lastSplit:
+                      description: LastSplit 은 마지막 분할 완료 시각. 분할 이력 없음 = nil.
+                      format: date-time
+                      type: string
+                    name:
+                      description: 'Name 은 샤드 식별자 (예: "shard-0").'
+                      type: string
+                    ordinal:
+                      description: Ordinal 은 샤드 순서 (0-based).
+                      format: int32
+                      type: integer
+                    primary:
+                      description: Primary 는 현재 primary endpoint.
+                      properties:
+                        endpoint:
+                          description: Endpoint 는 호스트:포트 형태의 접속 endpoint.
+                          type: string
+                        lagBytes:
+                          description: LagBytes 는 replica 의 WAL lag (bytes). primary
+                            는 0 또는 미설정.
+                          format: int64
+                          type: integer
+                        pod:
+                          description: Pod 는 K8s Pod 이름.
+                          type: string
+                        ready:
+                          description: Ready 는 readiness 통과 여부.
+                          type: boolean
+                      type: object
+                    replicas:
+                      description: Replicas 는 현재 replica endpoint 목록.
+                      items:
+                        description: ShardEndpoint 는 샤드 멤버 (primary 또는 replica) 1
+                          개의 관찰 상태.
+                        properties:
+                          endpoint:
+                            description: Endpoint 는 호스트:포트 형태의 접속 endpoint.
+                            type: string
+                          lagBytes:
+                            description: LagBytes 는 replica 의 WAL lag (bytes). primary
+                              는 0 또는 미설정.
+                            format: int64
+                            type: integer
+                          pod:
+                            description: Pod 는 K8s Pod 이름.
+                            type: string
+                          ready:
+                            description: Ready 는 readiness 통과 여부.
+                            type: boolean
+                        type: object
+                      type: array
+                    sizeBytes:
+                      description: SizeBytes 는 샤드 데이터 크기 (bytes). 0 이면 미관측.
+                      format: int64
+                      type: integer
+                  required:
+                  - name
+                  - ordinal
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.16/metadata/annotations.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.16/metadata/annotations.yaml
@@ -1,0 +1,11 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: keiailab-postgres-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.2
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4

--- a/operators/keiailab-postgres-operator/ci.yaml
+++ b/operators/keiailab-postgres-operator/ci.yaml
@@ -1,0 +1,4 @@
+---
+reviewers:
+  - eightynine01
+updateGraph: replaces-mode


### PR DESCRIPTION
Initial submission of Keiailab's postgres-operator. Distinct from existing Zalando `postgres-operator` and CrunchyData `postgresql` entries — separate package name `keiailab-postgres-operator`.

## About
- Apache-2.0 licensed PostgreSQL Kubernetes Operator
- Vanilla PG18+ (no external operator/backend fork/embed/wrapper)
- PG17/PG18 multi-major support, automated failover (RTO < 30s)
- pgBackRest BackupJob CRD
- Cosign signed images + SBOM

## Resources
- GitHub: https://github.com/keiailab/postgres-operator
- ArtifactHub: https://artifacthub.io/packages/helm/postgresql-operator/postgresql-operator
- License: Apache-2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)