### PR TITLE
operator [R] percona-xtradb-cluster-operator (1.12.0 1.13.0 1.14.0 1.15.0 1.15.1 1.16.0 1.16.1 1.17.0 1.18.0 1.19.0 1.19.1)

### DIFF
--- a/operators/percona-xtradb-cluster-operator/1.12.0/manifests/percona-xtradb-cluster-operator.v1.12.0.clusterserviceversion.yaml
+++ b/operators/percona-xtradb-cluster-operator/1.12.0/manifests/percona-xtradb-cluster-operator.v1.12.0.clusterserviceversion.yaml
@@ -202,7 +202,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-xtradb-cluster-operator'
-    olm.skipRange: <v1.12.0
+    olm.skipRange: <1.12.0
 spec:
   displayName: Percona Operator for MySQL based on Percona XtraDB Cluster
   description: >+

--- a/operators/percona-xtradb-cluster-operator/1.13.0/manifests/percona-xtradb-cluster-operator.v1.13.0.clusterserviceversion.yaml
+++ b/operators/percona-xtradb-cluster-operator/1.13.0/manifests/percona-xtradb-cluster-operator.v1.13.0.clusterserviceversion.yaml
@@ -202,7 +202,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-xtradb-cluster-operator'
-    olm.skipRange: <v1.13.0
+    olm.skipRange: <1.13.0
 spec:
   displayName: Percona Operator for MySQL based on Percona XtraDB Cluster
   description: >+

--- a/operators/percona-xtradb-cluster-operator/1.14.0/manifests/percona-xtradb-cluster-operator.v1.14.0.clusterserviceversion.yaml
+++ b/operators/percona-xtradb-cluster-operator/1.14.0/manifests/percona-xtradb-cluster-operator.v1.14.0.clusterserviceversion.yaml
@@ -212,7 +212,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-xtradb-cluster-operator'
-    olm.skipRange: <v1.14.0
+    olm.skipRange: <1.14.0
 spec:
   displayName: Percona Operator for MySQL based on Percona XtraDB Cluster
   description: >+

--- a/operators/percona-xtradb-cluster-operator/1.15.0/manifests/percona-xtradb-cluster-operator.v1.15.0.clusterserviceversion.yaml
+++ b/operators/percona-xtradb-cluster-operator/1.15.0/manifests/percona-xtradb-cluster-operator.v1.15.0.clusterserviceversion.yaml
@@ -215,7 +215,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-xtradb-cluster-operator'
-    olm.skipRange: <v1.15.0
+    olm.skipRange: <1.15.0
 spec:
   displayName: Percona Operator for MySQL based on Percona XtraDB Cluster
   description: >+

--- a/operators/percona-xtradb-cluster-operator/1.15.1/manifests/percona-xtradb-cluster-operator.v1.15.1.clusterserviceversion.yaml
+++ b/operators/percona-xtradb-cluster-operator/1.15.1/manifests/percona-xtradb-cluster-operator.v1.15.1.clusterserviceversion.yaml
@@ -218,7 +218,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-xtradb-cluster-operator'
-    olm.skipRange: <v1.15.1
+    olm.skipRange: <1.15.1
 spec:
   displayName: Percona Operator for MySQL based on Percona XtraDB Cluster
   description: >+

--- a/operators/percona-xtradb-cluster-operator/1.16.0/manifests/percona-xtradb-cluster-operator.v1.16.0.clusterserviceversion.yaml
+++ b/operators/percona-xtradb-cluster-operator/1.16.0/manifests/percona-xtradb-cluster-operator.v1.16.0.clusterserviceversion.yaml
@@ -218,7 +218,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-xtradb-cluster-operator'
-    olm.skipRange: <v1.16.0
+    olm.skipRange: <1.16.0
 spec:
   displayName: Percona Operator for MySQL based on Percona XtraDB Cluster
   description: >+

--- a/operators/percona-xtradb-cluster-operator/1.16.1/manifests/percona-xtradb-cluster-operator.v1.16.1.clusterserviceversion.yaml
+++ b/operators/percona-xtradb-cluster-operator/1.16.1/manifests/percona-xtradb-cluster-operator.v1.16.1.clusterserviceversion.yaml
@@ -218,7 +218,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-xtradb-cluster-operator'
-    olm.skipRange: <v1.16.1
+    olm.skipRange: <1.16.1
 spec:
   displayName: Percona Operator for MySQL based on Percona XtraDB Cluster
   description: >+

--- a/operators/percona-xtradb-cluster-operator/1.17.0/manifests/percona-xtradb-cluster-operator.v1.17.0.clusterserviceversion.yaml
+++ b/operators/percona-xtradb-cluster-operator/1.17.0/manifests/percona-xtradb-cluster-operator.v1.17.0.clusterserviceversion.yaml
@@ -218,7 +218,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-xtradb-cluster-operator'
-    olm.skipRange: <v1.17.0
+    olm.skipRange: <1.17.0
 spec:
   displayName: Percona Operator for MySQL based on Percona XtraDB Cluster
   description: >+

--- a/operators/percona-xtradb-cluster-operator/1.18.0/manifests/percona-xtradb-cluster-operator.v1.18.0.clusterserviceversion.yaml
+++ b/operators/percona-xtradb-cluster-operator/1.18.0/manifests/percona-xtradb-cluster-operator.v1.18.0.clusterserviceversion.yaml
@@ -219,7 +219,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-xtradb-cluster-operator'
-    olm.skipRange: <v1.18.0
+    olm.skipRange: <1.18.0
 spec:
   displayName: Percona Operator for MySQL based on Percona XtraDB Cluster
   provider:

--- a/operators/percona-xtradb-cluster-operator/1.19.0/manifests/percona-xtradb-cluster-operator.v1.19.0.clusterserviceversion.yaml
+++ b/operators/percona-xtradb-cluster-operator/1.19.0/manifests/percona-xtradb-cluster-operator.v1.19.0.clusterserviceversion.yaml
@@ -221,7 +221,7 @@ metadata:
         }
       ]
     containerImage: docker.io/percona/percona-xtradb-cluster-operator:1.19.0
-    olm.skipRange: <v1.19.0
+    olm.skipRange: <1.19.0
 spec:
   displayName: Percona Operator for MySQL based on Percona XtraDB Cluster
   provider:

--- a/operators/percona-xtradb-cluster-operator/1.19.1/manifests/percona-xtradb-cluster-operator.v1.19.1.clusterserviceversion.yaml
+++ b/operators/percona-xtradb-cluster-operator/1.19.1/manifests/percona-xtradb-cluster-operator.v1.19.1.clusterserviceversion.yaml
@@ -218,7 +218,7 @@ metadata:
         }
       ]
     containerImage: docker.io/percona/percona-xtradb-cluster-operator:1.19.1
-    olm.skipRange: <v1.19.1
+    olm.skipRange: <1.19.1
 spec:
   displayName: Percona Operator for MySQL based on Percona XtraDB Cluster
   provider:


### PR DESCRIPTION
## Summary
- Remove `v` prefix from semver values in `olm.skipRange` annotations

Generated with [Claude Code](https://claude.com/claude-code)