### PR TITLE
operator [R] percona-server-mongodb-operator (1.13.1 1.14.0 1.15.0 1.16.0 1.16.1 1.17.0)

### DIFF
--- a/operators/percona-server-mongodb-operator/1.13.1/manifests/percona-server-mongodb-operator.v1.13.1.clusterserviceversion.yaml
+++ b/operators/percona-server-mongodb-operator/1.13.1/manifests/percona-server-mongodb-operator.v1.13.1.clusterserviceversion.yaml
@@ -214,7 +214,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-server-mongodb-operator'
-    olm.skipRange: <v1.13.1
+    olm.skipRange: <1.13.1
 spec:
   displayName: Percona Distribution for MongoDB Operator
   description: >+

--- a/operators/percona-server-mongodb-operator/1.14.0/manifests/percona-server-mongodb-operator.v1.14.0.clusterserviceversion.yaml
+++ b/operators/percona-server-mongodb-operator/1.14.0/manifests/percona-server-mongodb-operator.v1.14.0.clusterserviceversion.yaml
@@ -214,7 +214,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-server-mongodb-operator'
-    olm.skipRange: <v1.14.0
+    olm.skipRange: <1.14.0
 spec:
   displayName: Percona Distribution for MongoDB Operator
   description: >+

--- a/operators/percona-server-mongodb-operator/1.15.0/manifests/percona-server-mongodb-operator.v1.15.0.clusterserviceversion.yaml
+++ b/operators/percona-server-mongodb-operator/1.15.0/manifests/percona-server-mongodb-operator.v1.15.0.clusterserviceversion.yaml
@@ -225,7 +225,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-server-mongodb-operator'
-    olm.skipRange: <v1.15.0
+    olm.skipRange: <1.15.0
 spec:
   displayName: Percona Distribution for MongoDB Operator
   description: >+

--- a/operators/percona-server-mongodb-operator/1.16.0/manifests/percona-server-mongodb-operator.v1.16.0.clusterserviceversion.yaml
+++ b/operators/percona-server-mongodb-operator/1.16.0/manifests/percona-server-mongodb-operator.v1.16.0.clusterserviceversion.yaml
@@ -235,7 +235,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-server-mongodb-operator'
-    olm.skipRange: <v1.16.0
+    olm.skipRange: <1.16.0
 spec:
   displayName: Percona Distribution for MongoDB Operator
   description: >+

--- a/operators/percona-server-mongodb-operator/1.16.1/manifests/percona-server-mongodb-operator.v1.16.1.clusterserviceversion.yaml
+++ b/operators/percona-server-mongodb-operator/1.16.1/manifests/percona-server-mongodb-operator.v1.16.1.clusterserviceversion.yaml
@@ -235,7 +235,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-server-mongodb-operator'
-    olm.skipRange: <v1.16.1
+    olm.skipRange: <1.16.1
 spec:
   displayName: Percona Distribution for MongoDB Operator
   description: >+

--- a/operators/percona-server-mongodb-operator/1.17.0/manifests/percona-server-mongodb-operator.v1.17.0.clusterserviceversion.yaml
+++ b/operators/percona-server-mongodb-operator/1.17.0/manifests/percona-server-mongodb-operator.v1.17.0.clusterserviceversion.yaml
@@ -230,7 +230,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-server-mongodb-operator'
-    olm.skipRange: <v1.17.0
+    olm.skipRange: <1.17.0
 spec:
   displayName: Percona Distribution for MongoDB Operator
   description: >+


### PR DESCRIPTION
## Summary
- Remove `v` prefix from semver values in `olm.skipRange` annotations

Generated with [Claude Code](https://claude.com/claude-code)