### PR TITLE
operator podtrace (0.11.9)

### DIFF
--- a/operators/podtrace/0.11.9/manifests/podtrace.clusterserviceversion.yaml
+++ b/operators/podtrace/0.11.9/manifests/podtrace.clusterserviceversion.yaml
@@ -1,0 +1,360 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: podtrace.v0.11.9
+  namespace: placeholder
+  annotations:
+    capabilities: Basic Install
+    categories: "Monitoring,Developer Tools"
+    containerImage: ghcr.io/gma1k/podtrace:0.11.9
+    createdAt: "2026-05-11T11:59:37Z"
+    description: eBPF-based diagnostic operator for Kubernetes pods
+    repository: https://github.com/gma1k/podtrace
+    support: https://github.com/gma1k/podtrace/issues
+    olm.skipRange: ">=0.11.0 <0.11.9"
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "podtrace.io/v1alpha1",
+          "kind": "TracerConfig",
+          "metadata": { "name": "default" },
+          "spec": {
+            "image": "ghcr.io/gma1k/podtrace:0.11.9",
+            "imagePullPolicy": "IfNotPresent",
+            "systemNamespace": "podtrace-system",
+            "agent": { "eventBufferSize": 10000 }
+          }
+        },
+        {
+          "apiVersion": "podtrace.io/v1alpha1",
+          "kind": "ExporterConfig",
+          "metadata": { "name": "prod-otlp", "namespace": "default" },
+          "spec": {
+            "type": "otlp",
+            "otlp": {
+              "endpoint": "otel-collector.observability:4318",
+              "protocol": "http",
+              "insecure": true
+            }
+          }
+        },
+        {
+          "apiVersion": "podtrace.io/v1alpha1",
+          "kind": "PodTrace",
+          "metadata": { "name": "watch-api", "namespace": "default" },
+          "spec": {
+            "selector": { "matchLabels": { "app": "api" } },
+            "filters": ["dns", "net"],
+            "exporterRef": { "name": "prod-otlp" }
+          }
+        },
+        {
+          "apiVersion": "podtrace.io/v1alpha1",
+          "kind": "PodTraceSession",
+          "metadata": { "name": "diag-api", "namespace": "default" },
+          "spec": {
+            "selector": { "matchLabels": { "app": "api" } },
+            "duration": "30s",
+            "filters": ["dns", "net", "fs"],
+            "exporterRef": { "name": "prod-otlp" },
+            "reportRef": { "configMap": { "name": "api-diag-report" } }
+          }
+        }
+      ]
+
+spec:
+  displayName: Podtrace
+  description: |
+    Podtrace is an eBPF-based diagnostic operator for Kubernetes that
+    surfaces low-level runtime behavior — TCP/UDP latency, DNS resolution,
+    file I/O, syscall traces, lock contention, OOM events, and
+    application-layer events (HTTP, gRPC, Postgres, MySQL, Redis,
+    Memcached, Kafka, FastCGI/PHP-FPM) — without requiring application
+    code changes or sidecars.
+
+    ## Three usage modes
+
+    Podtrace ships one operator that supports three workflows:
+
+    - **`PodTrace` CR** — continuous, realtime tracing of pods matching
+      a label selector. Events stream through a per-node agent
+      DaemonSet to a configured `ExporterConfig` (OTLP, Jaeger, Splunk
+      HEC, Datadog, or Zipkin).
+
+    - **`PodTraceSession` CR** — bounded, GitOps-driven diagnose runs.
+      The operator fans out a privileged Job per node hosting a matched
+      pod, collects events for a configured duration, and writes a
+      structured report to a `ConfigMap` or `Secret`. Equivalent to the
+      podtrace CLI's `--diagnose` mode but multi-tenant and
+      operator-managed.
+
+    - **`TracerConfig` CR** — cluster-wide tracer configuration that
+      governs the agent DaemonSet (event buffer sizes, default filters,
+      probe groups, alert thresholds, sample rates).
+
+    ## Architecture
+
+    On install the operator runs unprivileged in the
+    `podtrace-system` namespace and watches the four CRD kinds
+    cluster-wide. When a `TracerConfig` is created, the operator rolls
+    out a `podtrace-agent` DaemonSet across the cluster with the
+    minimum capabilities eBPF requires: `CAP_BPF`, `CAP_PERFMON`, and
+    `hostPID`. Per-session Jobs use a separate, narrower
+    ServiceAccount with namespaced RBAC scoped to the session's
+    target.
+
+    ## Stability
+
+    The CRDs are at `v1alpha1`; field names may change before
+    promotion to `v1beta1`. See
+    [STABILITY.md](https://github.com/gma1k/podtrace/blob/main/STABILITY.md)
+    for the project's stability statement and
+    [doc/compatibility.md](https://github.com/gma1k/podtrace/blob/main/doc/compatibility.md)
+    for the kernel and Kubernetes version compatibility matrix.
+
+    ## Prerequisites
+
+    - Linux nodes with kernel **5.8+** (BPF ring buffer)
+    - For some probes (gRPC, FastCGI, full path resolution),
+      `/sys/kernel/btf/vmlinux` must be present (BTF support)
+    - `cert-manager` is **required** if you enable the validating
+      webhook (default: enabled). The operator ships with
+      `cert-manager.io/inject-ca-from` annotations on the
+      `ValidatingWebhookConfiguration`. For air-gapped clusters
+      without cert-manager, configure self-signed webhook certs via
+      the underlying Helm chart values.
+
+    ## Resources
+
+    - [Source code & docs](https://github.com/gma1k/podtrace)
+    - [CRD reference](https://github.com/gma1k/podtrace/tree/main/doc)
+    - [Issue tracker](https://github.com/gma1k/podtrace/issues)
+
+  version: 0.11.9
+  replaces: podtrace.v0.11.8
+  maturity: alpha
+  minKubeVersion: 1.28.0
+
+  keywords:
+    - ebpf
+    - tracing
+    - observability
+    - debugging
+    - diagnostics
+    - kubernetes
+    - operator
+    - apm
+    - profiling
+    - networking
+
+  maintainers:
+    - name: Ghassan Malke
+      email: ghassan+podtrace@malke.nl
+
+  provider:
+    name: Podtrace
+    url: https://github.com/gma1k/podtrace
+
+  links:
+    - name: Source
+      url: https://github.com/gma1k/podtrace
+    - name: Documentation
+      url: https://github.com/gma1k/podtrace/tree/main/doc
+    - name: Container image
+      url: https://github.com/gma1k/podtrace/pkgs/container/podtrace
+    - name: Helm chart
+      url: https://github.com/gma1k/podtrace/pkgs/container/charts%2Fpodtrace
+
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAMAAABrrFhUAAAArlBMVEVHcEwnTmMdSWAeSV8VUG0XTWcWT2sWVXQykaoVUW4XTWgVUW4fTGMmT2U6YXM7WmoXT2oyVWgXTmk2WWsaS2QaTWcaS2QmUmgvjaNAkqMfS2IjTmQeS2NKbXpdcn0fTGODlJkxiJwujaP2+PksiZ4uiZ0vj6YtiZ4rYX4si5/j6OwuiqN4oqyOo7PI0tpjg5ixv8k/j58kdo8VVXQVVnUVU3EUUW8WV3Yzk6tDdI3CjAPRAAAAM3RSTlMAIH1H7Lbk/v76xPNzKwwH2xjQEZioijTMFFM9YAQCagEu4v6tTfNt/Yz+/gL+/v7+COnvx4bOAAAUBUlEQVR42uxciXaqSBBVEVBccAGMOxoTl7hlaBb//8emN6AbEMnJmUmbUDN5yXmKL1VU3bq3uptKpbTSSiuttNJKK6200korrbTSSiuttNJKK6200korrbTSSiuttNJKK6200kor7T+zbqcz/MPuD2eyomjt/h91X5fkpuMAp6lNun/Q/UXHaDkqNqdljhZ/zf9qTXHVyNy6Vf1jxT9wHZWz3nL4t4pfTRhoapL+J9y3O0YdxMkfR8JpGX8BCvpc8SumWWdCoPx6KOjOBnH2Q/SfzvUpUw9AHcx+c0ucs8UPXOosDIob1YTTlH8vFMDid5l0r0XpXrWYsnDqRud3tr52j/GS5z6Lkdli+kLvF7JjfaI1mTzXJnyeL7rw9SgAvqr9Mijg77Dba6dJz6Jf66lMhsjT+S/ivZbC9Lq61bHvEQTubb+lJQ6XA7fYrdX5LvE72DEq/rjzuw/6POIJ6n2oePriV2r9r5ULbBb2k4veL3uTaIkMXXhu0Quy8nnRWbanej5fhlXznFCAEA2wrS+V/fORBblR3UyHALZElxHKz9gSkz3NSLW++cggBNipmyn6b4/Yy8HzsWPEapy81qdPDYVFBynZHLqSxqrELO4ktugFeRK3K5l1B6gs8zNTo+F+m6uD55kdz6dmC2SqvjC/JbkF6Dvc0Ee/JUuLvDICzzI7rlp1557qIybFvdG73bwYKCbpWMpxS/SfYmDE895MKqfLkU+ud7168T2Wu1nVxEzQxB8YVc3mA9VXqXTCBHC93eVwvu08NwT7UTY1ZKHAEBoM5wav+jLfNEFsH/rk7U6HV2iHk+/hv1Dd2UNq6KttoYdeCohne/fYi4W88U7Xy/kVfp0v11f4dYIxAI7xWFABTeQUmIUF7Q7uStmujILkXg6vh1sTYYB7gVlw8XKdi1tidp2IYgb9LfOGGTRLPHjjYfWfr54HA3DyiHP3CR9siTS2S4FbgIYTFfSkHO6OIUB1b4fz4XDzYAAur+fzYediiJvl4IvUI/VlissGRmTNy83FKQtniXc67G7nw+V8Pb1e1csrLgHVtR5fCQbijoyX5DesT/NoMskS73qGbeCKusDJ83YHWgNaXpsnuQNaU2HHPyapgMHwcaNowtzf3U44ALddFAAlT/VVSQ24NWEl4AD/gveaWXgb8Ztg+p9hH0A0AH6DDXFHeM4kj2UQCglkUQeF0xYGqTwkq1RqmAVA4H89ny436P0VJsIZxgGLAif37rZJiSmiKoJ2gTQmAXB3lxOqfQh+p9eb510PlwtOAaedH2FSPhNBZ2AEAhw5V6+MsBJwPfV8uKnns3o7oEYIg0GCNypQY/m94geFUDGMahMQ8CAROMHu58FUOJx3VOo8IPqm+7hX/JxJBAJa0oNxEUkUFAFY+Lsd7ATnHWWQRrcI1RaVDVuUBj6CqOqARuAEu8ABNQI6FHG0R5eGYktINtwlTcoxH46wJeKGf75CLDzdbiEJ6D28sV2NNFrzKK4Udgvo9SVB88vOQ9YkYzHQmhXLMiAoG/4CUdUNvCkITYJc+h02N6vA6odEEFRENrz4ilSpaqmNkq5cZNARdhoBx0JDWp6GXYg0KoD33xkUWvvBA1UAuYZ4bDiUwrOCBaO4DmOuIn2JbfbEY8MztwAPZipmaplybEbRoiZsGIjHhuk82PnCyHKuz3Vs8Ae76EV9QiIc4dhwQZq+WL29fYvH2jDQQEQ2XFCobdeN9834W6XW9AEoXmr/nxQuBAGrdRAEjf13eFxH8R8PHX4AAgpJ4fm2ETQawXr1HcZN2q1r2EIFoJgUHr9A/6Ftv6W5hJwNk0kfeCCF396x/43N57cpt2hsOJTC+bdljwoA/v+eXQPz+VeSTSg23JV9IlPzFm0WuAICVAX7rPrYbjbbAs1NF3E2HErh5YMKgM6vYRkEL+lOON6g7NgXKA7acIRiwzNcl/6DUdUmgNm/fUF/vqUZAgKHrBfSJJpSDkmgABhugaX76jpA936PqmB/p0EEm8c4IOBseFhkSaiCSECwR4UQpGsAl0cxjmDTRXiB2DBJSj+fB39uSO7Dex2kUn2+aVArwBGo8BRoNkxgyc/nwStSAagZQtvbqRcba/yOx/c1nA0Lw4YXJri3yy2Jcqj2VzDbg/U448VNUAgGhZsN93s+3sfI8GC7O07YCqEc9m6M/Gy88T0QxWSFmGIQ4eOR/wBbXDYsEQhgePBi+5K0dSPq/xgNObhHSQEJMmoFET6u9vwHbOcJ4u0Lw4ZrBAIYHoxkbyPgrRHdXYwGHNzvCfwt8HecG8fVC3cpRIj4gqoiFBvW00tCoeohhmPB9DjcD4ItTwLwi6gZktzo4jph7eMt71/8USmcvh+rdeh7wKTC+/YYQ14QS8JF5PdnGInKFvOCgIkCmzI1odjwJIMHv21SIPCyeZuznDB26Bij4hblyzYkhu/c1TZLPPwE6ggghTlitvgcj7vkvy76gj98Mk1rQ/1kGALpiytKBfa4Yt7G6FPIJ33ybBgHAAjBhsnWV1iQd2ZUdrYuDGLKgwdlhBl9otC8b7eIF+WQQp38m74QkrhPBhTOoHhBHvtYEq5ijtyg/GeOqQAp+pdxzlDETzaeH1RChJeprllcnNh7BI37BEdmx4ZRSDITwKAbpwdC7BwnkAy1UNsufA3Gfeo0HpSF/O+4DRMgZzZC9xcAQbZM9mUagXpxUB7HY5ExPyEZb0jvzFk+CZeWHVmQowOdnkMzsvhyzT6URlwy4Ajs1+/rl20OANCacwbCrA5NyDkxH9y/JXq/P0yyf+y2vU9OAY7j1Spn9axL5yFAEWcmtqg16YGeO9tc+ktz0BuYkyGn/xDtX4zXqTnQPFfmtikAtL4AOf89FzApDGRvdJpqqo9N7nATgGBzrLzxtPix9CRrg6prCLVJpEP3/mVudRsN/NDissVyYb06boIvrZVFAKAJtlEsPA3qyP10evixRWSBTAG3VTwLW3011RxFuH1itDerjpVMzUkLea4ZuA4i/YI5X2ODZ2GJWbg+HOr5YFNoT+H/PRUIwbmVWB6yDei3agwrQwNFIBqdV/GMbM0rfVRNbXmgye3MR+1M6IP4XEvAMxN9uvfPT2RnV4Nu44FxR0E4GNXAPlT6LOmfz3oA10pvqWcgDbhXZyLYqEfZAL/neYgCgFVLH4FhvHoUjY2YZSJ72QrRopW6y3166trpCXp2ckZgwHe4Xe9dOSz9aR1lQOTW8CWteqawyfk+wEmQrHPdCs+OCnpipGKHfIiXRZbj+85gUpU09AMzw9imKmCB8MKvy2ZP5ZKFxtcnpypqwp6cHNImBThZBG88wkaljp2bJieHH1t2toDeMtOPowFMAn7sPQ0ZkCnwIwRCPsRNR+ZWE/7qpLB5rrxFKLBm3jqCQQJ41tt2VZ/bbhDur/7K4OUn+BDtU47JpO/QgMiGI6CaHHyjFPhgFgOP01ZYJJMmDECb7bLUf0US2f+K3Q6fhVZjbnV3NkD+g7rFV/Vq/fHxweqATp2W/sJyYbhmLM8iH9ta2kIHIBKrPg/VnR6G9QR6JQNg45bpG6NqG0WCGbSHMxDBJFC2WqF8iGvWXQ2CWurE5+ofFADWpTbKFLWuNNF22Hi1OTxn9fhYlQA2zZJFOACpHQ0oADcuAHjGjtECMK1EYAmUw4c4wo4Olvtuclyy+ud2+9C4pK6pYceoLxexBAKiSqBMWWRlTEfQJhLoAIdgxw4KALu4sZjB2kcBQE/OmscSiDCAQseqhJBFcno60kFLGUkSCwOwuzEBwP77flOTrUmfuVSwIXBhWcSNbXBhAIXvDbsdGwAb+q9i6cze6WEkgZ7okXqhblfjrjVHhQw7gZQIwC4OgKQgvpR4VtTccgWXQHmTG5WZjug1nAM9VgwobACqSO0n/Y8gVWAJlCuLmMYVRoABBsXfxfp46aL7b/FSZ9oD4kugTD4UjokZ6vJpNfHfhMBgkxERDcARHTpxEn72n0MCZcoiyodcZjrSxRGID79zAdBlP/UEHl3AVaDCsmhJ2IvPPhWibzoQCaNTBekAJHb9LMMZSLvyfJa5hie1AIiPOiQCAGCr6/OsGqSy6JlgQKOMkIGBjgKAE+0mQgFw4gA4iQAIuwpUWBaFFC5GNrSljg0Akw8oANyhIwgA/hNJoBxZ5KvRkLSKOGLBAIT7QJ5EAmVZyOLi6Qg68nU3AwAXAPqkESiBnvgR+0O8ewZ6qbRH/7Z3pc2N4kA03CXumyoOww/IN4T5//9s1d2SjB1nZiu77CZjvZpJGYFleLTu1mtELxrHtRw6eeSKU6E8GkKoBB15qhvVeML70VEW1GJWwCIXQDN7Ln3Go5W5dIoEIyMXD6OIBd/ND+YfDos4TPKoz3Coj/YVFoK0GuvKQXSb/j2sMPxEvNuMB18GZ9/JD+aL/aFm+1uP+jT1xw2BnveHvmwCP2IS+PdzA13Itut1k/8Vtk0dbcfk6yaPxV/m/SFBx4re/gri/pVDEhsYGBgYGBgYGPwxyPo4jmfrdQmwfBjkxK9LAC6C6I1+WWFZxatZwB7sygIcr/T9Jn1dAtrrzvewejkCAkUA7Lblr0XA5UjA8oIEgAXs+9EC9vDn1QGXyrIscduT5fTOUCz3J4vBcZyueHDlSRNxbZLdisB7VVUtWoAlPhUV5JIWBX6oRBZqt1SaUH4PvoFVIlIdK/3wK+LaajmZAKfM87yekjqPGIvKYzi9bKhLkcjcsj6GkK1GzxepfjOgECQQMIRlCd4jPCoBYQKOhSLf0MpmyIIMw4o9H37kPr8lsUNX5Bf5YXzoU1l26OO17clBOeONi8q7l+GU96DUyzZF7fJdOrlGtb63hOIv7jv3bUXAfNWrQJyvHGQBE3fn3B1oYwV6y/dloPda3pzsszmXCwgii1Itmk8jpYKHsR+fWq5A2Xz1YdVS+S7Km7CkhIB06PAkA8pFAtzfcFUQCIjvFkp2IoBDbGESpAILGOV2dKJUOR1Ptlwwl36oRP+kdlPjxeeuJaO0O0RFiFy2HXw3Mlr9EZYZbQePCBVORSUjAcssjJVWPhnAlQQEO3oEo8uM1E2NfJet+02ZgXZNbcylX5fuZrT6yFy4+NPt2/8mAcIGWqdz6H0x9Pga4adX3x4Sp4VVfU7JPfoFRrWTDHGuCHgrRHUFhPG8h+oMIi4jAWjCkes2ExQ18fiNkyS9B14iHFWUyfOOeWPXjaGWbkJHOu63g9XNwBs/06EOrVfu2pnQgQM3NaCMinRlXcADgETmUfBqZTFW4x3e/ScdoUTGJigFhZ24/z50N2n3BeS9o24cxrLbaDMSynZgDiBnqpxI0DWPzScToLQ80e5R1nGAmKhrfVHdXKmwjI+l/Rtm9lsCGv3u0i5WNel8lVKNqB2kQ1GBgl0kygCFnGhkwYfm9czoE+j0r30ZUUILRM7tu2QMNQHDPlS+1FvfUAbyk54gEsDvvcFV8+8wKZyH2kFaPy1t29GxFhIy00rrcEvriQpjUAfcfBkT+aQXMIVVqxtigQC1R3xKvflR9wOeWsAOzoB3yhlT0Tn9bNsNk00FCpfedtItN0sIWNMS4OIztUbRArQfE0pIbfVbBtXQzfAmNFVxCI6St9B4+AJ/ZQF3okDF2OSuaCzWVbeVZHCPPvOkaBxsCBLZO1Fn8YEA8P/ZGgq1umltv3dQGF3DFJ2fnxPwtA44zBYtTsjAp5Y2m0oC8FE/qCnHH9wvztSYg1/bHwioiQCuCViOBARPCbjQYOiBgFvtjS1JsG7oWfVLAhZqmdkR7nkWMN9ZgCWLQPqkCKxhtpAFJJ/XAemRgP1GgGzwQ7t3ugQ6E78oAnhL7ugcMKTnFgH9TlV1n2GbfKsEqWS8k/br00rw8rQIaAKg5QsYjQAu8CuHSlBXFFKLH+v9/0xiGYuAfqRZvRLd8iP0jWJwQF2yO/fRAm6quA8E1MezEMUQCUAGV9XiT3Zj98kE+80PzeBSpKcTEFzlS6ioY5JAU40dIbo13OOAdHQwotmUpzd999gK3ISo7wl4bw7dmQXtCAggEUVVwDt/D5joOVAvVPW2kjBs+7O7wtzv4d4q2v8CbwS7qzzCkWgaY7cQesgUgJDVBS6LoOevsmBU4NtwG1S2PLcA6vJlOC5ECyCL28JuUcNP7CHbVF6Q5sQTgwhWT+cSIMq1Z8+2h88f9VQYkAEv7mMP3V8puafxUmjPcUPjW2U9WKHtbj3PbZN8IIBq9nAchrGJVh1LQAaZytuxt0stsI/+5zwI475v87MD8KhGd92u1Om4kt3LzSGi3cLQgavc46p2/ICDnIwsaB/aRDxxVfMBh35AJ4NTRxHbOLtV/tLtdmOMIq7RuI988lfR/m2n+1YiAZGrYgXyTW4QvxQ08yPp0Vv/lNQijvTgTemgCDbbZR7RRwKW9uZeyzx477L1m91Dt2eTEyKX2F0PvrWedXIlyPOx3Dhgc2tdj1d2DuHz0ArKOT3MlEEyX1k4eLA2qHSkqjpaMROaEvOFSR16glUrvsYhCl9Ui9K+rZKASfQQZZS+LWpUHTr1IpWL7NaV+XZxejOYF5bt5X4e1sNx3zcoYPl+XjZ3K8DZUId5nntz8dbXdd3qTlrm1GUurg+h+spGMZCxD4PBSZyFzGBCtK+bulV5Vr3ID7/mHCydUvPSi5Pp9GYQe4JpYVnp4xw0LHha1eMdLJVlFdlnc+xF+slMNnzNqmiK4f14zZI++xqlnr615H4w9IIwBGzfRc3ZWIAhwBSB/wMzTLiUL0xA4fRj313eDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDL4x/gJWHdaEWQfzgAAAAABJRU5ErkJggg==
+      mediatype: image/png
+
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+
+  customresourcedefinitions:
+    owned:
+      - name: tracerconfigs.podtrace.io
+        version: v1alpha1
+        kind: TracerConfig
+        displayName: Tracer Config
+        description: |
+          Cluster-wide tracer configuration that governs the agent
+          DaemonSet — event buffer sizes, default filters, probe
+          groups, alert thresholds, and sample rates. Exactly one
+          `default` instance is typically created per cluster.
+        resources:
+          - kind: DaemonSet
+            version: apps/v1
+          - kind: ConfigMap
+            version: v1
+
+      - name: exporterconfigs.podtrace.io
+        version: v1alpha1
+        kind: ExporterConfig
+        displayName: Exporter Config
+        description: |
+          Endpoint and credential configuration for distributed-tracing
+          exporters (OTLP, Jaeger, Splunk HEC, Datadog, Zipkin).
+          Referenced by `PodTrace` and `PodTraceSession` resources via
+          `spec.exporterRef`.
+        resources:
+          - kind: Secret
+            version: v1
+          - kind: ConfigMap
+            version: v1
+
+      - name: podtraces.podtrace.io
+        version: v1alpha1
+        kind: PodTrace
+        displayName: Pod Trace
+        description: |
+          Continuous, realtime tracing intent over a set of pods.
+          Selectors and explicit pod refs route events through the
+          agent DaemonSet to the referenced `ExporterConfig`. Stays
+          active until the resource is deleted.
+        resources:
+          - kind: Pod
+            version: v1
+          - kind: DaemonSet
+            version: apps/v1
+
+      - name: podtracesessions.podtrace.io
+        version: v1alpha1
+        kind: PodTraceSession
+        displayName: Pod Trace Session
+        description: |
+          Bounded diagnose run over a set of pods. The operator
+          fans out one privileged Job per node hosting a matched
+          pod, collects events for the configured duration, and
+          writes a structured report to a `ConfigMap` or `Secret`.
+          Reaches `phase: Completed` when all child Jobs finish.
+        resources:
+          - kind: Job
+            version: batch/v1
+          - kind: ConfigMap
+            version: v1
+          - kind: Secret
+            version: v1
+
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+        - serviceAccountName: podtrace-operator
+          rules:
+            - apiGroups: ["podtrace.io"]
+              resources: ["tracerconfigs", "podtraces", "podtracesessions", "exporterconfigs"]
+              verbs: ["get", "list", "watch", "update", "patch", "delete"]
+            - apiGroups: ["podtrace.io"]
+              resources: ["tracerconfigs/status", "podtraces/status", "podtracesessions/status", "exporterconfigs/status"]
+              verbs: ["get", "update", "patch"]
+            - apiGroups: ["podtrace.io"]
+              resources: ["tracerconfigs/finalizers", "podtraces/finalizers", "podtracesessions/finalizers"]
+              verbs: ["update"]
+            - apiGroups: ["apps"]
+              resources: ["daemonsets"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            - apiGroups: ["batch"]
+              resources: ["jobs"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: [""]
+              resources: ["serviceaccounts", "configmaps", "secrets"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            - apiGroups: ["rbac.authorization.k8s.io"]
+              resources: ["clusterroles", "clusterrolebindings"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            - apiGroups: ["rbac.authorization.k8s.io"]
+              resources: ["roles", "rolebindings"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+            - apiGroups: [""]
+              resources: ["events"]
+              verbs: ["get", "list", "watch", "create", "patch"]
+            - apiGroups: ["events.k8s.io"]
+              resources: ["events"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["coordination.k8s.io"]
+              resources: ["leases"]
+              verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+      deployments:
+        - name: podtrace-operator
+          spec:
+            replicas: 1
+            strategy:
+              type: RollingUpdate
+              rollingUpdate:
+                maxUnavailable: 1
+                maxSurge: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: podtrace
+                app.kubernetes.io/component: operator
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: podtrace
+                  app.kubernetes.io/component: operator
+              spec:
+                serviceAccountName: podtrace-operator
+                securityContext:
+                  runAsNonRoot: true
+                  runAsUser: 65532
+                  fsGroup: 65532
+                containers:
+                  - name: operator
+                    image: ghcr.io/gma1k/podtrace:0.11.9
+                    imagePullPolicy: IfNotPresent
+                    args:
+                      - operator
+                      - --system-namespace=podtrace-system
+                      - --leader-elect=true
+                      - --leader-elect-namespace=podtrace-system
+                      - --metrics-addr=:8080
+                      - --health-addr=:8081
+                    env:
+                      - name: POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    ports:
+                      - name: metrics
+                        containerPort: 8080
+                        protocol: TCP
+                      - name: health
+                        containerPort: 8081
+                        protocol: TCP
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: health
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: health
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 128Mi
+                      limits:
+                        cpu: 500m
+                        memory: 512Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                        drop: ["ALL"]

--- a/operators/podtrace/0.11.9/manifests/podtrace.io_exporterconfigs.yaml
+++ b/operators/podtrace/0.11.9/manifests/podtrace.io_exporterconfigs.yaml
@@ -1,0 +1,287 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
+  name: exporterconfigs.podtrace.io
+spec:
+  group: podtrace.io
+  names:
+    categories:
+    - podtrace
+    kind: ExporterConfig
+    listKind: ExporterConfigList
+    plural: exporterconfigs
+    shortNames:
+    - ec
+    singular: exporterconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    - jsonPath: .status.referencedBy
+      name: Refs
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ExporterConfig is a reusable trace exporter configuration referenced by
+          PodTrace and PodTraceSession. It decouples endpoint/credential management
+          from trace intent.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ExporterConfigSpec configures a reusable trace exporter.
+              Exactly one of the typed fields (OTLP, Jaeger, Zipkin, Splunk, DataDog)
+              must be populated, and it must match the Type field.
+            properties:
+              datadog:
+                description: DataDogExporter configures the DataDog exporter.
+                properties:
+                  apiKeySecretRef:
+                    description: |-
+                      APIKeySecretRef references the DataDog API key in a Secret in the
+                      same namespace as the ExporterConfig.
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  site:
+                    description: Site, e.g. "datadoghq.com" or "datadoghq.eu". Defaults
+                      to datadoghq.com.
+                    type: string
+                required:
+                - apiKeySecretRef
+                type: object
+              jaeger:
+                description: JaegerExporter configures the Jaeger exporter.
+                properties:
+                  endpoint:
+                    description: Endpoint, e.g. "http://jaeger-collector.observability:14268/api/traces".
+                    type: string
+                required:
+                - endpoint
+                type: object
+              otlp:
+                description: OTLPExporter configures the OpenTelemetry OTLP exporter.
+                properties:
+                  endpoint:
+                    description: Endpoint of the OTLP receiver, e.g. "otel-collector.observability:4318".
+                    type: string
+                  headers:
+                    description: |-
+                      Headers to attach to every export request. Secret-backed headers use
+                      the HeadersFromSecret field.
+                    items:
+                      description: OTLPHeader is a single literal or secret-backed
+                        OTLP header.
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          description: SecretKeySelector selects a key from a Secret
+                            in the same namespace.
+                          properties:
+                            key:
+                              type: string
+                            name:
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  headersFromSecret:
+                    description: |-
+                      HeadersFromSecret pulls additional headers from a Secret in the same
+                      namespace. Each key in the secret becomes a header; values are used verbatim.
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  insecure:
+                    description: Insecure disables TLS. Do not use in production.
+                    type: boolean
+                  protocol:
+                    description: Protocol selects http or grpc. Defaults to http.
+                    enum:
+                    - http
+                    - grpc
+                    type: string
+                required:
+                - endpoint
+                type: object
+              samplePercent:
+                description: |-
+                  SamplePercent sets an exporter-level sampling rate cap, 0-100.
+                  If both this and the referent trace's SamplePercent are set, the minimum applies.
+                format: int32
+                maximum: 100
+                minimum: 0
+                type: integer
+              splunk:
+                description: SplunkExporter configures the Splunk HEC exporter.
+                properties:
+                  endpoint:
+                    description: Endpoint of the Splunk HEC receiver.
+                    type: string
+                  tokenSecretRef:
+                    description: |-
+                      TokenSecretRef references the Splunk HEC token in a Secret in the
+                      same namespace as the ExporterConfig.
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                required:
+                - endpoint
+                - tokenSecretRef
+                type: object
+              type:
+                description: Type selects the exporter implementation.
+                enum:
+                - otlp
+                - jaeger
+                - zipkin
+                - splunk
+                - datadog
+                type: string
+              zipkin:
+                description: ZipkinExporter configures the Zipkin exporter.
+                properties:
+                  endpoint:
+                    description: Endpoint, e.g. "http://zipkin.observability:9411/api/v2/spans".
+                    type: string
+                required:
+                - endpoint
+                type: object
+            required:
+            - type
+            type: object
+          status:
+            description: ExporterConfigStatus reports the observed state of an ExporterConfig.
+            properties:
+              conditions:
+                description: Conditions is the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed.
+                format: int64
+                type: integer
+              ready:
+                description: Ready is true when referenced Secrets exist and credentials
+                  validate.
+                type: boolean
+              referencedBy:
+                description: ReferencedBy counts how many PodTraces and PodTraceSessions
+                  reference this exporter.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/podtrace/0.11.9/manifests/podtrace.io_podtraces.yaml
+++ b/operators/podtrace/0.11.9/manifests/podtrace.io_podtraces.yaml
@@ -1,0 +1,383 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
+  name: podtraces.podtrace.io
+spec:
+  group: podtrace.io
+  names:
+    categories:
+    - podtrace
+    kind: PodTrace
+    listKind: PodTraceList
+    plural: podtraces
+    shortNames:
+    - pt
+    singular: podtrace
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.matchedPods
+      name: Matched
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.exporterRef.name
+      name: Exporter
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PodTrace is a continuous realtime eBPF trace over a dynamic set
+          of pods.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              PodTraceSpec defines a continuous, realtime tracing intent over a set of pods.
+              PodTrace is the continuous-observability counterpart of PodTraceSession: it
+              has no bounded duration and remains active until the resource is deleted or
+              paused. Agents on each node watch PodTrace resources and feed matching pods
+              into their local tracer.
+            properties:
+              containerName:
+                description: |-
+                  ContainerName restricts tracing to a specific container within each
+                  matched pod. If empty, the first container is used.
+                type: string
+              exporterRef:
+                description: ExporterRef names an ExporterConfig in the same namespace.
+                  Required.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              filters:
+                description: |-
+                  Filters restricts the event categories captured. When empty, all
+                  categories are captured.
+                items:
+                  description: EventFilter enumerates the event categories podtrace
+                    can capture.
+                  enum:
+                  - dns
+                  - net
+                  - fs
+                  - cpu
+                  - proc
+                  type: string
+                type: array
+              namespaceSelector:
+                description: |-
+                  NamespaceSelector scopes the Selector across namespaces. When unset
+                  the selector is evaluated within the PodTrace's own namespace only.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: Paused suspends tracing for this resource without deleting
+                  it.
+                type: boolean
+              podRefs:
+                description: PodRefs explicitly enumerates target pods.
+                items:
+                  description: PodRef references a specific pod by namespace/name.
+                  properties:
+                    name:
+                      description: Name is the name of the pod.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the pod. If empty, defaults to the
+                        namespace of the owning CR (for namespaced CRs).
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              samplePercent:
+                description: SamplePercent sets the sampling rate for exported traces,
+                  0-100.
+                format: int32
+                maximum: 100
+                minimum: 0
+                type: integer
+              selector:
+                description: |-
+                  Selector picks target pods by label. Mutually exclusive with PodRefs;
+                  exactly one of the two must be set.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              thresholds:
+                description: Thresholds override the agent's default anomaly-detection
+                  settings.
+                properties:
+                  errorRatePercent:
+                    description: |-
+                      ErrorRatePercent triggers issue detection when errors exceed this
+                      percentage over the rolling window. 0-100.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
+                  fsSlowMs:
+                    description: |-
+                      FSSlowMs triggers issue detection when a filesystem operation takes
+                      longer than this value in milliseconds.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  rttSpikeMs:
+                    description: |-
+                      RTTSpikeMs triggers issue detection when network RTT exceeds this
+                      value in milliseconds.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
+            required:
+            - exporterRef
+            type: object
+          status:
+            description: PodTraceStatus reflects the observed state of a PodTrace.
+            properties:
+              conditions:
+                description: |-
+                  Conditions is the latest available observations of the PodTrace state.
+                  Common types: Ready, Reconciled, Paused, Degraded.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              matchedPods:
+                description: MatchedPods is the total number of pods currently matched
+                  across all nodes.
+                format: int32
+                type: integer
+              nodeStatus:
+                description: |-
+                  NodeStatus aggregates per-node agent reports. Agents patch their own
+                  entry every StatusReportInterval (see TracerConfig).
+                items:
+                  description: PodTraceNodeStatus reports one agent's view of this
+                    PodTrace.
+                  properties:
+                    activeCgroups:
+                      description: ActiveCgroups is the count of cgroups the agent
+                        is currently tracing for this PodTrace.
+                      format: int32
+                      type: integer
+                    droppedEvents:
+                      description: |-
+                        DroppedEvents counts events that were produced by the kernel but could
+                        not be forwarded to an exporter (buffer full or exporter backpressure).
+                      format: int64
+                      type: integer
+                    eventsTotal:
+                      description: |-
+                        EventsTotal is the cumulative number of events captured by this agent
+                        for this PodTrace since the agent last started.
+                      format: int64
+                      type: integer
+                    lastHeartbeat:
+                      description: LastHeartbeat is the time this entry was last updated
+                        by its agent.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Message provides human-readable detail, typically
+                        an error cause when Ready is false.
+                      type: string
+                    node:
+                      description: Node is the name of the node reporting this status.
+                        Unique within the array.
+                      type: string
+                    ready:
+                      description: Ready indicates the agent has successfully attached
+                        to the local matched cgroups.
+                      type: boolean
+                  required:
+                  - activeCgroups
+                  - droppedEvents
+                  - eventsTotal
+                  - lastHeartbeat
+                  - node
+                  - ready
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - node
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this PodTrace.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/podtrace/0.11.9/manifests/podtrace.io_podtracesessions.yaml
+++ b/operators/podtrace/0.11.9/manifests/podtrace.io_podtracesessions.yaml
@@ -1,0 +1,491 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
+  name: podtracesessions.podtrace.io
+spec:
+  group: podtrace.io
+  names:
+    categories:
+    - podtrace
+    kind: PodTraceSession
+    listKind: PodTraceSessionList
+    plural: podtracesessions
+    shortNames:
+    - pts
+    singular: podtracesession
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.duration
+      name: Duration
+      type: string
+    - jsonPath: .spec.exporterRef.name
+      name: Exporter
+      type: string
+    - jsonPath: .status.summary.totalEvents
+      name: Events
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          PodTraceSession is a bounded, diagnose-mode trace. Running a session
+          creates one privileged Job per node hosting a matched pod, each invoking
+          `podtrace --diagnose <duration>` against the local subset.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              PodTraceSessionSpec defines a bounded diagnose-mode trace. The operator
+              reconciles this into one privileged Job per node hosting matched pods.
+            properties:
+              containerName:
+                description: ContainerName restricts tracing to a specific container.
+                type: string
+              duration:
+                description: |-
+                  Duration is the total wall-clock time the session should run. Required.
+                  Format: Go duration, e.g. "30s", "5m". Maximum is enforced by the
+                  operator against TracerConfig.spec.session.maxDuration.
+                type: string
+              exporterRef:
+                description: ExporterRef names an ExporterConfig in the same namespace.
+                  Required.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              filters:
+                description: Filters restricts the event categories captured. When
+                  empty, all are captured.
+                items:
+                  description: EventFilter enumerates the event categories podtrace
+                    can capture.
+                  enum:
+                  - dns
+                  - net
+                  - fs
+                  - cpu
+                  - proc
+                  type: string
+                type: array
+              namespaceSelector:
+                description: |-
+                  NamespaceSelector scopes the Selector across namespaces. When unset
+                  the selector is evaluated within the session's own namespace only.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              podRefs:
+                description: PodRefs explicitly enumerates target pods.
+                items:
+                  description: PodRef references a specific pod by namespace/name.
+                  properties:
+                    name:
+                      description: Name is the name of the pod.
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the pod. If empty, defaults to the
+                        namespace of the owning CR (for namespaced CRs).
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              reportRef:
+                description: |-
+                  ReportRef points at where the diagnose report summary should be persisted.
+                  If unset, only the exporter receives events and the session status
+                  retains a small inline summary.
+                properties:
+                  configMap:
+                    description: |-
+                      ConfigMap in the same namespace as the session. The operator will
+                      create/update it with the report payload. Use this sink for small
+                      reports; ConfigMaps are capped at 1MiB of data by etcd.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  objectStore:
+                    description: |-
+                      ObjectStore uploads the report to a cloud bucket (s3, gs, az). Use
+                      this sink for reports that may exceed the 1MiB ConfigMap/Secret
+                      limit. Rejected by the validating webhook in v1alpha1 — the
+                      schema is reserved so clients can adopt it without a CRD bump
+                      later.
+                    properties:
+                      credentialsSecretRef:
+                        description: |-
+                          CredentialsSecretRef names a Secret in the session's namespace
+                          whose keys the uploader reads (e.g. "access_key_id",
+                          "secret_access_key"). Implementation-specific — interpretation is
+                          left to the CLI uploader.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      uri:
+                        description: URI of the destination, e.g. "s3://bucket/path/"
+                          or "gs://bucket/path/".
+                        type: string
+                    required:
+                    - uri
+                    type: object
+                  secret:
+                    description: |-
+                      Secret in the same namespace as the session. Prefer this sink when the
+                      report may contain sensitive hostnames/paths/payloads.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+              samplePercent:
+                description: SamplePercent sets the sampling rate for exported traces,
+                  0-100.
+                format: int32
+                maximum: 100
+                minimum: 0
+                type: integer
+              selector:
+                description: Selector picks target pods by label. Mutually exclusive
+                  with PodRefs.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              thresholds:
+                description: Thresholds override the session's default anomaly-detection
+                  settings.
+                properties:
+                  errorRatePercent:
+                    description: |-
+                      ErrorRatePercent triggers issue detection when errors exceed this
+                      percentage over the rolling window. 0-100.
+                    format: int32
+                    maximum: 100
+                    minimum: 0
+                    type: integer
+                  fsSlowMs:
+                    description: |-
+                      FSSlowMs triggers issue detection when a filesystem operation takes
+                      longer than this value in milliseconds.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  rttSpikeMs:
+                    description: |-
+                      RTTSpikeMs triggers issue detection when network RTT exceeds this
+                      value in milliseconds.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
+              ttlSecondsAfterFinished:
+                description: |-
+                  TTLSecondsAfterFinished cleans up the session resource after completion.
+                  If unset, the operator default applies.
+                format: int32
+                minimum: 0
+                type: integer
+            required:
+            - duration
+            - exporterRef
+            type: object
+          status:
+            description: PodTraceSessionStatus reflects the observed state of a PodTraceSession.
+            properties:
+              completionTime:
+                description: CompletionTime is set when all child Jobs have finished.
+                format: date-time
+                type: string
+              conditions:
+                description: Conditions is the latest available observations of session
+                  state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              jobs:
+                description: Jobs lists the per-node Job children managed by this
+                  session.
+                items:
+                  description: SessionJobRef describes a child Job created by the
+                    session reconciler.
+                  properties:
+                    completed:
+                      description: Completed indicates whether the Job has finished
+                        (success or failure).
+                      type: boolean
+                    completionTime:
+                      description: CompletionTime of the Job's pod, if finished.
+                      format: date-time
+                      type: string
+                    eventCount:
+                      description: EventCount is the number of events this Job's tracer
+                        reported.
+                      format: int64
+                      type: integer
+                    message:
+                      description: Message carries Job-level error text when Completed
+                        is true and the Job failed.
+                      type: string
+                    name:
+                      description: Name of the Job resource.
+                      type: string
+                    node:
+                      description: Node the Job is pinned to. Unique within the array.
+                      type: string
+                    startTime:
+                      description: StartTime of the Job's pod.
+                      format: date-time
+                      type: string
+                  required:
+                  - completed
+                  - name
+                  - node
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - node
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this session.
+                format: int64
+                type: integer
+              phase:
+                description: Phase is the high-level state of the session.
+                enum:
+                - Pending
+                - Running
+                - Completed
+                - Failed
+                type: string
+              startTime:
+                description: StartTime is set when the first child Job enters Running.
+                format: date-time
+                type: string
+              summary:
+                description: Summary is a compact per-category event roll-up for this
+                  session.
+                properties:
+                  cpuEvents:
+                    format: int64
+                    type: integer
+                  dnsEvents:
+                    format: int64
+                    type: integer
+                  errorsDetected:
+                    format: int32
+                    type: integer
+                  fsEvents:
+                    format: int64
+                    type: integer
+                  netEvents:
+                    format: int64
+                    type: integer
+                  procEvents:
+                    format: int64
+                    type: integer
+                  totalEvents:
+                    format: int64
+                    type: integer
+                required:
+                - totalEvents
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/podtrace/0.11.9/manifests/podtrace.io_tracerconfigs.yaml
+++ b/operators/podtrace/0.11.9/manifests/podtrace.io_tracerconfigs.yaml
@@ -1,0 +1,1340 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+    helm.sh/resource-policy: keep
+  name: tracerconfigs.podtrace.io
+spec:
+  group: podtrace.io
+  names:
+    categories:
+    - podtrace
+    kind: TracerConfig
+    listKind: TracerConfigList
+    plural: tracerconfigs
+    shortNames:
+    - tc
+    singular: tracerconfig
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.desiredAgents
+      name: Desired
+      type: integer
+    - jsonPath: .status.readyAgents
+      name: Ready
+      type: integer
+    - jsonPath: .status.activeSessions
+      name: Sessions
+      type: integer
+    - jsonPath: .spec.image
+      name: Image
+      priority: 1
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          TracerConfig is the cluster-wide infrastructure configuration for the
+          podtrace operator. A single TracerConfig named "default" governs the
+          fleet-wide DaemonSet and Session Jobs.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              TracerConfigSpec configures the tracer infrastructure. It is cluster-scoped
+              because it governs a fleet-wide DaemonSet and the Jobs the operator spawns.
+            properties:
+              affinity:
+                description: Affinity applied to agent and session pods.
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node matches the corresponding matchExpressions; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: |-
+                            An empty preferred scheduling term matches all objects with implicit weight 0
+                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to an update), the system
+                          may or may not try to eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: |-
+                                A null or empty node selector term matches no objects. The requirements of
+                                them are ANDed.
+                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the anti-affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and subtracting
+                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the anti-affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the anti-affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              agent:
+                description: Agent configures the DaemonSet that provides realtime
+                  tracing.
+                properties:
+                  eventBufferSize:
+                    description: EventBufferSize is the per-agent event channel capacity.
+                      Default 10000.
+                    format: int32
+                    minimum: 128
+                    type: integer
+                  logLevel:
+                    description: 'LogLevel applied to agent pods. One of: debug, info,
+                      warn, error.'
+                    enum:
+                    - debug
+                    - info
+                    - warn
+                    - error
+                    type: string
+                  priorityClassName:
+                    description: |-
+                      PriorityClassName applied to agent pods. Defaults to system-node-critical
+                      when unset and the priority class exists on the cluster.
+                    type: string
+                  resources:
+                    description: Resources applied to each agent pod.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  statusReportInterval:
+                    description: |-
+                      StatusReportInterval controls how often each agent patches PodTrace
+                      status.nodeStatus. Default 30s.
+                    type: string
+                type: object
+              btfMode:
+                description: BTFMode controls how the agent resolves BTF.
+                enum:
+                - auto
+                - host
+                - embedded
+                type: string
+              image:
+                description: Image for both the agent DaemonSet and session Job pods.
+                type: string
+              imagePullPolicy:
+                description: ImagePullPolicy. Defaults to IfNotPresent.
+                type: string
+              imagePullSecrets:
+                description: ImagePullSecrets referenced by agent and session pods.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              maxConcurrentSessionsPerNode:
+                description: |-
+                  MaxConcurrentSessionsPerNode caps privileged Job pods per node.
+                  Defaults to 2.
+                format: int32
+                minimum: 1
+                type: integer
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector applied to agent and session pods.
+                type: object
+              session:
+                description: Session configures per-session Job pods spawned for PodTraceSession
+                  CRs.
+                properties:
+                  activeDeadlineSecondsOffset:
+                    description: |-
+                      ActiveDeadlineSecondsOffset is added to spec.duration to compute the
+                      Job's activeDeadlineSeconds (giving the Job grace to finish reporting).
+                      Default 30.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  backoffLimit:
+                    description: BackoffLimit for the Job. Default 0 (fail fast).
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  maxDuration:
+                    description: |-
+                      MaxDuration caps spec.duration on any PodTraceSession reconciled against
+                      this TracerConfig. If unset, no cap is enforced by the operator.
+                    type: string
+                  resources:
+                    description: Resources applied to each session Job pod.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  sidecarUploader:
+                    type: boolean
+                  ttlSecondsAfterFinished:
+                    description: |-
+                      TTLSecondsAfterFinished default applied to session Jobs when a session
+                      does not specify its own. Default 300.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
+              systemNamespace:
+                description: |-
+                  SystemNamespace is the namespace in which the operator creates the
+                  agent DaemonSet, session Jobs, and resolved exporter bundles.
+                  Defaults to "podtrace-system". Must be a Pod-Security-Admission
+                  "privileged" namespace.
+                type: string
+              tolerations:
+                description: Tolerations applied to agent and session pods.
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - image
+            type: object
+          status:
+            description: TracerConfigStatus reflects the observed state of a TracerConfig.
+            properties:
+              activeSessions:
+                description: ActiveSessions is the number of PodTraceSession Jobs
+                  currently Running.
+                format: int32
+                type: integer
+              conditions:
+                description: Conditions is the latest available observations.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              desiredAgents:
+                description: DesiredAgents is the number of nodes the agent DaemonSet
+                  targets.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed.
+                format: int64
+                type: integer
+              readyAgents:
+                description: ReadyAgents is the number of agent pods currently Ready.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/podtrace/0.11.9/metadata/annotations.yaml
+++ b/operators/podtrace/0.11.9/metadata/annotations.yaml
@@ -1,0 +1,19 @@
+annotations:
+  # Bundle layout
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+
+  # Package + channels
+  operators.operatorframework.io.bundle.package.v1: podtrace
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+
+  # OperatorHub.io categories. These determine where podtrace appears
+  # in the OperatorHub UI's category sidebar.
+  operatorhub.io/categories: "Monitoring,Developer Tools"
+
+  # Tooling provenance (informational; reviewers may inspect it)
+  operators.operatorframework.io.metrics.builder: helm-render+hand-authored-csv
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1


### PR DESCRIPTION
First-class auto-submission for podtrace 0.11.9, generated by
`scripts/submit-olm-bundle.sh` from the gma1k/podtrace release pipeline.

### Submission details

| Field | Value |
|---|---|
| Bundle path | `operators/podtrace/0.11.9/` |
| Operator image | `ghcr.io/gma1k/podtrace:0.11.9` (cosign keyless signed) |
| `updateGraph` | `replaces-mode` (per existing `operators/podtrace/ci.yaml`) |
| Replaces | `podtrace.v0.11.8` |
| Channels | `stable` (default) |
| Install modes | `AllNamespaces` only |
| Maintainer | Ghassan Malke (`gma1k`) |

### Local validation
- `operator-sdk bundle validate ./bundle/0.11.9 --select-optional name=community` ✓
- `operator-sdk bundle validate ./bundle/0.11.9 --select-optional name=operatorhub` ✓
- End-to-end on kind: `operator-sdk run bundle` reaches `Succeeded`, all 4 CRDs install, alm-examples reconcile.

### Source
- gma1k/podtrace tag: [`v0.11.9`](https://github.com/gma1k/podtrace/releases/tag/v0.11.9)
- License: Apache 2.0