### PR TITLE
operator [R] dynatrace-operator (0.10.2 0.10.3 0.11.0 0.11.1 0.11.2)

### DIFF
--- a/operators/dynatrace-operator/0.10.2/manifests/dynatrace-operator.clusterserviceversion.yaml
+++ b/operators/dynatrace-operator/0.10.2/manifests/dynatrace-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     repository: https://github.com/Dynatrace/dynatrace-operator
     support: Dynatrace
     createdAt: '2023-01-12T07:33:12.270436'
-    olm.skipRange: <=v0.10.1
+    olm.skipRange: <=0.10.1
   name: dynatrace-operator.v0.10.2
   namespace: placeholder
 spec:

--- a/operators/dynatrace-operator/0.10.3/manifests/dynatrace-operator.clusterserviceversion.yaml
+++ b/operators/dynatrace-operator/0.10.3/manifests/dynatrace-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     repository: https://github.com/Dynatrace/dynatrace-operator
     support: Dynatrace
     createdAt: '2023-03-01T12:20:20.848067'
-    olm.skipRange: <=v0.10.2
+    olm.skipRange: <=0.10.2
   name: dynatrace-operator.v0.10.3
   namespace: placeholder
 spec:

--- a/operators/dynatrace-operator/0.11.0/manifests/dynatrace-operator.clusterserviceversion.yaml
+++ b/operators/dynatrace-operator/0.11.0/manifests/dynatrace-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     repository: https://github.com/Dynatrace/dynatrace-operator
     support: Dynatrace
     createdAt: '2023-04-20T16:03:01.864486'
-    olm.skipRange: <=v0.10.4
+    olm.skipRange: <=0.10.4
   name: dynatrace-operator.v0.11.0
   namespace: placeholder
 spec:

--- a/operators/dynatrace-operator/0.11.1/manifests/dynatrace-operator.clusterserviceversion.yaml
+++ b/operators/dynatrace-operator/0.11.1/manifests/dynatrace-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     repository: https://github.com/Dynatrace/dynatrace-operator
     support: Dynatrace
     createdAt: '2023-04-28T11:07:51.673458'
-    olm.skipRange: <=v0.11.0
+    olm.skipRange: <=0.11.0
   name: dynatrace-operator.v0.11.1
   namespace: placeholder
 spec:

--- a/operators/dynatrace-operator/0.11.2/manifests/dynatrace-operator.clusterserviceversion.yaml
+++ b/operators/dynatrace-operator/0.11.2/manifests/dynatrace-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     repository: https://github.com/Dynatrace/dynatrace-operator
     support: Dynatrace
     createdAt: '2023-05-18T17:44:27.520754'
-    olm.skipRange: <=v0.11.1
+    olm.skipRange: <=0.11.1
   name: dynatrace-operator.v0.11.2
   namespace: placeholder
 spec:


### PR DESCRIPTION
## Summary
- Remove `v` prefix from semver values in `olm.skipRange` annotations

Generated with [Claude Code](https://claude.com/claude-code)