### PR TITLE
operator [R] percona-postgresql-operator (1.1.0 1.2.0 1.3.0 1.4.0 2.3.1 2.3.2 2.4.0 2.4.1 2.5.0 2.6.0 2.6.1 2.7.0 2.8.0 2.8.1 2.8.2 2.9.0)

### DIFF
--- a/operators/percona-postgresql-operator/1.1.0/manifests/percona-postgresql-operator.v1.1.0.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/1.1.0/manifests/percona-postgresql-operator.v1.1.0.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   name: percona-postgresql-operator.v1.1.0
   namespace: default
   annotations:
-    olm.skipRange: <v1.1.0
+    olm.skipRange: <1.1.0
     categories: Database
     certified: 'true'
     createdAt: '2021-12-15T13:11:44.000Z'

--- a/operators/percona-postgresql-operator/1.2.0/manifests/percona-postgresql-operator.v1.2.0.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/1.2.0/manifests/percona-postgresql-operator.v1.2.0.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   name: percona-postgresql-operator.v1.2.0
   namespace: default
   annotations:
-    olm.skipRange: <v1.2.0
+    olm.skipRange: <1.2.0
     categories: Database
     certified: 'true'
     createdAt: '2022-04-11T13:11:44.000Z'

--- a/operators/percona-postgresql-operator/1.3.0/manifests/percona-postgresql-operator.v1.3.0.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/1.3.0/manifests/percona-postgresql-operator.v1.3.0.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   name: percona-postgresql-operator.v1.3.0
   namespace: default
   annotations:
-    olm.skipRange: <v1.3.0
+    olm.skipRange: <1.3.0
     categories: Database
     certified: 'true'
     createdAt: '2022-08-11T13:11:44.000Z'

--- a/operators/percona-postgresql-operator/1.4.0/manifests/percona-postgresql-operator.v1.4.0.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/1.4.0/manifests/percona-postgresql-operator.v1.4.0.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   name: percona-postgresql-operator.v1.4.0
   namespace: default
   annotations:
-    olm.skipRange: <v1.4.0
+    olm.skipRange: <1.4.0
     categories: Database
     certified: 'true'
     createdAt: '2022-04-06T13:11:44.000Z'

--- a/operators/percona-postgresql-operator/2.3.1/manifests/percona-postgresql-operator.v2.3.1.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/2.3.1/manifests/percona-postgresql-operator.v2.3.1.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     support: percona.com
     olm.properties: '[]'
-    olm.skipRange: <v2.3.1
+    olm.skipRange: <2.3.1
     categories: Database
     capabilities: Deep Insights
     description: >-

--- a/operators/percona-postgresql-operator/2.3.2/manifests/percona-postgresql-operator.v2.3.2.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/2.3.2/manifests/percona-postgresql-operator.v2.3.2.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     support: percona.com
     olm.properties: '[]'
-    olm.skipRange: <v2.3.2
+    olm.skipRange: <2.3.2
     categories: Database
     capabilities: Deep Insights
     description: >-

--- a/operators/percona-postgresql-operator/2.4.0/manifests/percona-postgresql-operator.v2.4.0.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/2.4.0/manifests/percona-postgresql-operator.v2.4.0.clusterserviceversion.yaml
@@ -141,7 +141,7 @@ metadata:
           }
         }
       ]
-    olm.skipRange: '<v2.4.0'
+    olm.skipRange: '<2.4.0'
 spec:
   displayName: Percona Operator for PostgreSQL
   provider:

--- a/operators/percona-postgresql-operator/2.4.1/manifests/percona-postgresql-operator.v2.4.1.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/2.4.1/manifests/percona-postgresql-operator.v2.4.1.clusterserviceversion.yaml
@@ -141,7 +141,7 @@ metadata:
           }
         }
       ]
-    olm.skipRange: '<v2.4.1'
+    olm.skipRange: '<2.4.1'
 spec:
   displayName: Percona Operator for PostgreSQL
   provider:

--- a/operators/percona-postgresql-operator/2.5.0/manifests/percona-postgresql-operator.v2.5.0.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/2.5.0/manifests/percona-postgresql-operator.v2.5.0.clusterserviceversion.yaml
@@ -140,7 +140,7 @@ metadata:
           }
         }
       ]
-    olm.skipRange: '<v2.5.0'
+    olm.skipRange: '<2.5.0'
 spec:
   displayName: Percona Operator for PostgreSQL
   provider:

--- a/operators/percona-postgresql-operator/2.6.0/manifests/percona-postgresql-operator.v2.6.0.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/2.6.0/manifests/percona-postgresql-operator.v2.6.0.clusterserviceversion.yaml
@@ -140,7 +140,7 @@ metadata:
           }
         }
       ]
-    olm.skipRange: '<v2.6.0'
+    olm.skipRange: '<2.6.0'
 spec:
   displayName: Percona Operator for PostgreSQL
   provider:

--- a/operators/percona-postgresql-operator/2.6.1/manifests/percona-postgresql-operator.v2.6.1.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/2.6.1/manifests/percona-postgresql-operator.v2.6.1.clusterserviceversion.yaml
@@ -140,7 +140,7 @@ metadata:
           }
         }
       ]
-    olm.skipRange: '<v2.6.1'
+    olm.skipRange: '<2.6.1'
 spec:
   displayName: Percona Operator for PostgreSQL
   provider:

--- a/operators/percona-postgresql-operator/2.7.0/manifests/percona-postgresql-operator.v2.7.0.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/2.7.0/manifests/percona-postgresql-operator.v2.7.0.clusterserviceversion.yaml
@@ -140,7 +140,7 @@ metadata:
           }
         }
       ]
-    olm.skipRange: '<v2.7.0'
+    olm.skipRange: '<2.7.0'
 spec:
   displayName: Percona Operator for PostgreSQL
   provider:

--- a/operators/percona-postgresql-operator/2.8.0/manifests/percona-postgresql-operator.v2.8.0.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/2.8.0/manifests/percona-postgresql-operator.v2.8.0.clusterserviceversion.yaml
@@ -140,7 +140,7 @@ metadata:
           }
         }
       ]
-    olm.skipRange: '<v2.8.0'
+    olm.skipRange: '<2.8.0'
 spec:
   displayName: Percona Operator for PostgreSQL
   provider:

--- a/operators/percona-postgresql-operator/2.8.1/manifests/percona-postgresql-operator.v2.8.1.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/2.8.1/manifests/percona-postgresql-operator.v2.8.1.clusterserviceversion.yaml
@@ -147,7 +147,7 @@ metadata:
           }
         }
       ]
-    olm.skipRange: '<v2.8.1'
+    olm.skipRange: '<2.8.1'
 spec:
   displayName: Percona Operator for PostgreSQL
   provider:

--- a/operators/percona-postgresql-operator/2.8.2/manifests/percona-postgresql-operator.v2.8.2.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/2.8.2/manifests/percona-postgresql-operator.v2.8.2.clusterserviceversion.yaml
@@ -147,7 +147,7 @@ metadata:
           }
         }
       ]
-    olm.skipRange: '<v2.8.2'
+    olm.skipRange: '<2.8.2'
 spec:
   displayName: Percona Operator for PostgreSQL
   provider:

--- a/operators/percona-postgresql-operator/2.9.0/manifests/percona-postgresql-operator.v2.9.0.clusterserviceversion.yaml
+++ b/operators/percona-postgresql-operator/2.9.0/manifests/percona-postgresql-operator.v2.9.0.clusterserviceversion.yaml
@@ -157,7 +157,7 @@ metadata:
           }
         }
       ]
-    olm.skipRange: '<v2.9.0'
+    olm.skipRange: '<2.9.0'
 spec:
   displayName: Percona Operator for PostgreSQL
   provider:


### PR DESCRIPTION
## Summary
- Remove `v` prefix from semver values in `olm.skipRange` annotations

Generated with [Claude Code](https://claude.com/claude-code)