### PR TITLE
operator keiailab-postgres-operator (0.3.0-alpha.18)

### DIFF
--- a/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/keiailab-postgres-operator.clusterserviceversion.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/keiailab-postgres-operator.clusterserviceversion.yaml
@@ -1,0 +1,723 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "postgres.keiailab.io/v1alpha1",
+          "kind": "BackupJob",
+          "metadata": {
+            "name": "quickstart-full-backup",
+            "namespace": "default"
+          },
+          "spec": {
+            "cluster": {
+              "name": "quickstart"
+            },
+            "executionMode": "job",
+            "jobTemplate": {
+              "spec": {
+                "backoffLimit": 1,
+                "template": {
+                  "spec": {
+                    "containers": [
+                      {
+                        "args": [
+                          "pgbackrest --stanza=\"${POSTGRES_CLUSTER_NAME}\" --repo=\"${BACKUP_REPO}\" backup --type=\"${BACKUP_TYPE}\""
+                        ],
+                        "command": [
+                          "/bin/sh",
+                          "-c"
+                        ],
+                        "image": "ghcr.io/keiailab/pg:18",
+                        "name": "pgbackrest"
+                      }
+                    ],
+                    "restartPolicy": "Never"
+                  }
+                }
+              }
+            },
+            "repo": "repo1",
+            "tool": "pgbackrest",
+            "type": "full"
+          }
+        },
+        {
+          "apiVersion": "postgres.keiailab.io/v1alpha1",
+          "kind": "ClusterImageCatalog",
+          "metadata": {
+            "name": "postgresql-standard"
+          },
+          "spec": {
+            "images": [
+              {
+                "image": "ghcr.io/keiailab/pg:17",
+                "major": 17
+              },
+              {
+                "image": "ghcr.io/keiailab/pg:18",
+                "major": 18
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "postgres.keiailab.io/v1alpha1",
+          "kind": "ImageCatalog",
+          "metadata": {
+            "name": "postgresql",
+            "namespace": "default"
+          },
+          "spec": {
+            "images": [
+              {
+                "extensions": [
+                  {
+                    "image": {
+                      "reference": "ghcr.io/keiailab/pg-extension-pgaudit:18"
+                    },
+                    "name": "pgaudit"
+                  }
+                ],
+                "image": "ghcr.io/keiailab/pg:18",
+                "major": 18
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "postgres.keiailab.io/v1alpha1",
+          "kind": "Pooler",
+          "metadata": {
+            "name": "quickstart-rw-pooler",
+            "namespace": "default"
+          },
+          "spec": {
+            "cluster": {
+              "name": "quickstart"
+            },
+            "instances": 2,
+            "pgbouncer": {
+              "authSecretRef": {
+                "name": "quickstart-pooler-auth"
+              },
+              "image": "ghcr.io/cloudnative-pg/pgbouncer:1.24.1",
+              "parameters": {
+                "default_pool_size": "20",
+                "max_client_conn": "1000"
+              },
+              "poolMode": "session"
+            },
+            "type": "rw"
+          }
+        },
+        {
+          "apiVersion": "postgres.keiailab.io/v1alpha1",
+          "kind": "PostgresCluster",
+          "metadata": {
+            "name": "quickstart",
+            "namespace": "default"
+          },
+          "spec": {
+            "postgresVersion": "18",
+            "shardingMode": "none",
+            "shards": {
+              "initialCount": 1,
+              "replicas": 0,
+              "storage": {
+                "size": "10Gi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "postgres.keiailab.io/v1alpha1",
+          "kind": "PostgresDatabase",
+          "metadata": {
+            "name": "quickstart-appdb"
+          },
+          "spec": {
+            "cluster": {
+              "name": "quickstart"
+            },
+            "databaseReclaimPolicy": "retain",
+            "ensure": "present",
+            "extensions": [
+              {
+                "ensure": "present",
+                "name": "pgcrypto"
+              },
+              {
+                "ensure": "present",
+                "name": "postgres_fdw"
+              }
+            ],
+            "fdws": [
+              {
+                "name": "postgres_fdw",
+                "usage": [
+                  {
+                    "name": "app",
+                    "type": "grant"
+                  }
+                ]
+              }
+            ],
+            "name": "appdb",
+            "owner": "app",
+            "privileges": [
+              {
+                "privileges": [
+                  "CONNECT",
+                  "TEMPORARY"
+                ],
+                "role": "app",
+                "type": "grant"
+              }
+            ],
+            "schemas": [
+              {
+                "ensure": "present",
+                "name": "app",
+                "owner": "app",
+                "privileges": [
+                  {
+                    "privileges": [
+                      "USAGE",
+                      "CREATE"
+                    ],
+                    "role": "app",
+                    "type": "grant"
+                  }
+                ]
+              }
+            ],
+            "servers": [
+              {
+                "fdw": "postgres_fdw",
+                "name": "quickstart-rw",
+                "options": [
+                  {
+                    "name": "host",
+                    "value": "quickstart-rw"
+                  },
+                  {
+                    "name": "dbname",
+                    "value": "appdb"
+                  },
+                  {
+                    "name": "port",
+                    "value": "5432"
+                  }
+                ],
+                "usage": [
+                  {
+                    "name": "app",
+                    "type": "grant"
+                  }
+                ]
+              }
+            ],
+            "tablespace": "fastspace"
+          }
+        },
+        {
+          "apiVersion": "postgres.keiailab.io/v1alpha1",
+          "kind": "PostgresUser",
+          "metadata": {
+            "name": "quickstart-app"
+          },
+          "spec": {
+            "bypassrls": false,
+            "cluster": {
+              "name": "quickstart"
+            },
+            "connectionLimit": 25,
+            "createdb": true,
+            "createrole": false,
+            "ensure": "present",
+            "inRoles": [
+              "readonly",
+              "writers"
+            ],
+            "inherit": true,
+            "login": true,
+            "name": "app",
+            "replication": false,
+            "validUntil": "infinity"
+          }
+        },
+        {
+          "apiVersion": "postgres.keiailab.io/v1alpha1",
+          "kind": "ScheduledBackup",
+          "metadata": {
+            "name": "quickstart-nightly",
+            "namespace": "default"
+          },
+          "spec": {
+            "backupOwnerReference": "self",
+            "cluster": {
+              "name": "quickstart"
+            },
+            "concurrencyPolicy": "Forbid",
+            "immediate": true,
+            "repo": "repo1",
+            "retention": {
+              "full": 7
+            },
+            "schedule": "0 0 17 * * *",
+            "suspend": false,
+            "tool": "pgbackrest",
+            "type": "full"
+          }
+        }
+      ]
+    capabilities: Seamless Upgrades
+    categories: Database, Storage
+    containerImage: ghcr.io/keiailab/postgres-operator:0.3.0-alpha.18
+    createdAt: "2026-05-12T13:53:44Z"
+    description: |
+      Apache-2.0 PostgreSQL Kubernetes Operator — vanilla PG18+, license-clean,
+      PGO-class 운영 품질을 목표로 하되 외부 operator/backend 를 fork, embed,
+      wrapper 로 사용하지 않는 독립 신규 구현. PG17/PG18 양 메이저 지원.
+    operators.operatorframework.io/builder: operator-sdk-v1.42.2
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/keiailab/postgres-operator
+    support: https://github.com/keiailab/postgres-operator/issues
+  name: keiailab-postgres-operator.v0.3.0-alpha.18
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: BackupJob 은 PostgresCluster 의 pgBackRest 기반 backup/restore Job
+        추상이다. executionMode=sidecar 는 ready primary Pod 에 K8s exec 로 명령을 전달하고, executionMode=job
+        은 별도 batch/v1 Job 으로 runner 를 실행한다.
+      displayName: Backup Job
+      kind: BackupJob
+      name: backupjobs.postgres.keiailab.io
+      version: v1alpha1
+    - description: ClusterImageCatalog 는 cluster 전체에서 공유할 PostgreSQL runtime image
+        catalog 다. PostgresCluster.spec.imageCatalogRef.kind=ClusterImageCatalog 로
+        참조한다. CloudNativePG ClusterImageCatalog 와 호환 표면을 제공한다.
+      displayName: Cluster Image Catalog
+      kind: ClusterImageCatalog
+      name: clusterimagecatalogs.postgres.keiailab.io
+      version: v1alpha1
+    - description: ImageCatalog 는 namespace 단위 PostgreSQL runtime image catalog 다.
+        PostgresCluster.spec.imageCatalogRef.kind=ImageCatalog 로 같은 namespace 에서 major
+        version 을 선택한다. CloudNativePG ImageCatalog 호환 표면.
+      displayName: Image Catalog
+      kind: ImageCatalog
+      name: imagecatalogs.postgres.keiailab.io
+      version: v1alpha1
+    - description: Pooler 는 PostgresCluster 대상 PgBouncer connection pool 계층을 선언한다.
+        spec.type=rw 는 primary 쓰기 endpoint, spec.type=ro 는 replica 읽기 endpoint 로 연결한다.
+        ConfigMap, Deployment, Service, exporter sidecar, PAUSE/RESUME, SIGHUP reload
+        를 포함한다.
+      displayName: Pooler
+      kind: Pooler
+      name: poolers.postgres.keiailab.io
+      version: v1alpha1
+    - description: PostgresCluster 는 K8s-native 자체 분산 PostgreSQL 클러스터의 선언적 표현이다 (ADR
+        0001 / RFC 0001). primary + streaming standby + native sharding 로드맵, replica
+        cluster, image catalog 참조, declarative monitoring 표면을 포함한다.
+      displayName: Postgres Cluster
+      kind: PostgresCluster
+      name: postgresclusters.postgres.keiailab.io
+      version: v1alpha1
+    - description: PostgresDatabase 는 PostgresCluster 안의 database/tablespace/schema/extension/FDW/foreign
+        server 와 그들의 privilege 를 선언적으로 관리한다. ready primary Pod 의 postgres 컨테이너에서 psql
+        로 SQL 을 적용하고 status.applied/conditions 를 기록한다. databaseReclaimPolicy=delete
+        는 CR 삭제 시 DROP DATABASE 까지 책임진다.
+      displayName: Postgres Database
+      kind: PostgresDatabase
+      name: postgresdatabases.postgres.keiailab.io
+      version: v1alpha1
+    - description: PostgresUser 는 PostgresCluster 안의 PostgreSQL role 을 선언적으로 관리한다.
+        role flags, membership, connectionLimit, passwordSecretRef, validUntil 을 ready
+        primary Pod psql 로 적용하고 status.managedRolesStatus 로 집계한다. CNPG managed.roles
+        호환 표면.
+      displayName: Postgres User
+      kind: PostgresUser
+      name: postgresusers.postgres.keiailab.io
+      version: v1alpha1
+    - description: ScheduledBackup 은 6-field cron schedule 에 따라 PostgresCluster 대상
+        atomic BackupJob 을 생성한다. concurrencyPolicy 와 backupOwnerReference 로 동시 실행
+        정책과 owner reference 동작을 제어한다.
+      displayName: Scheduled Backup
+      kind: ScheduledBackup
+      name: scheduledbackups.postgres.keiailab.io
+      version: v1alpha1
+  description: |
+    # Postgres Operator
+
+    Apache-2.0 licensed Kubernetes operator for PostgreSQL — manages the
+    `PostgresCluster` CRD with shard-aware topology (primary + standby
+    streaming replication), automated failover (RTO < 30s verified),
+    pgBackRest integration, and PG17/PG18 compatibility.
+
+    ## Features
+
+    - **PostgresCluster CRD** — declarative shard-aware topology (primary +
+      standby streaming replication, hot-standby read scaling).
+    - **Automated failover** — primary Pod delete smoke verified RTO < 30s.
+    - **PG17 + PG18 multi-major support** — runtime image build/load via
+      `hack/smoke.sh`, kind cluster smoke includes psql round-trip +
+      streaming replication assertion.
+    - **pgBackRest integration** — BackupJob CRD reconciles backup/restore
+      Jobs and ScheduledBackup creates cron-driven BackupJobs.
+    - **PgBouncer Pooler** — Pooler CRD reconciles ConfigMap, Deployment,
+      Service, and fail-closed userlist Secret validation.
+    - **Supply chain** — Cosign signed container images + SBOM (SPDX-2.3).
+    - **Security baseline** — Pod Security Standards Restricted, RBAC
+      least-privilege, NetworkPolicy isolation, non-root runAsUser.
+
+    ## Documentation
+
+    - GitHub: https://github.com/keiailab/postgres-operator
+    - Helm Repository: https://keiailab.github.io/postgres-operator
+    - Discussions: https://github.com/keiailab/postgres-operator/discussions
+
+    ## Prerequisites
+
+    - Kubernetes 1.26+
+    - Storage class for PVCs (recommended: ceph-rbd or comparable RWO)
+    - (Optional) cert-manager for automatic TLS certificate management
+    - (Optional) Prometheus Operator for `ServiceMonitor` scraping
+  displayName: Postgres Operator
+  icon:
+  - base64data: PCFET0NUWVBFIGh0bWw+CjxodG1sIGNsYXNzPSJjbGllbnQtbm9qcyIgbGFuZz0iZW4iIGRpcj0ibHRyIj4KPGhlYWQ+CjxtZXRhIGNoYXJzZXQ9IlVURi04Ii8+Cjx0aXRsZT5Qb3N0Z3JlU1FMIHdpa2k8L3RpdGxlPgo8c2NyaXB0PmRvY3VtZW50LmRvY3VtZW50RWxlbWVudC5jbGFzc05hbWU9ImNsaWVudC1qcyI7UkxDT05GPXsid2dCcmVha0ZyYW1lcyI6ZmFsc2UsIndnU2VwYXJhdG9yVHJhbnNmb3JtVGFibGUiOlsiIiwiIl0sIndnRGlnaXRUcmFuc2Zvcm1UYWJsZSI6WyIiLCIiXSwid2dEZWZhdWx0RGF0ZUZvcm1hdCI6ImRteSIsIndnTW9udGhOYW1lcyI6WyIiLCJKYW51YXJ5IiwiRmVicnVhcnkiLCJNYXJjaCIsIkFwcmlsIiwiTWF5IiwiSnVuZSIsIkp1bHkiLCJBdWd1c3QiLCJTZXB0ZW1iZXIiLCJPY3RvYmVyIiwiTm92ZW1iZXIiLCJEZWNlbWJlciJdLCJ3Z1JlcXVlc3RJZCI6ImI0M2JmNWZkMjk0ODEzZTAwZjVkNjZlOSIsIndnQ1NQTm9uY2UiOmZhbHNlLCJ3Z0Nhbm9uaWNhbE5hbWVzcGFjZSI6IiIsIndnQ2Fub25pY2FsU3BlY2lhbFBhZ2VOYW1lIjpmYWxzZSwid2dOYW1lc3BhY2VOdW1iZXIiOjAsIndnUGFnZU5hbWUiOiJNYWluX1BhZ2UiLCJ3Z1RpdGxlIjoiTWFpbiBQYWdlIiwid2dDdXJSZXZpc2lvbklkIjo0MjA0OCwid2dSZXZpc2lvbklkIjo0MjA0OCwid2dBcnRpY2xlSWQiOjEsIndnSXNBcnRpY2xlIjp0cnVlLCJ3Z0lzUmVkaXJlY3QiOmZhbHNlLCJ3Z0FjdGlvbiI6InZpZXciLCJ3Z1VzZXJOYW1lIjpudWxsLCJ3Z1VzZXJHcm91cHMiOlsiKiJdLCJ3Z0NhdGVnb3JpZXMiOltdLCJ3Z1BhZ2VDb250ZW50TGFuZ3VhZ2UiOiJlbiIsIndnUGFnZUNvbnRlbnRNb2RlbCI6Indpa2l0ZXh0Iiwid2dSZWxldmFudFBhZ2VOYW1lIjoiTWFpbl9QYWdlIiwid2dSZWxldmFudEFydGljbGVJZCI6MSwid2dJc1Byb2JhYmx5RWRpdGFibGUiOmZhbHNlLCJ3Z1JlbGV2YW50UGFnZUlzUHJvYmFibHlFZGl0YWJsZSI6ZmFsc2UsIndnUmVzdHJpY3Rpb25FZGl0IjpbInN5c29wIl0sIndnUmVzdHJpY3Rpb25Nb3ZlIjpbInN5c29wIl0sIndnSXNNYWluUGFnZSI6dHJ1ZX07UkxTVEFURT17InNpdGUuc3R5bGVzIjoicmVhZHkiLCJ1c2VyLnN0eWxlcyI6InJlYWR5IiwidXNlciI6InJlYWR5IiwidXNlci5vcHRpb25zIjoibG9hZGluZyIsInNraW5zLm1vbm9ib29rLnN0eWxlcyI6InJlYWR5In07ClJMUEFHRU1PRFVMRVM9WyJzaXRlIiwibWVkaWF3aWtpLnBhZ2UucmVhZHkiLCJza2lucy5tb25vYm9vay5zY3JpcHRzIl07PC9zY3JpcHQ+CjxzY3JpcHQ+KFJMUT13aW5kb3cuUkxRfHxbXSkucHVzaChmdW5jdGlvbigpe213LmxvYWRlci5pbXBsZW1lbnQoInVzZXIub3B0aW9uc0AxMnM1aSIsZnVuY3Rpb24oJCxqUXVlcnkscmVxdWlyZSxtb2R1bGUpe213LnVzZXIudG9rZW5zLnNldCh7InBhdHJvbFRva2VuIjoiK1xcIiwid2F0Y2hUb2tlbiI6IitcXCIsImNzcmZUb2tlbiI6IitcXCJ9KTt9KTt9KTs8L3NjcmlwdD4KPGxpbmsgcmVsPSJzdHlsZXNoZWV0IiBocmVmPSIvbG9hZC5waHA/bGFuZz1lbiZhbXA7bW9kdWxlcz1za2lucy5tb25vYm9vay5zdHlsZXMmYW1wO29ubHk9c3R5bGVzJmFtcDtza2luPW1vbm9ib29rIi8+CjxzY3JpcHQgYXN5bmM9IiIgc3JjPSIvbG9hZC5waHA/bGFuZz1lbiZhbXA7bW9kdWxlcz1zdGFydHVwJmFtcDtvbmx5PXNjcmlwdHMmYW1wO3Jhdz0xJmFtcDtza2luPW1vbm9ib29rIj48L3NjcmlwdD4KPG1ldGEgbmFtZT0iUmVzb3VyY2VMb2FkZXJEeW5hbWljU3R5bGVzIiBjb250ZW50PSIiLz4KPGxpbmsgcmVsPSJzdHlsZXNoZWV0IiBocmVmPSIvbG9hZC5waHA/bGFuZz1lbiZhbXA7bW9kdWxlcz1zaXRlLnN0eWxlcyZhbXA7b25seT1zdHlsZXMmYW1wO3NraW49bW9ub2Jvb2siLz4KPG1ldGEgbmFtZT0iZ2VuZXJhdG9yIiBjb250ZW50PSJNZWRpYVdpa2kgMS4zOS4xNyIvPgo8bWV0YSBuYW1lPSJmb3JtYXQtZGV0ZWN0aW9uIiBjb250ZW50PSJ0ZWxlcGhvbmU9bm8iLz4KPG1ldGEgbmFtZT0idmlld3BvcnQiIGNvbnRlbnQ9IndpZHRoPWRldmljZS13aWR0aCwgaW5pdGlhbC1zY2FsZT0xLjAsIHVzZXItc2NhbGFibGU9eWVzLCBtaW5pbXVtLXNjYWxlPTAuMjUsIG1heGltdW0tc2NhbGU9NS4wIi8+CjxsaW5rIHJlbD0iaWNvbiIgaHJlZj0iL2Zhdmljb24uaWNvIi8+CjxsaW5rIHJlbD0ic2VhcmNoIiB0eXBlPSJhcHBsaWNhdGlvbi9vcGVuc2VhcmNoZGVzY3JpcHRpb24reG1sIiBocmVmPSIvb3BlbnNlYXJjaF9kZXNjLnBocCIgdGl0bGU9IlBvc3RncmVTUUwgd2lraSAoZW4pIi8+CjxsaW5rIHJlbD0iRWRpdFVSSSIgdHlwZT0iYXBwbGljYXRpb24vcnNkK3htbCIgaHJlZj0iaHR0cHM6Ly93aWtpLnBvc3RncmVzcWwub3JnL2FwaS5waHA/YWN0aW9uPXJzZCIvPgo8bGluayByZWw9ImFsdGVybmF0ZSIgdHlwZT0iYXBwbGljYXRpb24vYXRvbSt4bWwiIHRpdGxlPSJQb3N0Z3JlU1FMIHdpa2kgQXRvbSBmZWVkIiBocmVmPSIvaW5kZXgucGhwP3RpdGxlPVNwZWNpYWw6UmVjZW50Q2hhbmdlcyZhbXA7ZmVlZD1hdG9tIi8+CjwvaGVhZD4KPGJvZHkgY2xhc3M9Im1lZGlhd2lraSBsdHIgc2l0ZWRpci1sdHIgbXctaGlkZS1lbXB0eS1lbHQgbnMtMCBucy1zdWJqZWN0IHBhZ2UtTWFpbl9QYWdlIHJvb3RwYWdlLU1haW5fUGFnZSBza2luLW1vbm9ib29rIGFjdGlvbi12aWV3IHNraW4tLXJlc3BvbnNpdmUiPjxkaXYgaWQ9Imdsb2JhbFdyYXBwZXIiPgoJPGRpdiBpZD0iY29sdW1uLWNvbnRlbnQiPgoJCTxkaXYgaWQ9ImNvbnRlbnQiIGNsYXNzPSJtdy1ib2R5IiByb2xlPSJtYWluIj4KCQkJPGEgaWQ9InRvcCI+PC9hPgoJCQk8ZGl2IGlkPSJzaXRlTm90aWNlIj48ZGl2IGlkPSJsb2NhbE5vdGljZSI+PGRpdiBjbGFzcz0ic2l0ZW5vdGljZSIgbGFuZz0iZW4iIGRpcj0ibHRyIj48cD48Yj48YSByZWw9Im5vZm9sbG93IiBjbGFzcz0iZXh0ZXJuYWwgdGV4dCIgaHJlZj0iaHR0cHM6Ly93aWtpLnBvc3RncmVzcWwub3JnL3dpa2kvV2lraUVkaXRpbmciPldhbnQgdG8gZWRpdCwgYnV0IGRvbid0IHNlZSBhbiBlZGl0IGJ1dHRvbiB3aGVuIGxvZ2dlZCBpbj8gIENsaWNrIGhlcmUuPC9hPjwvYj4KPC9wPjwvZGl2PjwvZGl2PjwvZGl2PgoJCQk8ZGl2IGNsYXNzPSJtdy1pbmRpY2F0b3JzIj4KCQkJPC9kaXY+CgkJCTxoMSBpZD0iZmlyc3RIZWFkaW5nIiBjbGFzcz0iZmlyc3RIZWFkaW5nIG13LWZpcnN0LWhlYWRpbmciPjxzcGFuIGNsYXNzPSJtdy1wYWdlLXRpdGxlLW1haW4iPk1haW4gUGFnZTwvc3Bhbj48L2gxPgoJCQk8ZGl2IGlkPSJib2R5Q29udGVudCIgY2xhc3M9Im1vbm9ib29rLWJvZHkiPgoJCQkJPGRpdiBpZD0ic2l0ZVN1YiI+RnJvbSBQb3N0Z3JlU1FMIHdpa2k8L2Rpdj4KCQkJCTxkaXYgaWQ9ImNvbnRlbnRTdWIiID48L2Rpdj4KCQkJCQoJCQkJPGRpdiBpZD0ianVtcC10by1uYXYiPjwvZGl2PjxhIGhyZWY9IiNjb2x1bW4tb25lIiBjbGFzcz0ibXctanVtcC1saW5rIj5KdW1wIHRvIG5hdmlnYXRpb248L2E+PGEgaHJlZj0iI3NlYXJjaElucHV0IiBjbGFzcz0ibXctanVtcC1saW5rIj5KdW1wIHRvIHNlYXJjaDwvYT4KCQkJCTwhLS0gc3RhcnQgY29udGVudCAtLT4KCQkJCTxkaXYgaWQ9Im13LWNvbnRlbnQtdGV4dCIgY2xhc3M9Im13LWJvZHktY29udGVudCBtdy1jb250ZW50LWx0ciIgbGFuZz0iZW4iIGRpcj0ibHRyIj48ZGl2IGNsYXNzPSJtdy1wYXJzZXItb3V0cHV0Ij48cD48YnIgLz4KPC9wPgo8aDE+PHNwYW4gaWQ9IldlbGNvbWVfdG9fdGhlX1Bvc3RncmVTUUxfV2lraS4yMSI+PC9zcGFuPjxzcGFuIGNsYXNzPSJtdy1oZWFkbGluZSIgaWQ9IldlbGNvbWVfdG9fdGhlX1Bvc3RncmVTUUxfV2lraSEiPldlbGNvbWUgdG8gdGhlIFBvc3RncmVTUUwgV2lraSE8L3NwYW4+PC9oMT4KPHA+VGhpcyB3aWtpIGNvbnRhaW5zIHVzZXIgZG9jdW1lbnRhdGlvbiwgaG93LXRvcywgYW5kIHRpcHMgJ24nIHRyaWNrcyByZWxhdGVkIHRvIFBvc3RncmVTUUwuIEl0IGFsc28gc2VydmVzIGFzIGEgY29sbGFib3JhdGlvbiBhcmVhIGZvciBQb3N0Z3JlU1FMIGNvbnRyaWJ1dG9ycy4KPC9wPgo8aDI+PHNwYW4gY2xhc3M9Im13LWhlYWRsaW5lIiBpZD0iVXNlcl9Eb2N1bWVudGF0aW9uIj5Vc2VyIERvY3VtZW50YXRpb248L3NwYW4+PC9oMj4KPHVsPjxsaT48YSBocmVmPSIvd2lraS9GcmVxdWVudGx5X0Fza2VkX1F1ZXN0aW9ucyIgdGl0bGU9IkZyZXF1ZW50bHkgQXNrZWQgUXVlc3Rpb25zIj5GcmVxdWVudGx5IEFza2VkIFF1ZXN0aW9uczwvYT48L2xpPjwvdWw+CjxoND48c3BhbiBpZD0iQ29tbXVuaXR5X0dlbmVyYXRlZF9BcnRpY2xlcy4yQ19HdWlkZXMuMkNfYW5kX0RvY3VtZW50YXRpb24iPjwvc3Bhbj48c3BhbiBjbGFzcz0ibXctaGVhZGxpbmUiIGlkPSJDb21tdW5pdHlfR2VuZXJhdGVkX0FydGljbGVzLF9HdWlkZXMsX2FuZF9Eb2N1bWVudGF0aW9uIj5Db21tdW5pdHkgR2VuZXJhdGVkIEFydGljbGVzLCBHdWlkZXMsIGFuZCBEb2N1bWVudGF0aW9uPC9zcGFuPjwvaDQ+Cjx1bD48bGk+PGEgaHJlZj0iL3dpa2kvQ29tbXVuaXR5X0dlbmVyYXRlZF9BcnRpY2xlcyxfR3VpZGVzLF9hbmRfRG9jdW1lbnRhdGlvbiIgdGl0bGU9IkNvbW11bml0eSBHZW5lcmF0ZWQgQXJ0aWNsZXMsIEd1aWRlcywgYW5kIERvY3VtZW50YXRpb24iPkdlbmVyYWwgYXJ0aWNsZXMgYW5kIGd1aWRlczwvYT48L2xpPgo8bGk+PGEgaHJlZj0iL3dpa2kvUG9zdGdyZVNRTF9UdXRvcmlhbHMiIHRpdGxlPSJQb3N0Z3JlU1FMIFR1dG9yaWFscyI+UG9zdGdyZVNRTCBUdXRvcmlhbHM8L2E+PC9saT4KPGxpPjxhIGhyZWY9Ii93aWtpL0NhdGVnb3J5OlNuaXBwZXRzIiB0aXRsZT0iQ2F0ZWdvcnk6U25pcHBldHMiPlBvc3RncmVTUUwgUmVsYXRlZCBDb2RlIFNuaXBwZXRzPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9EZXRhaWxlZF9pbnN0YWxsYXRpb25fZ3VpZGVzIiB0aXRsZT0iRGV0YWlsZWQgaW5zdGFsbGF0aW9uIGd1aWRlcyI+RGV0YWlsZWQgaW5zdGFsbGF0aW9uIGd1aWRlczwvYT48L2xpPgo8bGk+PGEgaHJlZj0iL3dpa2kvQ29udmVydGluZ19mcm9tX290aGVyX0RhdGFiYXNlc190b19Qb3N0Z3JlU1FMIiB0aXRsZT0iQ29udmVydGluZyBmcm9tIG90aGVyIERhdGFiYXNlcyB0byBQb3N0Z3JlU1FMIj5Db252ZXJ0aW5nIGZyb20gb3RoZXIgRGF0YWJhc2VzIHRvIFBvc3RncmVTUUw8L2E+PC9saT4KPGxpPjxhIGhyZWY9Ii93aWtpL0NvbXBhcmlzb25fd2l0aF9vdGhlcl9EYXRhYmFzZV9zeXN0ZW1zIiB0aXRsZT0iQ29tcGFyaXNvbiB3aXRoIG90aGVyIERhdGFiYXNlIHN5c3RlbXMiPkNvbXBhcmlzb24gd2l0aCBvdGhlciBEYXRhYmFzZSBzeXN0ZW1zPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9EYXRhYmFzZV9BZG1pbmlzdHJhdGlvbl9hbmRfTWFpbnRlbmFuY2UiIGNsYXNzPSJtdy1yZWRpcmVjdCIgdGl0bGU9IkRhdGFiYXNlIEFkbWluaXN0cmF0aW9uIGFuZCBNYWludGVuYW5jZSI+RGF0YWJhc2UgQWRtaW5pc3RyYXRpb24gYW5kIE1haW50ZW5hbmNlPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9EZXZlbG9wbWVudF9BcnRpY2xlcyIgdGl0bGU9IkRldmVsb3BtZW50IEFydGljbGVzIj5EZXZlbG9wbWVudCB3aXRoIFBvc3RncmVTUUw8L2E+PC9saT4KPGxpPjxhIGhyZWY9Ii93aWtpL1BlcmZvcm1hbmNlX09wdGltaXphdGlvbiIgdGl0bGU9IlBlcmZvcm1hbmNlIE9wdGltaXphdGlvbiI+UG9zdGdyZVNRTCBQZXJmb3JtYW5jZSBPcHRpbWl6YXRpb248L2E+PC9saT4KPGxpPjxhIGhyZWY9Ii93aWtpL1Bvc3RncmVTUUxfUmVsYXRlZF9TbGlkZXNfYW5kX1ByZXNlbnRhdGlvbnMiIHRpdGxlPSJQb3N0Z3JlU1FMIFJlbGF0ZWQgU2xpZGVzIGFuZCBQcmVzZW50YXRpb25zIj5Qb3N0Z3JlU1FMIFJlbGF0ZWQgU2xpZGVzIGFuZCBQcmVzZW50YXRpb25zPC9hPjwvbGk+PC91bD4KPGg0PjxzcGFuIGNsYXNzPSJtdy1oZWFkbGluZSIgaWQ9IkRvY3VtZW50YXRpb25fb25fdGhlX21haW5fc2l0ZSI+RG9jdW1lbnRhdGlvbiBvbiB0aGUgbWFpbiBzaXRlPC9zcGFuPjwvaDQ+Cjx1bD48bGk+PGEgcmVsPSJub2ZvbGxvdyIgY2xhc3M9ImV4dGVybmFsIHRleHQiIGhyZWY9Imh0dHA6Ly93d3cucG9zdGdyZXNxbC5vcmcvZG9jcy9tYW51YWxzLyI+UG9zdGdyZVNRTCBNYW51YWxzPC9hPjwvbGk+CjxsaT48YSByZWw9Im5vZm9sbG93IiBjbGFzcz0iZXh0ZXJuYWwgdGV4dCIgaHJlZj0iaHR0cDovL3d3dy5wb3N0Z3Jlc3FsLm9yZy9kb2NzL2Jvb2tzLyI+UG9zdGdyZVNRTCBCb29rczwvYT48L2xpPjwvdWw+CjxoMj48c3BhbiBjbGFzcz0ibXctaGVhZGxpbmUiIGlkPSJBbHRlcm5hdGVfTGFuZ3VhZ2VzIj5BbHRlcm5hdGUgTGFuZ3VhZ2VzPC9zcGFuPjwvaDI+CjxwPlRoZSBmb2xsb3dpbmcgcGFnZXMgY29udGFpbiB1c2VyIGRvY3VtZW50YXRpb24gaW4gbGFuZ3VhZ2VzIG90aGVyIHRoYW4gRW5nbGlzaC4KPC9wPgo8dWw+PGxpPjxhIGhyZWY9Ii93aWtpL01haW5fUGFnZS9kZSIgY2xhc3M9Im13LXJlZGlyZWN0IiB0aXRsZT0iTWFpbiBQYWdlL2RlIj5kZXV0c2NoPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UvZXMiIHRpdGxlPSJNYWluIFBhZ2UvZXMiPmVzcGHDsW9sPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UvZnIiIHRpdGxlPSJNYWluIFBhZ2UvZnIiPmZyYW7Dp2FpczwvYT48L2xpPgo8bGk+PGEgaHJlZj0iL3dpa2kvTWFpbl9QYWdlL2hlIiB0aXRsZT0iTWFpbiBQYWdlL2hlIj7XoteR16jXmdeqPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UvamEiIHRpdGxlPSJNYWluIFBhZ2UvamEiPuaXpeacrOiqnjwvYT48L2xpPgo8bGk+PGEgaHJlZj0iL3dpa2kvTWFpbl9QYWdlL3B0IiB0aXRsZT0iTWFpbiBQYWdlL3B0Ij5wb3J0dWd1w6pzPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UvcnUiIHRpdGxlPSJNYWluIFBhZ2UvcnUiPtGA0YPRgdGB0LrQuNC5PC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UvemgiIGNsYXNzPSJtdy1yZWRpcmVjdCIgdGl0bGU9Ik1haW4gUGFnZS96aCI+5Lit5paHPC9hPjwvbGk+CjxsaT48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UvemgtaGFudCIgY2xhc3M9Im13LXJlZGlyZWN0IiB0aXRsZT0iTWFpbiBQYWdlL3poLWhhbnQiPuS4reaWh++8iOe5gemrlDwvYT48L2xpPjwvdWw+CjxwPjxiciAvPgo8L3A+CjxoMj48c3BhbiBjbGFzcz0ibXctaGVhZGxpbmUiIGlkPSJDb250cmlidXRvcl9JbmZvcm1hdGlvbiI+Q29udHJpYnV0b3IgSW5mb3JtYXRpb248L3NwYW4+PC9oMj4KPHVsPjxsaT5Zb3UgY2FuIGZpbmQgbWFueSBQb3N0Z3JlU1FMIHVzZXJzIGFuZCBkZXZlbG9wZXJzIGNoYXR0aW5nIGluIDxhIHJlbD0ibm9mb2xsb3ciIGNsYXNzPSJleHRlcm5hbCB0ZXh0IiBocmVmPSJpcmM6Ly9pcmMubGliZXJhLmNoYXQvcG9zdGdyZXNxbCI+I3Bvc3RncmVzcWwgb24gTGliZXJhPC9hPi4gQSBsaXN0IG9mIElSQyBuaWNrIG5hbWVzIHdpdGggdGhlaXIgcmVzcGVjdGl2ZSByZWFsIHdvcmxkIG5hbWVzIGNhbiBiZSBmb3VuZCA8YSBocmVmPSIvd2lraS9JUkMyUldOYW1lcyIgdGl0bGU9IklSQzJSV05hbWVzIj4gaGVyZTwvYT4uPC9saT4KPGxpPjxhIGhyZWY9Ii93aWtpL0V2ZW50cyIgdGl0bGU9IkV2ZW50cyI+IFVwY29taW5nIEV2ZW50czwvYT48L2xpPgo8bGk+PGEgaHJlZj0iL3dpa2kvRGV2ZWxvcG1lbnRfaW5mb3JtYXRpb24iIHRpdGxlPSJEZXZlbG9wbWVudCBpbmZvcm1hdGlvbiI+RGV2ZWxvcG1lbnQgaW5mb3JtYXRpb248L2E+PC9saT4KPGxpPjxhIGhyZWY9Ii93aWtpL0Fkdm9jYWN5IiB0aXRsZT0iQWR2b2NhY3kiPkFkdm9jYWN5PC9hPjwvbGk+PC91bD4KPGgyPjxzcGFuIGNsYXNzPSJtdy1oZWFkbGluZSIgaWQ9IlVzZXJfQWNjb3VudHMiPlVzZXIgQWNjb3VudHM8L3NwYW4+PC9oMj4KPHVsPjxsaT5BbGwgYWN0aXZpdHkgb24gdGhpcyBzaXRlIHNob3VsZCBmb2xsb3cgdGhlIDxhIGhyZWY9Ii93aWtpL1BvbGljaWVzIiB0aXRsZT0iUG9saWNpZXMiPlBvc3RncmVTUUwgUHJvamVjdCBQb2xpY2llczwvYT4uPC9saT4KPGxpPkluIG9yZGVyIHRvIGVkaXQgb3IgY3JlYXRlIGRvY3VtZW50cyBvbiB0aGUgc2l0ZSwgeW91IHdpbGwgbmVlZCBhIDxhIHJlbD0ibm9mb2xsb3ciIGNsYXNzPSJleHRlcm5hbCB0ZXh0IiBocmVmPSJodHRwczovL3d3dy5wb3N0Z3Jlc3FsLm9yZy9hY2NvdW50L2xvZ2luLyI+UG9zdGdyZVNRTCBjb21tdW5pdHkgYWNjb3VudDwvYT4uIFRoaXMgaXMgdGhlIHNhbWUgYWNjb3VudCB1c2VkIHdoZW4gc3VibWl0dGluZyBuZXdzIG9yIGV2ZW50cyBvbiA8YSByZWw9Im5vZm9sbG93IiBjbGFzcz0iZXh0ZXJuYWwgdGV4dCIgaHJlZj0iaHR0cDovL3d3dy5wb3N0Z3Jlc3FsLm9yZyI+d3d3LnBvc3RncmVzcWwub3JnPC9hPi48L2xpPjwvdWw+CjxwPjxiPk5PVEU6IGR1ZSB0byByZWNlbnQgc3BhbSBhY3Rpdml0eSAiZWRpdG9yIiBwcml2aWxlZ2VzIGFyZSBncmFudGVkIG1hbnVhbGx5IGZvciB0aGUgdGltZSBiZWluZy4gSWYgeW91IGp1c3QgY3JlYXRlZCBhIG5ldyBjb21tdW5pdHkgYWNjb3VudCBvciBpZiB5b3VyIGN1cnJlbnQgYWNjb3VudCB1c2VkIHRvIGhhdmUgImVkaXRvciIgcHJpdmlsZWdlcyBhc2sgb24gdGhlIDxhIHJlbD0ibm9mb2xsb3ciIGNsYXNzPSJleHRlcm5hbCB0ZXh0IiBocmVmPSJtYWlsdG86cGdzcWwtd3d3QHBvc3RncmVzcWwub3JnIj5Qb3N0Z3JlU1FMIC13d3cgTWFpbGluZ2xpc3Q8L2E+IGZvciBoZWxwLiAgUGxlYXNlIGluY2x1ZGUgeW91ciBjb21tdW5pdHkgYWNjb3VudCBuYW1lIGluIHRob3NlIHJlcXVlc3RzLjwvYj4KPC9wPgo8IS0tIApOZXdQUCBsaW1pdCByZXBvcnQKQ2FjaGVkIHRpbWU6IDIwMjYwNTA5MDkyMTM4CkNhY2hlIGV4cGlyeTogODY0MDAKUmVkdWNlZCBleHBpcnk6IGZhbHNlCkNvbXBsaWNhdGlvbnM6IFtdCkNQVSB0aW1lIHVzYWdlOiAwLjAzMyBzZWNvbmRzClJlYWwgdGltZSB1c2FnZTogMC4wNDUgc2Vjb25kcwpQcmVwcm9jZXNzb3IgdmlzaXRlZCBub2RlIGNvdW50OiA0OS8xMDAwMDAwClBvc3TigJBleHBhbmQgaW5jbHVkZSBzaXplOiAwLzIwOTcxNTIgYnl0ZXMKVGVtcGxhdGUgYXJndW1lbnQgc2l6ZTogMC8yMDk3MTUyIGJ5dGVzCkhpZ2hlc3QgZXhwYW5zaW9uIGRlcHRoOiAyLzEwMApFeHBlbnNpdmUgcGFyc2VyIGZ1bmN0aW9uIGNvdW50OiAwLzEwMApVbnN0cmlwIHJlY3Vyc2lvbiBkZXB0aDogMC8yMApVbnN0cmlwIHBvc3TigJBleHBhbmQgc2l6ZTogMC81MDAwMDAwIGJ5dGVzCi0tPgo8IS0tClRyYW5zY2x1c2lvbiBleHBhbnNpb24gdGltZSByZXBvcnQgKCUsbXMsY2FsbHMsdGVtcGxhdGUpCjEwMC4wMCUgICAgOS4zMDAgICAgICAxIFRlbXBsYXRlOkxhbmd1YWdlcwoxMDAuMDAlICAgIDkuMzAwICAgICAgMSAtdG90YWwKLS0+Cgo8IS0tIFNhdmVkIGluIHBhcnNlciBjYWNoZSB3aXRoIGtleSB3aWtpZGItbWVkaWF3aWtpLTpwY2FjaGU6aWRoYXNoOjEtMCFjYW5vbmljYWwgYW5kIHRpbWVzdGFtcCAyMDI2MDUwOTA5MjEzOCBhbmQgcmV2aXNpb24gaWQgNDIwNDguCiAtLT4KPC9kaXY+CjxkaXYgY2xhc3M9InByaW50Zm9vdGVyIiBkYXRhLW5vc25pcHBldD0iIj5SZXRyaWV2ZWQgZnJvbSAiPGEgZGlyPSJsdHIiIGhyZWY9Imh0dHBzOi8vd2lraS5wb3N0Z3Jlc3FsLm9yZy9pbmRleC5waHA/dGl0bGU9TWFpbl9QYWdlJmFtcDtvbGRpZD00MjA0OCI+aHR0cHM6Ly93aWtpLnBvc3RncmVzcWwub3JnL2luZGV4LnBocD90aXRsZT1NYWluX1BhZ2UmYW1wO29sZGlkPTQyMDQ4PC9hPiI8L2Rpdj48L2Rpdj4KCQkJCTxkaXYgaWQ9ImNhdGxpbmtzIiBjbGFzcz0iY2F0bGlua3MgY2F0bGlua3MtYWxsaGlkZGVuIiBkYXRhLW13PSJpbnRlcmZhY2UiPjwvZGl2PgoJCQkJPCEtLSBlbmQgY29udGVudCAtLT4KCQkJCTxkaXYgY2xhc3M9InZpc3VhbENsZWFyIj48L2Rpdj4KCQkJPC9kaXY+CgkJPC9kaXY+CgkJPGRpdiBjbGFzcz0idmlzdWFsQ2xlYXIiPjwvZGl2PgoJPC9kaXY+Cgk8ZGl2IGlkPSJjb2x1bW4tb25lIiA+CgkJPGgyPk5hdmlnYXRpb24gbWVudTwvaDI+CgkJPGRpdiByb2xlPSJuYXZpZ2F0aW9uIiBjbGFzcz0icG9ydGxldCIgaWQ9InAtY2FjdGlvbnMiIGFyaWEtbGFiZWxsZWRieT0icC1jYWN0aW9ucy1sYWJlbCI+CgkJCTxoMyBpZD0icC1jYWN0aW9ucy1sYWJlbCIgPlBhZ2UgYWN0aW9uczwvaDM+CgkJCTxkaXYgY2xhc3M9InBCb2R5Ij4KCQkJCTx1bCA+CgkJCQk8bGkgaWQ9ImNhLW5zdGFiLW1haW4iIGNsYXNzPSJzZWxlY3RlZCBtdy1saXN0LWl0ZW0iPjxhIGhyZWY9Ii93aWtpL01haW5fUGFnZSIgdGl0bGU9IlZpZXcgdGhlIGNvbnRlbnQgcGFnZSBbY10iIGFjY2Vzc2tleT0iYyI+TWFpbiBQYWdlPC9hPjwvbGk+PGxpIGlkPSJjYS10YWxrIiBjbGFzcz0ibXctbGlzdC1pdGVtIj48YSBocmVmPSIvd2lraS9UYWxrOk1haW5fUGFnZSIgcmVsPSJkaXNjdXNzaW9uIiB0aXRsZT0iRGlzY3Vzc2lvbiBhYm91dCB0aGUgY29udGVudCBwYWdlIFt0XSIgYWNjZXNza2V5PSJ0Ij5EaXNjdXNzaW9uPC9hPjwvbGk+PGxpIGlkPSJjYS12aWV3IiBjbGFzcz0ic2VsZWN0ZWQgbXctbGlzdC1pdGVtIj48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UiPlJlYWQ8L2E+PC9saT48bGkgaWQ9ImNhLXZpZXdzb3VyY2UiIGNsYXNzPSJtdy1saXN0LWl0ZW0iPjxhIGhyZWY9Ii9pbmRleC5waHA/dGl0bGU9TWFpbl9QYWdlJmFtcDthY3Rpb249ZWRpdCIgdGl0bGU9IlRoaXMgcGFnZSBpcyBwcm90ZWN0ZWQuJiMxMDtZb3UgY2FuIHZpZXcgaXRzIHNvdXJjZSBbZV0iIGFjY2Vzc2tleT0iZSI+VmlldyBzb3VyY2U8L2E+PC9saT48bGkgaWQ9ImNhLWhpc3RvcnkiIGNsYXNzPSJtdy1saXN0LWl0ZW0iPjxhIGhyZWY9Ii9pbmRleC5waHA/dGl0bGU9TWFpbl9QYWdlJmFtcDthY3Rpb249aGlzdG9yeSIgdGl0bGU9IlBhc3QgcmV2aXNpb25zIG9mIHRoaXMgcGFnZSBbaF0iIGFjY2Vzc2tleT0iaCI+SGlzdG9yeTwvYT48L2xpPgoJCQkJCgkJCQk8L3VsPgoJCQk8L2Rpdj4KCQk8L2Rpdj4KCQkKPGRpdiByb2xlPSJuYXZpZ2F0aW9uIiBjbGFzcz0icG9ydGxldCBtdy1wb3J0bGV0IG13LXBvcnRsZXQtY2FjdGlvbnMtbW9iaWxlIgoJaWQ9InAtY2FjdGlvbnMtbW9iaWxlIiBhcmlhLWxhYmVsbGVkYnk9InAtY2FjdGlvbnMtbW9iaWxlLWxhYmVsIj4KCTxoMyBpZD0icC1jYWN0aW9ucy1tb2JpbGUtbGFiZWwiID5QYWdlIGFjdGlvbnM8L2gzPgoJPGRpdiBjbGFzcz0icEJvZHkiPgoJCTx1bCA+PGxpIGlkPSJtYWluLW1vYmlsZSIgY2xhc3M9InNlbGVjdGVkIG13LWxpc3QtaXRlbSI+PGEgaHJlZj0iL3dpa2kvTWFpbl9QYWdlIiB0aXRsZT0iTWFpbiBQYWdlIj5NYWluIFBhZ2U8L2E+PC9saT48bGkgaWQ9InRhbGstbW9iaWxlIiBjbGFzcz0ibXctbGlzdC1pdGVtIj48YSBocmVmPSIvd2lraS9UYWxrOk1haW5fUGFnZSIgdGl0bGU9IkRpc2N1c3Npb24iPkRpc2N1c3Npb248L2E+PC9saT48bGkgaWQ9ImNhLW1vcmUiIGNsYXNzPSJtdy1saXN0LWl0ZW0iPjxhIGhyZWY9IiNwLWNhY3Rpb25zIj5Nb3JlPC9hPjwvbGk+PGxpIGlkPSJjYS10b29scyIgY2xhc3M9Im13LWxpc3QtaXRlbSI+PGEgaHJlZj0iI3AtdGIiIHRpdGxlPSJUb29scyI+VG9vbHM8L2E+PC9saT48L3VsPgoJCQoJPC9kaXY+CjwvZGl2PgoKCQk8ZGl2IHJvbGU9Im5hdmlnYXRpb24iIGNsYXNzPSJwb3J0bGV0IiBpZD0icC1wZXJzb25hbCIgYXJpYS1sYWJlbGxlZGJ5PSJwLXBlcnNvbmFsLWxhYmVsIj4KCQkJPGgzIGlkPSJwLXBlcnNvbmFsLWxhYmVsIiA+UGVyc29uYWwgdG9vbHM8L2gzPgoJCQk8ZGl2IGNsYXNzPSJwQm9keSI+CgkJCQk8dWwgPgoJCQkJPGxpIGlkPSJwdC1sb2dpbiIgY2xhc3M9Im13LWxpc3QtaXRlbSI+PGEgaHJlZj0iL2luZGV4LnBocD90aXRsZT1TcGVjaWFsOlVzZXJMb2dpbiZhbXA7cmV0dXJudG89TWFpbitQYWdlIiB0aXRsZT0iWW91IG11c3QgbG9nIGluIHRvIGVkaXQgYW55IHBhZ2VzIG9uIHRoaXMgc2l0ZS4gW29dIiBhY2Nlc3NrZXk9Im8iPkxvZyBpbjwvYT48L2xpPgoJCQkJPC91bD4KCQkJPC9kaXY+CgkJPC9kaXY+CgkJPGRpdiBjbGFzcz0icG9ydGxldCIgaWQ9InAtbG9nbyIgcm9sZT0iYmFubmVyIj4KCQkJPGEgaHJlZj0iL3dpa2kvTWFpbl9QYWdlIiBjbGFzcz0ibXctd2lraS1sb2dvIj48L2E+CgkJPC9kaXY+CgkJPGRpdiBpZD0ic2lkZWJhciI+CgkJCjxkaXYgcm9sZT0ibmF2aWdhdGlvbiIgY2xhc3M9InBvcnRsZXQgbXctcG9ydGxldCBtdy1wb3J0bGV0LW5hdmlnYXRpb24iCglpZD0icC1uYXZpZ2F0aW9uIiBhcmlhLWxhYmVsbGVkYnk9InAtbmF2aWdhdGlvbi1sYWJlbCI+Cgk8aDMgaWQ9InAtbmF2aWdhdGlvbi1sYWJlbCIgPk5hdmlnYXRpb248L2gzPgoJPGRpdiBjbGFzcz0icEJvZHkiPgoJCTx1bCA+PGxpIGlkPSJuLW1haW5wYWdlIiBjbGFzcz0ibXctbGlzdC1pdGVtIj48YSBocmVmPSIvd2lraS9NYWluX1BhZ2UiIHRpdGxlPSJWaXNpdCB0aGUgbWFpbiBwYWdlIFt6XSIgYWNjZXNza2V5PSJ6Ij5NYWluIFBhZ2U8L2E+PC9saT48bGkgaWQ9Im4tcmFuZG9tcGFnZSIgY2xhc3M9Im13LWxpc3QtaXRlbSI+PGEgaHJlZj0iL3dpa2kvU3BlY2lhbDpSYW5kb20iIHRpdGxlPSJMb2FkIGEgcmFuZG9tIHBhZ2UgW3hdIiBhY2Nlc3NrZXk9IngiPlJhbmRvbSBwYWdlPC9hPjwvbGk+PGxpIGlkPSJuLXJlY2VudGNoYW5nZXMiIGNsYXNzPSJtdy1saXN0LWl0ZW0iPjxhIGhyZWY9Ii93aWtpL1NwZWNpYWw6UmVjZW50Q2hhbmdlcyIgdGl0bGU9IkEgbGlzdCBvZiByZWNlbnQgY2hhbmdlcyBpbiB0aGUgd2lraSBbcl0iIGFjY2Vzc2tleT0iciI+UmVjZW50IGNoYW5nZXM8L2E+PC9saT48bGkgaWQ9Im4taGVscCIgY2xhc3M9Im13LWxpc3QtaXRlbSI+PGEgaHJlZj0iaHR0cHM6Ly93d3cubWVkaWF3aWtpLm9yZy93aWtpL1NwZWNpYWw6TXlMYW5ndWFnZS9IZWxwOkNvbnRlbnRzIiB0aXRsZT0iVGhlIHBsYWNlIHRvIGZpbmQgb3V0Ij5IZWxwPC9hPjwvbGk+PC91bD4KCQkKCTwvZGl2Pgo8L2Rpdj4KCgkJPGRpdiByb2xlPSJzZWFyY2giIGNsYXNzPSJwb3J0bGV0IiBpZD0icC1zZWFyY2giPgoJCQk8aDMgaWQ9InAtc2VhcmNoLWxhYmVsIiA+PGxhYmVsIGZvcj0ic2VhcmNoSW5wdXQiPlNlYXJjaDwvbGFiZWw+PC9oMz4KCQkJPGRpdiBjbGFzcz0icEJvZHkiIGlkPSJzZWFyY2hCb2R5Ij4KCQkJCTxmb3JtIGFjdGlvbj0iL2luZGV4LnBocCIgaWQ9InNlYXJjaGZvcm0iPjxpbnB1dCB0eXBlPSJoaWRkZW4iIHZhbHVlPSJTcGVjaWFsOlNlYXJjaCIgbmFtZT0idGl0bGUiPjxpbnB1dCB0eXBlPSJzZWFyY2giIG5hbWU9InNlYXJjaCIgcGxhY2Vob2xkZXI9IlNlYXJjaCBQb3N0Z3JlU1FMIHdpa2kiIGFyaWEtbGFiZWw9IlNlYXJjaCBQb3N0Z3JlU1FMIHdpa2kiIGF1dG9jYXBpdGFsaXplPSJzZW50ZW5jZXMiIHRpdGxlPSJTZWFyY2ggUG9zdGdyZVNRTCB3aWtpIFtmXSIgYWNjZXNza2V5PSJmIiBpZD0ic2VhcmNoSW5wdXQiLz48aW5wdXQgdHlwZT0ic3VibWl0IiBuYW1lPSJnbyIgdmFsdWU9IkdvIiB0aXRsZT0iR28gdG8gYSBwYWdlIHdpdGggdGhpcyBleGFjdCBuYW1lIGlmIGl0IGV4aXN0cyIgY2xhc3M9InNlYXJjaEJ1dHRvbiIgaWQ9InNlYXJjaEJ1dHRvbiIvPiA8aW5wdXQgdHlwZT0ic3VibWl0IiBuYW1lPSJmdWxsdGV4dCIgdmFsdWU9IlNlYXJjaCIgdGl0bGU9IlNlYXJjaCB0aGUgcGFnZXMgZm9yIHRoaXMgdGV4dCIgY2xhc3M9InNlYXJjaEJ1dHRvbiBtdy1mYWxsYmFja1NlYXJjaEJ1dHRvbiIgaWQ9Im13LXNlYXJjaEJ1dHRvbiIvPjwvZm9ybT4KCQkJPC9kaXY+CgkJPC9kaXY+CgkJCjxkaXYgcm9sZT0ibmF2aWdhdGlvbiIgY2xhc3M9InBvcnRsZXQgbXctcG9ydGxldCBtdy1wb3J0bGV0LXRiIgoJaWQ9InAtdGIiIGFyaWEtbGFiZWxsZWRieT0icC10Yi1sYWJlbCI+Cgk8aDMgaWQ9InAtdGItbGFiZWwiID5Ub29sczwvaDM+Cgk8ZGl2IGNsYXNzPSJwQm9keSI+CgkJPHVsID48bGkgaWQ9InQtd2hhdGxpbmtzaGVyZSIgY2xhc3M9Im13LWxpc3QtaXRlbSI+PGEgaHJlZj0iL3dpa2kvU3BlY2lhbDpXaGF0TGlua3NIZXJlL01haW5fUGFnZSIgdGl0bGU9IkEgbGlzdCBvZiBhbGwgd2lraSBwYWdlcyB0aGF0IGxpbmsgaGVyZSBbal0iIGFjY2Vzc2tleT0iaiI+V2hhdCBsaW5rcyBoZXJlPC9hPjwvbGk+PGxpIGlkPSJ0LXJlY2VudGNoYW5nZXNsaW5rZWQiIGNsYXNzPSJtdy1saXN0LWl0ZW0iPjxhIGhyZWY9Ii93aWtpL1NwZWNpYWw6UmVjZW50Q2hhbmdlc0xpbmtlZC9NYWluX1BhZ2UiIHJlbD0ibm9mb2xsb3ciIHRpdGxlPSJSZWNlbnQgY2hhbmdlcyBpbiBwYWdlcyBsaW5rZWQgZnJvbSB0aGlzIHBhZ2UgW2tdIiBhY2Nlc3NrZXk9ImsiPlJlbGF0ZWQgY2hhbmdlczwvYT48L2xpPjxsaSBpZD0idC1zcGVjaWFscGFnZXMiIGNsYXNzPSJtdy1saXN0LWl0ZW0iPjxhIGhyZWY9Ii93aWtpL1NwZWNpYWw6U3BlY2lhbFBhZ2VzIiB0aXRsZT0iQSBsaXN0IG9mIGFsbCBzcGVjaWFsIHBhZ2VzIFtxXSIgYWNjZXNza2V5PSJxIj5TcGVjaWFsIHBhZ2VzPC9hPjwvbGk+PGxpIGlkPSJ0LXByaW50IiBjbGFzcz0ibXctbGlzdC1pdGVtIj48YSBocmVmPSJqYXZhc2NyaXB0OnByaW50KCk7IiByZWw9ImFsdGVybmF0ZSIgdGl0bGU9IlByaW50YWJsZSB2ZXJzaW9uIG9mIHRoaXMgcGFnZSBbcF0iIGFjY2Vzc2tleT0icCI+UHJpbnRhYmxlIHZlcnNpb248L2E+PC9saT48bGkgaWQ9InQtcGVybWFsaW5rIiBjbGFzcz0ibXctbGlzdC1pdGVtIj48YSBocmVmPSIvaW5kZXgucGhwP3RpdGxlPU1haW5fUGFnZSZhbXA7b2xkaWQ9NDIwNDgiIHRpdGxlPSJQZXJtYW5lbnQgbGluayB0byB0aGlzIHJldmlzaW9uIG9mIHRoaXMgcGFnZSI+UGVybWFuZW50IGxpbms8L2E+PC9saT48bGkgaWQ9InQtaW5mbyIgY2xhc3M9Im13LWxpc3QtaXRlbSI+PGEgaHJlZj0iL2luZGV4LnBocD90aXRsZT1NYWluX1BhZ2UmYW1wO2FjdGlvbj1pbmZvIiB0aXRsZT0iTW9yZSBpbmZvcm1hdGlvbiBhYm91dCB0aGlzIHBhZ2UiPlBhZ2UgaW5mb3JtYXRpb248L2E+PC9saT48L3VsPgoJCQoJPC9kaXY+CjwvZGl2PgoKCQkKCQk8L2Rpdj4KCQk8YSBocmVmPSIjc2lkZWJhciIgdGl0bGU9Ikp1bXAgdG8gbmF2aWdhdGlvbiIKCQkJY2xhc3M9Im1lbnUtdG9nZ2xlIiBpZD0ic2lkZWJhci10b2dnbGUiPjwvYT4KCQk8YSBocmVmPSIjcC1wZXJzb25hbCIgdGl0bGU9InVzZXIgdG9vbHMiCgkJCWNsYXNzPSJtZW51LXRvZ2dsZSIgaWQ9InAtcGVyc29uYWwtdG9nZ2xlIj48L2E+CgkJPGEgaHJlZj0iI2dsb2JhbFdyYXBwZXIiIHRpdGxlPSJiYWNrIHRvIHRvcCIKCQkJY2xhc3M9Im1lbnUtdG9nZ2xlIiBpZD0iZ2xvYmFsV3JhcHBlci10b2dnbGUiPjwvYT4KCTwvZGl2PgoJPCEtLSBlbmQgb2YgdGhlIGxlZnQgKGJ5IGRlZmF1bHQgYXQgbGVhc3QpIGNvbHVtbiAtLT4KCTxkaXYgY2xhc3M9InZpc3VhbENsZWFyIj48L2Rpdj4KCTxkaXYgaWQ9ImZvb3RlciIgY2xhc3M9Im13LWZvb3RlciIgcm9sZT0iY29udGVudGluZm8iCgkJPgoJCTxkaXYgaWQ9ImYtcG93ZXJlZGJ5aWNvIiBjbGFzcz0iZm9vdGVyLWljb25zIj4KCQkJPGEgaHJlZj0iaHR0cHM6Ly93d3cubWVkaWF3aWtpLm9yZy8iPjxpbWcgc3JjPSIvcmVzb3VyY2VzL2Fzc2V0cy9wb3dlcmVkYnlfbWVkaWF3aWtpXzg4eDMxLnBuZyIgYWx0PSJQb3dlcmVkIGJ5IE1lZGlhV2lraSIgc3Jjc2V0PSIvcmVzb3VyY2VzL2Fzc2V0cy9wb3dlcmVkYnlfbWVkaWF3aWtpXzEzMng0Ny5wbmcgMS41eCwgL3Jlc291cmNlcy9hc3NldHMvcG93ZXJlZGJ5X21lZGlhd2lraV8xNzZ4NjIucG5nIDJ4IiB3aWR0aD0iODgiIGhlaWdodD0iMzEiIGxvYWRpbmc9ImxhenkiLz48L2E+CgkJPC9kaXY+CgkJPHVsIGlkPSJmLWxpc3QiPgoJCQk8bGkgaWQ9Imxhc3Rtb2QiPiBUaGlzIHBhZ2Ugd2FzIGxhc3QgZWRpdGVkIG9uIDIzIE9jdG9iZXIgMjAyNSwgYXQgMTQ6NTQuPC9saT4KCQkJPGxpIGlkPSJwcml2YWN5Ij48YSBocmVmPSIvd2lraS9Qb3N0Z3JlU1FMX3dpa2k6UHJpdmFjeV9wb2xpY3kiPlByaXZhY3kgcG9saWN5PC9hPjwvbGk+PGxpIGlkPSJhYm91dCI+PGEgaHJlZj0iL3dpa2kvUG9zdGdyZVNRTF93aWtpOkFib3V0Ij5BYm91dCBQb3N0Z3JlU1FMIHdpa2k8L2E+PC9saT48bGkgaWQ9ImRpc2NsYWltZXIiPjxhIGhyZWY9Ii93aWtpL1Bvc3RncmVTUUxfd2lraTpHZW5lcmFsX2Rpc2NsYWltZXIiPkRpc2NsYWltZXJzPC9hPjwvbGk+CgkJPC91bD4KCTwvZGl2Pgo8L2Rpdj4KPHNjcmlwdD4oUkxRPXdpbmRvdy5STFF8fFtdKS5wdXNoKGZ1bmN0aW9uKCl7bXcuY29uZmlnLnNldCh7IndnUGFnZVBhcnNlUmVwb3J0Ijp7ImxpbWl0cmVwb3J0Ijp7ImNwdXRpbWUiOiIwLjAzMyIsIndhbGx0aW1lIjoiMC4wNDUiLCJwcHZpc2l0ZWRub2RlcyI6eyJ2YWx1ZSI6NDksImxpbWl0IjoxMDAwMDAwfSwicG9zdGV4cGFuZGluY2x1ZGVzaXplIjp7InZhbHVlIjowLCJsaW1pdCI6MjA5NzE1Mn0sInRlbXBsYXRlYXJndW1lbnRzaXplIjp7InZhbHVlIjowLCJsaW1pdCI6MjA5NzE1Mn0sImV4cGFuc2lvbmRlcHRoIjp7InZhbHVlIjoyLCJsaW1pdCI6MTAwfSwiZXhwZW5zaXZlZnVuY3Rpb25jb3VudCI6eyJ2YWx1ZSI6MCwibGltaXQiOjEwMH0sInVuc3RyaXAtZGVwdGgiOnsidmFsdWUiOjAsImxpbWl0IjoyMH0sInVuc3RyaXAtc2l6ZSI6eyJ2YWx1ZSI6MCwibGltaXQiOjUwMDAwMDB9LCJ0aW1pbmdwcm9maWxlIjpbIjEwMC4wMCUgICAgOS4zMDAgICAgICAxIFRlbXBsYXRlOkxhbmd1YWdlcyIsIjEwMC4wMCUgICAgOS4zMDAgICAgICAxIC10b3RhbCJdfSwiY2FjaGVyZXBvcnQiOnsidGltZXN0YW1wIjoiMjAyNjA1MDkwOTIxMzgiLCJ0dGwiOjg2NDAwLCJ0cmFuc2llbnRjb250ZW50IjpmYWxzZX19fSk7bXcuY29uZmlnLnNldCh7IndnQmFja2VuZFJlc3BvbnNlVGltZSI6MjAzfSk7fSk7PC9zY3JpcHQ+CjwvYm9keT4KPC9odG1sPg==
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/exec
+          verbs:
+          - create
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - cert-manager.io
+          resources:
+          - certificates
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - postgres.keiailab.io
+          resources:
+          - backupjobs
+          - poolers
+          - postgresclusters
+          - postgresdatabases
+          - postgresusers
+          - scheduledbackups
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - postgres.keiailab.io
+          resources:
+          - backupjobs/finalizers
+          - poolers/finalizers
+          - postgresclusters/finalizers
+          - postgresdatabases/finalizers
+          - scheduledbackups/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - postgres.keiailab.io
+          resources:
+          - backupjobs/status
+          - poolers/status
+          - postgresclusters/status
+          - postgresdatabases/status
+          - postgresusers/status
+          - scheduledbackups/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - postgres.keiailab.io
+          resources:
+          - clusterimagecatalogs
+          - imagecatalogs
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: postgres-operator
+          control-plane: controller-manager
+        name: controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: postgres-operator
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app.kubernetes.io/name: postgres-operator
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                command:
+                - /manager
+                image: ghcr.io/keiailab/postgres-operator:0.3.0-alpha.18
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 8081
+                  name: health
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - postgres
+  - postgresql
+  - database
+  - high-availability
+  - replication
+  - failover
+  - pgbackrest
+  - backup
+  links:
+  - name: GitHub
+    url: https://github.com/keiailab/postgres-operator
+  - name: Documentation
+    url: https://github.com/keiailab/postgres-operator/blob/main/README.md
+  - name: Helm Repository
+    url: https://keiailab.github.io/postgres-operator
+  - name: Discussions
+    url: https://github.com/keiailab/postgres-operator/discussions
+  maintainers:
+  - email: help@masblue.studio
+    name: Keiailab
+  maturity: alpha
+  minKubeVersion: 1.26.0
+  provider:
+    name: Keiailab
+    url: https://github.com/keiailab
+  version: 0.3.0-alpha.18

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_backupjobs.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_backupjobs.yaml
@@ -1,0 +1,9264 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  creationTimestamp: null
+  name: backupjobs.postgres.keiailab.io
+spec:
+  group: postgres.keiailab.io
+  names:
+    categories:
+    - postgres
+    - backup
+    - all
+    kind: BackupJob
+    listKind: BackupJobList
+    plural: backupjobs
+    shortNames:
+    - bj
+    singular: backupjob
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .spec.tool
+      name: Tool
+      type: string
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          BackupJob은 단일 백업 실행 명령이다 (RFC 0004).
+
+          본 CRD는 *atomic 단위*다 — 변경 시 새 BackupJob 생성. cron 기반 정기 백업은
+          ScheduledBackup CRD 가 BackupJob 을 생성하는 방식으로 분리한다.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              BackupJobSpec은 단일 백업 호출의 명세다 (RFC 0004 §2.1).
+
+              immutable 필드 (생성 후 변경 불가, webhook이 reject 예정 — phase 2):
+                - cluster.name
+                - tool
+                - type
+                - executionMode
+            properties:
+              cluster:
+                description: Cluster는 백업 대상 PostgresCluster 참조 (같은 namespace).
+                properties:
+                  name:
+                    description: Name은 PostgresCluster.metadata.name.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              executionMode:
+                description: |-
+                  ExecutionMode는 plugin이 백업을 *어디서 실행*할지 결정 (P1-6, RFC 0004 §3.1):
+                    - "sidecar": PG Pod 동거 컨테이너 (pgBackRest 패턴)
+                    - "job":     standalone K8s Job (WAL-G 패턴)
+                    - "":        plugin default
+                enum:
+                - sidecar
+                - job
+                - ""
+                type: string
+              jobTemplate:
+                description: |-
+                  JobTemplate은 ExecutionMode="job"일 때 생성할 runner batch/v1 Job 템플릿이다.
+                  operator는 name/namespace/ownerReference/표준 label/env만 주입하고, image,
+                  command, volume, secret, resource, securityContext 같은 실행 세부사항은 본
+                  템플릿을 그대로 따른다.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata of the jobs created from this template.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the job.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      activeDeadlineSeconds:
+                        description: |-
+                          Specifies the duration in seconds relative to the startTime that the job
+                          may be continuously active before the system tries to terminate it; value
+                          must be positive integer. If a Job is suspended (at creation or through an
+                          update), this timer will effectively be stopped and reset when the Job is
+                          resumed again.
+                        format: int64
+                        type: integer
+                      backoffLimit:
+                        description: |-
+                          Specifies the number of retries before marking this job failed.
+                          Defaults to 6, unless backoffLimitPerIndex (only Indexed Job) is specified.
+                          When backoffLimitPerIndex is specified, backoffLimit defaults to 2147483647.
+                        format: int32
+                        type: integer
+                      backoffLimitPerIndex:
+                        description: |-
+                          Specifies the limit for the number of retries within an
+                          index before marking this index as failed. When enabled the number of
+                          failures per index is kept in the pod's
+                          batch.kubernetes.io/job-index-failure-count annotation. It can only
+                          be set when Job's completionMode=Indexed, and the Pod's restart
+                          policy is Never. The field is immutable.
+                        format: int32
+                        type: integer
+                      completionMode:
+                        description: |-
+                          completionMode specifies how Pod completions are tracked. It can be
+                          `NonIndexed` (default) or `Indexed`.
+
+                          `NonIndexed` means that the Job is considered complete when there have
+                          been .spec.completions successfully completed Pods. Each Pod completion is
+                          homologous to each other.
+
+                          `Indexed` means that the Pods of a
+                          Job get an associated completion index from 0 to (.spec.completions - 1),
+                          available in the annotation batch.kubernetes.io/job-completion-index.
+                          The Job is considered complete when there is one successfully completed Pod
+                          for each index.
+                          When value is `Indexed`, .spec.completions must be specified and
+                          `.spec.parallelism` must be less than or equal to 10^5.
+                          In addition, The Pod name takes the form
+                          `$(job-name)-$(index)-$(random-string)`,
+                          the Pod hostname takes the form `$(job-name)-$(index)`.
+
+                          More completion modes can be added in the future.
+                          If the Job controller observes a mode that it doesn't recognize, which
+                          is possible during upgrades due to version skew, the controller
+                          skips updates for the Job.
+                        type: string
+                      completions:
+                        description: |-
+                          Specifies the desired number of successfully finished pods the
+                          job should be run with.  Setting to null means that the success of any
+                          pod signals the success of all pods, and allows parallelism to have any positive
+                          value.  Setting to 1 means that parallelism is limited to 1 and the success of that
+                          pod signals the success of the job.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                        format: int32
+                        type: integer
+                      managedBy:
+                        description: |-
+                          ManagedBy field indicates the controller that manages a Job. The k8s Job
+                          controller reconciles jobs which don't have this field at all or the field
+                          value is the reserved string `kubernetes.io/job-controller`, but skips
+                          reconciling Jobs with a custom value for this field.
+                          The value must be a valid domain-prefixed path (e.g. acme.io/foo) -
+                          all characters before the first "/" must be a valid subdomain as defined
+                          by RFC 1123. All characters trailing the first "/" must be valid HTTP Path
+                          characters as defined by RFC 3986. The value cannot exceed 63 characters.
+                          This field is immutable.
+                        type: string
+                      manualSelector:
+                        description: |-
+                          manualSelector controls generation of pod labels and pod selectors.
+                          Leave `manualSelector` unset unless you are certain what you are doing.
+                          When false or unset, the system pick labels unique to this job
+                          and appends those labels to the pod template.  When true,
+                          the user is responsible for picking unique labels and specifying
+                          the selector.  Failure to pick a unique label may cause this
+                          and other jobs to not function correctly.  However, You may see
+                          `manualSelector=true` in jobs that were created with the old `extensions/v1beta1`
+                          API.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector
+                        type: boolean
+                      maxFailedIndexes:
+                        description: |-
+                          Specifies the maximal number of failed indexes before marking the Job as
+                          failed, when backoffLimitPerIndex is set. Once the number of failed
+                          indexes exceeds this number the entire Job is marked as Failed and its
+                          execution is terminated. When left as null the job continues execution of
+                          all of its indexes and is marked with the `Complete` Job condition.
+                          It can only be specified when backoffLimitPerIndex is set.
+                          It can be null or up to completions. It is required and must be
+                          less than or equal to 10^4 when is completions greater than 10^5.
+                        format: int32
+                        type: integer
+                      parallelism:
+                        description: |-
+                          Specifies the maximum desired number of pods the job should
+                          run at any given time. The actual number of pods running in steady state will
+                          be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism),
+                          i.e. when the work left to do is less than max parallelism.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                        format: int32
+                        type: integer
+                      podFailurePolicy:
+                        description: |-
+                          Specifies the policy of handling failed pods. In particular, it allows to
+                          specify the set of actions and conditions which need to be
+                          satisfied to take the associated action.
+                          If empty, the default behaviour applies - the counter of failed pods,
+                          represented by the jobs's .status.failed field, is incremented and it is
+                          checked against the backoffLimit. This field cannot be used in combination
+                          with restartPolicy=OnFailure.
+                        properties:
+                          rules:
+                            description: |-
+                              A list of pod failure policy rules. The rules are evaluated in order.
+                              Once a rule matches a Pod failure, the remaining of the rules are ignored.
+                              When no rule matches the Pod failure, the default handling applies - the
+                              counter of pod failures is incremented and it is checked against
+                              the backoffLimit. At most 20 elements are allowed.
+                            items:
+                              description: |-
+                                PodFailurePolicyRule describes how a pod failure is handled when the requirements are met.
+                                One of onExitCodes and onPodConditions, but not both, can be used in each rule.
+                              properties:
+                                action:
+                                  description: |-
+                                    Specifies the action taken on a pod failure when the requirements are satisfied.
+                                    Possible values are:
+
+                                    - FailJob: indicates that the pod's job is marked as Failed and all
+                                      running pods are terminated.
+                                    - FailIndex: indicates that the pod's index is marked as Failed and will
+                                      not be restarted.
+                                    - Ignore: indicates that the counter towards the .backoffLimit is not
+                                      incremented and a replacement pod is created.
+                                    - Count: indicates that the pod is handled in the default way - the
+                                      counter towards the .backoffLimit is incremented.
+                                    Additional values are considered to be added in the future. Clients should
+                                    react to an unknown action by skipping the rule.
+                                  type: string
+                                onExitCodes:
+                                  description: Represents the requirement on the container
+                                    exit codes.
+                                  properties:
+                                    containerName:
+                                      description: |-
+                                        Restricts the check for exit codes to the container with the
+                                        specified name. When null, the rule applies to all containers.
+                                        When specified, it should match one the container or initContainer
+                                        names in the pod template.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        Represents the relationship between the container exit code(s) and the
+                                        specified values. Containers completed with success (exit code 0) are
+                                        excluded from the requirement check. Possible values are:
+
+                                        - In: the requirement is satisfied if at least one container exit code
+                                          (might be multiple if there are multiple containers not restricted
+                                          by the 'containerName' field) is in the set of specified values.
+                                        - NotIn: the requirement is satisfied if at least one container exit code
+                                          (might be multiple if there are multiple containers not restricted
+                                          by the 'containerName' field) is not in the set of specified values.
+                                        Additional values are considered to be added in the future. Clients should
+                                        react to an unknown operator by assuming the requirement is not satisfied.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        Specifies the set of values. Each returned container exit code (might be
+                                        multiple in case of multiple containers) is checked against this set of
+                                        values with respect to the operator. The list of values must be ordered
+                                        and must not contain duplicates. Value '0' cannot be used for the In operator.
+                                        At least one element is required. At most 255 elements are allowed.
+                                      items:
+                                        format: int32
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  required:
+                                  - operator
+                                  - values
+                                  type: object
+                                onPodConditions:
+                                  description: |-
+                                    Represents the requirement on the pod conditions. The requirement is represented
+                                    as a list of pod condition patterns. The requirement is satisfied if at
+                                    least one pattern matches an actual pod condition. At most 20 elements are allowed.
+                                  items:
+                                    description: |-
+                                      PodFailurePolicyOnPodConditionsPattern describes a pattern for matching
+                                      an actual pod condition type.
+                                    properties:
+                                      status:
+                                        description: |-
+                                          Specifies the required Pod condition status. To match a pod condition
+                                          it is required that the specified status equals the pod condition status.
+                                          Defaults to True.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          Specifies the required Pod condition type. To match a pod condition
+                                          it is required that specified type equals the pod condition type.
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - action
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - rules
+                        type: object
+                      podReplacementPolicy:
+                        description: |-
+                          podReplacementPolicy specifies when to create replacement Pods.
+                          Possible values are:
+                          - TerminatingOrFailed means that we recreate pods
+                            when they are terminating (has a metadata.deletionTimestamp) or failed.
+                          - Failed means to wait until a previously created Pod is fully terminated (has phase
+                            Failed or Succeeded) before creating a replacement Pod.
+
+                          When using podFailurePolicy, Failed is the the only allowed value.
+                          TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use.
+                        type: string
+                      selector:
+                        description: |-
+                          A label query over pods that should match the pod count.
+                          Normally, the system sets this field for you.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      successPolicy:
+                        description: |-
+                          successPolicy specifies the policy when the Job can be declared as succeeded.
+                          If empty, the default behavior applies - the Job is declared as succeeded
+                          only when the number of succeeded pods equals to the completions.
+                          When the field is specified, it must be immutable and works only for the Indexed Jobs.
+                          Once the Job meets the SuccessPolicy, the lingering pods are terminated.
+                        properties:
+                          rules:
+                            description: |-
+                              rules represents the list of alternative rules for the declaring the Jobs
+                              as successful before `.status.succeeded >= .spec.completions`. Once any of the rules are met,
+                              the "SuccessCriteriaMet" condition is added, and the lingering pods are removed.
+                              The terminal state for such a Job has the "Complete" condition.
+                              Additionally, these rules are evaluated in order; Once the Job meets one of the rules,
+                              other rules are ignored. At most 20 elements are allowed.
+                            items:
+                              description: |-
+                                SuccessPolicyRule describes rule for declaring a Job as succeeded.
+                                Each rule must have at least one of the "succeededIndexes" or "succeededCount" specified.
+                              properties:
+                                succeededCount:
+                                  description: |-
+                                    succeededCount specifies the minimal required size of the actual set of the succeeded indexes
+                                    for the Job. When succeededCount is used along with succeededIndexes, the check is
+                                    constrained only to the set of indexes specified by succeededIndexes.
+                                    For example, given that succeededIndexes is "1-4", succeededCount is "3",
+                                    and completed indexes are "1", "3", and "5", the Job isn't declared as succeeded
+                                    because only "1" and "3" indexes are considered in that rules.
+                                    When this field is null, this doesn't default to any value and
+                                    is never evaluated at any time.
+                                    When specified it needs to be a positive integer.
+                                  format: int32
+                                  type: integer
+                                succeededIndexes:
+                                  description: |-
+                                    succeededIndexes specifies the set of indexes
+                                    which need to be contained in the actual set of the succeeded indexes for the Job.
+                                    The list of indexes must be within 0 to ".spec.completions-1" and
+                                    must not contain duplicates. At least one element is required.
+                                    The indexes are represented as intervals separated by commas.
+                                    The intervals can be a decimal integer or a pair of decimal integers separated by a hyphen.
+                                    The number are listed in represented by the first and last element of the series,
+                                    separated by a hyphen.
+                                    For example, if the completed indexes are 1, 3, 4, 5 and 7, they are
+                                    represented as "1,3-5,7".
+                                    When this field is null, this field doesn't default to any value
+                                    and is never evaluated at any time.
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - rules
+                        type: object
+                      suspend:
+                        description: |-
+                          suspend specifies whether the Job controller should create Pods or not. If
+                          a Job is created with suspend set to true, no Pods are created by the Job
+                          controller. If a Job is suspended after creation (i.e. the flag goes from
+                          false to true), the Job controller will delete all active Pods associated
+                          with this Job. Users must design their workload to gracefully handle this.
+                          Suspending a Job will reset the StartTime field of the Job, effectively
+                          resetting the ActiveDeadlineSeconds timer too. Defaults to false.
+                        type: boolean
+                      template:
+                        description: |-
+                          Describes the pod that will be created when executing a job.
+                          The only allowed template.spec.restartPolicy values are "Never" or "OnFailure".
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                        properties:
+                          metadata:
+                            description: |-
+                              Standard object's metadata.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            type: object
+                          spec:
+                            description: |-
+                              Specification of the desired behavior of the pod.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                            properties:
+                              activeDeadlineSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod may be active on the node relative to
+                                  StartTime before the system will actively try to mark it failed and kill associated containers.
+                                  Value must be a positive integer.
+                                format: int64
+                                type: integer
+                              affinity:
+                                description: If specified, the pod's scheduling constraints
+                                properties:
+                                  nodeAffinity:
+                                    description: Describes node affinity scheduling
+                                      rules for the pod.
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and adding
+                                          "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                          node(s) with the highest sum are the most preferred.
+                                        items:
+                                          description: |-
+                                            An empty preferred scheduling term matches all objects with implicit weight 0
+                                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                          properties:
+                                            preference:
+                                              description: A node selector term, associated
+                                                with the corresponding weight.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            weight:
+                                              description: Weight associated with
+                                                matching the corresponding nodeSelectorTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - preference
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: |-
+                                          If the affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to an update), the system
+                                          may or may not try to eventually evict the pod from its node.
+                                        properties:
+                                          nodeSelectorTerms:
+                                            description: Required. A list of node
+                                              selector terms. The terms are ORed.
+                                            items:
+                                              description: |-
+                                                A null or empty node selector term matches no objects. The requirements of
+                                                them are ANDed.
+                                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  podAffinity:
+                                    description: Describes pod affinity scheduling
+                                      rules (e.g. co-locate this pod in the same node,
+                                      zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and adding
+                                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                          node(s) with the highest sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: |-
+                                                    A label query over a set of resources, in this case pods.
+                                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  description: |-
+                                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                                    be taken into consideration. The keys are used to lookup values from the
+                                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                    to select the group of existing pods which pods will be taken into consideration
+                                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                    pod labels will be ignored. The default value is empty.
+                                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  description: |-
+                                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                    be taken into consideration. The keys are used to lookup values from the
+                                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                    to select the group of existing pods which pods will be taken into consideration
+                                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                    pod labels will be ignored. The default value is empty.
+                                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  description: |-
+                                                    A label query over the set of namespaces that the term applies to.
+                                                    The term is applied to the union of the namespaces selected by this field
+                                                    and the ones listed in the namespaces field.
+                                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                                    An empty selector ({}) matches all namespaces.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  description: |-
+                                                    namespaces specifies a static list of namespace names that the term applies to.
+                                                    The term is applied to the union of the namespaces listed in this field
+                                                    and the ones selected by namespaceSelector.
+                                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  description: |-
+                                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                                    selected pods is running.
+                                                    Empty topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: |-
+                                                weight associated with matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: |-
+                                          If the affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to a pod label update), the
+                                          system may or may not try to eventually evict the pod from its node.
+                                          When there are multiple elements, the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                        items:
+                                          description: |-
+                                            Defines a set of pods (namely those matching the labelSelector
+                                            relative to the given namespace(s)) that this pod should be
+                                            co-located (affinity) or not co-located (anti-affinity) with,
+                                            where co-located is defined as running on a node whose value of
+                                            the label with key <topologyKey> matches that of any node on which
+                                            a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: |-
+                                                A label query over a set of resources, in this case pods.
+                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              description: |-
+                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              description: |-
+                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  podAntiAffinity:
+                                    description: Describes pod anti-affinity scheduling
+                                      rules (e.g. avoid putting this pod in the same
+                                      node, zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the anti-affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and subtracting
+                                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                          node(s) with the highest sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: |-
+                                                    A label query over a set of resources, in this case pods.
+                                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  description: |-
+                                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                                    be taken into consideration. The keys are used to lookup values from the
+                                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                    to select the group of existing pods which pods will be taken into consideration
+                                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                    pod labels will be ignored. The default value is empty.
+                                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  description: |-
+                                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                    be taken into consideration. The keys are used to lookup values from the
+                                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                    to select the group of existing pods which pods will be taken into consideration
+                                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                    pod labels will be ignored. The default value is empty.
+                                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  description: |-
+                                                    A label query over the set of namespaces that the term applies to.
+                                                    The term is applied to the union of the namespaces selected by this field
+                                                    and the ones listed in the namespaces field.
+                                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                                    An empty selector ({}) matches all namespaces.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  description: |-
+                                                    namespaces specifies a static list of namespace names that the term applies to.
+                                                    The term is applied to the union of the namespaces listed in this field
+                                                    and the ones selected by namespaceSelector.
+                                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  description: |-
+                                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                                    selected pods is running.
+                                                    Empty topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: |-
+                                                weight associated with matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: |-
+                                          If the anti-affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the anti-affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to a pod label update), the
+                                          system may or may not try to eventually evict the pod from its node.
+                                          When there are multiple elements, the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                        items:
+                                          description: |-
+                                            Defines a set of pods (namely those matching the labelSelector
+                                            relative to the given namespace(s)) that this pod should be
+                                            co-located (affinity) or not co-located (anti-affinity) with,
+                                            where co-located is defined as running on a node whose value of
+                                            the label with key <topologyKey> matches that of any node on which
+                                            a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: |-
+                                                A label query over a set of resources, in this case pods.
+                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              description: |-
+                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              description: |-
+                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                type: object
+                              automountServiceAccountToken:
+                                description: AutomountServiceAccountToken indicates
+                                  whether a service account token should be automatically
+                                  mounted.
+                                type: boolean
+                              containers:
+                                description: |-
+                                  List of containers belonging to the pod.
+                                  Containers cannot currently be added or removed.
+                                  There must be at least one container in a Pod.
+                                  Cannot be updated.
+                                items:
+                                  description: A single application container that
+                                    you want to run within a pod.
+                                  properties:
+                                    args:
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The container image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The container image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
+                                      items:
+                                        description: EnvFromSource represents the
+                                          source of a set of ConfigMaps or Secrets
+                                        properties:
+                                          configMapRef:
+                                            description: The ConfigMap to select from
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            description: |-
+                                              Optional text to prepend to the name of each environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          secretRef:
+                                            description: The Secret to select from
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      description: |-
+                                        Container image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level config management to default or override
+                                        container images in workload controllers like Deployments and StatefulSets.
+                                      type: string
+                                    imagePullPolicy:
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                      type: string
+                                    lifecycle:
+                                      description: |-
+                                        Actions that the management system should take in response to container lifecycle events.
+                                        Cannot be updated.
+                                      properties:
+                                        postStart:
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                          properties:
+                                            exec:
+                                              description: Exec specifies a command
+                                                to execute in the container.
+                                              properties:
+                                                command:
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
+                                              properties:
+                                                host:
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                          properties:
+                                            exec:
+                                              description: Exec specifies a command
+                                                to execute in the container.
+                                              properties:
+                                                command:
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
+                                              properties:
+                                                host:
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        stopSignal:
+                                          description: |-
+                                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                                            If not specified, the default is defined by the container runtime in use.
+                                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                          type: string
+                                      type: object
+                                    livenessProbe:
+                                      description: |-
+                                        Periodic probe of container liveness.
+                                        Container will be restarted if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      description: |-
+                                        Name of the container specified as a DNS_LABEL.
+                                        Each container in a pod must have a unique name (DNS_LABEL).
+                                        Cannot be updated.
+                                      type: string
+                                    ports:
+                                      description: |-
+                                        List of ports to expose from the container. Not specifying a port here
+                                        DOES NOT prevent that port from being exposed. Any port which is
+                                        listening on the default "0.0.0.0" address inside a container will be
+                                        accessible from the network.
+                                        Modifying this array with strategic merge patch may corrupt the data.
+                                        For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                        Cannot be updated.
+                                      items:
+                                        description: ContainerPort represents a network
+                                          port in a single container.
+                                        properties:
+                                          containerPort:
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            description: What host IP to bind the
+                                              external port to.
+                                            type: string
+                                          hostPort:
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      description: |-
+                                        Periodic probe of container service readiness.
+                                        Container will be removed from service endpoints if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      description: |-
+                                        Resources resize policy for the container.
+                                        This field cannot be set on ephemeral containers.
+                                      items:
+                                        description: ContainerResizePolicy represents
+                                          resource resize policy for the container.
+                                        properties:
+                                          resourceName:
+                                            description: |-
+                                              Name of the resource to which this resource resize policy applies.
+                                              Supported values: cpu, memory.
+                                            type: string
+                                          restartPolicy:
+                                            description: |-
+                                              Restart policy to apply when specified resource is resized.
+                                              If not specified, it defaults to NotRequired.
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      description: |-
+                                        Compute Resources required by this container.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      properties:
+                                        claims:
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+                                            This field depends on the
+                                            DynamicResourceAllocation feature gate.
+
+                                            This field is immutable. It can only be set for containers.
+                                          items:
+                                            description: ResourceClaim references
+                                              one entry in PodSpec.ResourceClaims.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                                  the Pod where this field is used. It makes that resource available
+                                                  inside a container.
+                                                type: string
+                                              request:
+                                                description: |-
+                                                  Request is the name chosen for a request in the referenced claim.
+                                                  If empty, everything from the claim is made available, otherwise
+                                                  only the result of this request.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      description: |-
+                                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                                        This overrides the pod-level restart policy. When this field is not specified,
+                                        the restart behavior is defined by the Pod's restart policy and the container type.
+                                        Additionally, setting the RestartPolicy as "Always" for the init container will
+                                        have the following effect:
+                                        this init container will be continually restarted on
+                                        exit until all regular containers have terminated. Once all regular
+                                        containers have completed, all init containers with restartPolicy "Always"
+                                        will be shut down. This lifecycle differs from normal init containers and
+                                        is often referred to as a "sidecar" container. Although this init
+                                        container still starts in the init container sequence, it does not wait
+                                        for the container to complete before proceeding to the next init
+                                        container. Instead, the next init container starts immediately after this
+                                        init container is started, or after any startupProbe has successfully
+                                        completed.
+                                      type: string
+                                    restartPolicyRules:
+                                      description: |-
+                                        Represents a list of rules to be checked to determine if the
+                                        container should be restarted on exit. The rules are evaluated in
+                                        order. Once a rule matches a container exit condition, the remaining
+                                        rules are ignored. If no rule matches the container exit condition,
+                                        the Container-level restart policy determines the whether the container
+                                        is restarted or not. Constraints on the rules:
+                                        - At most 20 rules are allowed.
+                                        - Rules can have the same action.
+                                        - Identical rules are not forbidden in validations.
+                                        When rules are specified, container MUST set RestartPolicy explicitly
+                                        even it if matches the Pod's RestartPolicy.
+                                      items:
+                                        description: ContainerRestartRule describes
+                                          how a container exit is handled.
+                                        properties:
+                                          action:
+                                            description: |-
+                                              Specifies the action taken on a container exit if the requirements
+                                              are satisfied. The only possible value is "Restart" to restart the
+                                              container.
+                                            type: string
+                                          exitCodes:
+                                            description: Represents the exit codes
+                                              to check on container exits.
+                                            properties:
+                                              operator:
+                                                description: |-
+                                                  Represents the relationship between the container exit code(s) and the
+                                                  specified values. Possible values are:
+                                                  - In: the requirement is satisfied if the container exit code is in the
+                                                    set of specified values.
+                                                  - NotIn: the requirement is satisfied if the container exit code is
+                                                    not in the set of specified values.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  Specifies the set of values to check for container exit codes.
+                                                  At most 255 elements are allowed.
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    securityContext:
+                                      description: |-
+                                        SecurityContext defines the security options the container should be run with.
+                                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        appArmorProfile:
+                                          description: |-
+                                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                            overrides the pod's appArmorProfile.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile loaded on the node that should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must match the loaded name of the profile.
+                                                Must be set if and only if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of AppArmor profile will be applied.
+                                                Valid options are:
+                                                  Localhost - a profile pre-loaded on the node.
+                                                  RuntimeDefault - the container runtime's default profile.
+                                                  Unconfined - no AppArmor enforcement.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        procMount:
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default value is Default which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      description: |-
+                                        StartupProbe indicates that the Pod has successfully initialized.
+                                        If specified, no other probes are executed until this completes successfully.
+                                        If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                        This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                        when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                        This cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
+                                      type: boolean
+                                    stdinOnce:
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
+                                      type: boolean
+                                    terminationMessagePath:
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
+                                      type: string
+                                    terminationMessagePolicy:
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
+                                      type: string
+                                    tty:
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
+                                      type: boolean
+                                    volumeDevices:
+                                      description: volumeDevices is the list of block
+                                        devices to be used by the container.
+                                      items:
+                                        description: volumeDevice describes a mapping
+                                          of a raw block device within a container.
+                                        properties:
+                                          devicePath:
+                                            description: devicePath is the path inside
+                                              of the container that the device will
+                                              be mapped to.
+                                            type: string
+                                          name:
+                                            description: name must match the name
+                                              of a persistentVolumeClaim in the pod
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem.
+                                        Cannot be updated.
+                                      items:
+                                        description: VolumeMount describes a mounting
+                                          of a Volume within a container.
+                                        properties:
+                                          mountPath:
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
+                                              not contain ':'.
+                                            type: string
+                                          mountPropagation:
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
+                                              to container and the other way around.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
+                                              When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                              (which defaults to None).
+                                            type: string
+                                          name:
+                                            description: This must match the Name
+                                              of a Volume.
+                                            type: string
+                                          readOnly:
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                                              Defaults to false.
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            description: |-
+                                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                                              recursively.
+
+                                              If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                              If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                              recursively read-only.  If this field is set to IfPossible, the mount is made
+                                              recursively read-only, if it is supported by the container runtime.  If this
+                                              field is set to Enabled, the mount is made recursively read-only if it is
+                                              supported by the container runtime, otherwise the pod will not be started and
+                                              an error will be generated to indicate the reason.
+
+                                              If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                              None (or be unspecified, which defaults to None).
+
+                                              If this field is not specified, it is treated as an equivalent of Disabled.
+                                            type: string
+                                          subPath:
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
+                                            type: string
+                                          subPathExpr:
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              dnsConfig:
+                                description: |-
+                                  Specifies the DNS parameters of a pod.
+                                  Parameters specified here will be merged to the generated DNS
+                                  configuration based on DNSPolicy.
+                                properties:
+                                  nameservers:
+                                    description: |-
+                                      A list of DNS name server IP addresses.
+                                      This will be appended to the base nameservers generated from DNSPolicy.
+                                      Duplicated nameservers will be removed.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  options:
+                                    description: |-
+                                      A list of DNS resolver options.
+                                      This will be merged with the base options generated from DNSPolicy.
+                                      Duplicated entries will be removed. Resolution options given in Options
+                                      will override those that appear in the base DNSPolicy.
+                                    items:
+                                      description: PodDNSConfigOption defines DNS
+                                        resolver options of a pod.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name is this DNS resolver option's name.
+                                            Required.
+                                          type: string
+                                        value:
+                                          description: Value is this DNS resolver
+                                            option's value.
+                                          type: string
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  searches:
+                                    description: |-
+                                      A list of DNS search domains for host-name lookup.
+                                      This will be appended to the base search paths generated from DNSPolicy.
+                                      Duplicated search paths will be removed.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              dnsPolicy:
+                                description: |-
+                                  Set DNS policy for the pod.
+                                  Defaults to "ClusterFirst".
+                                  Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                                  DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                                  To have DNS options set along with hostNetwork, you have to specify DNS policy
+                                  explicitly to 'ClusterFirstWithHostNet'.
+                                type: string
+                              enableServiceLinks:
+                                description: |-
+                                  EnableServiceLinks indicates whether information about services should be injected into pod's
+                                  environment variables, matching the syntax of Docker links.
+                                  Optional: Defaults to true.
+                                type: boolean
+                              ephemeralContainers:
+                                description: |-
+                                  List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                                  pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                                  creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                                  ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
+                                items:
+                                  description: |-
+                                    An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                    user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                    scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                    removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                    Pod to exceed its resource allocation.
+
+                                    To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+                                    Pod. Ephemeral containers may not be removed or restarted.
+                                  properties:
+                                    args:
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
+                                      items:
+                                        description: EnvFromSource represents the
+                                          source of a set of ConfigMaps or Secrets
+                                        properties:
+                                          configMapRef:
+                                            description: The ConfigMap to select from
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            description: |-
+                                              Optional text to prepend to the name of each environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          secretRef:
+                                            description: The Secret to select from
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      description: |-
+                                        Container image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                      type: string
+                                    imagePullPolicy:
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                      type: string
+                                    lifecycle:
+                                      description: Lifecycle is not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        postStart:
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                          properties:
+                                            exec:
+                                              description: Exec specifies a command
+                                                to execute in the container.
+                                              properties:
+                                                command:
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
+                                              properties:
+                                                host:
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                          properties:
+                                            exec:
+                                              description: Exec specifies a command
+                                                to execute in the container.
+                                              properties:
+                                                command:
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
+                                              properties:
+                                                host:
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        stopSignal:
+                                          description: |-
+                                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                                            If not specified, the default is defined by the container runtime in use.
+                                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                          type: string
+                                      type: object
+                                    livenessProbe:
+                                      description: Probes are not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      description: |-
+                                        Name of the ephemeral container specified as a DNS_LABEL.
+                                        This name must be unique among all containers, init containers and ephemeral containers.
+                                      type: string
+                                    ports:
+                                      description: Ports are not allowed for ephemeral
+                                        containers.
+                                      items:
+                                        description: ContainerPort represents a network
+                                          port in a single container.
+                                        properties:
+                                          containerPort:
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            description: What host IP to bind the
+                                              external port to.
+                                            type: string
+                                          hostPort:
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      description: Probes are not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      description: Resources resize policy for the
+                                        container.
+                                      items:
+                                        description: ContainerResizePolicy represents
+                                          resource resize policy for the container.
+                                        properties:
+                                          resourceName:
+                                            description: |-
+                                              Name of the resource to which this resource resize policy applies.
+                                              Supported values: cpu, memory.
+                                            type: string
+                                          restartPolicy:
+                                            description: |-
+                                              Restart policy to apply when specified resource is resized.
+                                              If not specified, it defaults to NotRequired.
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      description: |-
+                                        Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
+                                        already allocated to the pod.
+                                      properties:
+                                        claims:
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+                                            This field depends on the
+                                            DynamicResourceAllocation feature gate.
+
+                                            This field is immutable. It can only be set for containers.
+                                          items:
+                                            description: ResourceClaim references
+                                              one entry in PodSpec.ResourceClaims.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                                  the Pod where this field is used. It makes that resource available
+                                                  inside a container.
+                                                type: string
+                                              request:
+                                                description: |-
+                                                  Request is the name chosen for a request in the referenced claim.
+                                                  If empty, everything from the claim is made available, otherwise
+                                                  only the result of this request.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      description: |-
+                                        Restart policy for the container to manage the restart behavior of each
+                                        container within a pod.
+                                        You cannot set this field on ephemeral containers.
+                                      type: string
+                                    restartPolicyRules:
+                                      description: |-
+                                        Represents a list of rules to be checked to determine if the
+                                        container should be restarted on exit. You cannot set this field on
+                                        ephemeral containers.
+                                      items:
+                                        description: ContainerRestartRule describes
+                                          how a container exit is handled.
+                                        properties:
+                                          action:
+                                            description: |-
+                                              Specifies the action taken on a container exit if the requirements
+                                              are satisfied. The only possible value is "Restart" to restart the
+                                              container.
+                                            type: string
+                                          exitCodes:
+                                            description: Represents the exit codes
+                                              to check on container exits.
+                                            properties:
+                                              operator:
+                                                description: |-
+                                                  Represents the relationship between the container exit code(s) and the
+                                                  specified values. Possible values are:
+                                                  - In: the requirement is satisfied if the container exit code is in the
+                                                    set of specified values.
+                                                  - NotIn: the requirement is satisfied if the container exit code is
+                                                    not in the set of specified values.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  Specifies the set of values to check for container exit codes.
+                                                  At most 255 elements are allowed.
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    securityContext:
+                                      description: |-
+                                        Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        appArmorProfile:
+                                          description: |-
+                                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                            overrides the pod's appArmorProfile.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile loaded on the node that should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must match the loaded name of the profile.
+                                                Must be set if and only if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of AppArmor profile will be applied.
+                                                Valid options are:
+                                                  Localhost - a profile pre-loaded on the node.
+                                                  RuntimeDefault - the container runtime's default profile.
+                                                  Unconfined - no AppArmor enforcement.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        procMount:
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default value is Default which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      description: Probes are not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
+                                      type: boolean
+                                    stdinOnce:
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
+                                      type: boolean
+                                    targetContainerName:
+                                      description: |-
+                                        If set, the name of the container from PodSpec that this ephemeral container targets.
+                                        The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                        If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                                        The container runtime must implement support for this feature. If the runtime does not
+                                        support namespace targeting then the result of setting this field is undefined.
+                                      type: string
+                                    terminationMessagePath:
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
+                                      type: string
+                                    terminationMessagePolicy:
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
+                                      type: string
+                                    tty:
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
+                                      type: boolean
+                                    volumeDevices:
+                                      description: volumeDevices is the list of block
+                                        devices to be used by the container.
+                                      items:
+                                        description: volumeDevice describes a mapping
+                                          of a raw block device within a container.
+                                        properties:
+                                          devicePath:
+                                            description: devicePath is the path inside
+                                              of the container that the device will
+                                              be mapped to.
+                                            type: string
+                                          name:
+                                            description: name must match the name
+                                              of a persistentVolumeClaim in the pod
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                        Cannot be updated.
+                                      items:
+                                        description: VolumeMount describes a mounting
+                                          of a Volume within a container.
+                                        properties:
+                                          mountPath:
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
+                                              not contain ':'.
+                                            type: string
+                                          mountPropagation:
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
+                                              to container and the other way around.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
+                                              When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                              (which defaults to None).
+                                            type: string
+                                          name:
+                                            description: This must match the Name
+                                              of a Volume.
+                                            type: string
+                                          readOnly:
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                                              Defaults to false.
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            description: |-
+                                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                                              recursively.
+
+                                              If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                              If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                              recursively read-only.  If this field is set to IfPossible, the mount is made
+                                              recursively read-only, if it is supported by the container runtime.  If this
+                                              field is set to Enabled, the mount is made recursively read-only if it is
+                                              supported by the container runtime, otherwise the pod will not be started and
+                                              an error will be generated to indicate the reason.
+
+                                              If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                              None (or be unspecified, which defaults to None).
+
+                                              If this field is not specified, it is treated as an equivalent of Disabled.
+                                            type: string
+                                          subPath:
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
+                                            type: string
+                                          subPathExpr:
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              hostAliases:
+                                description: |-
+                                  HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                  file if specified.
+                                items:
+                                  description: |-
+                                    HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                    pod's hosts file.
+                                  properties:
+                                    hostnames:
+                                      description: Hostnames for the above IP address.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    ip:
+                                      description: IP address of the host file entry.
+                                      type: string
+                                  required:
+                                  - ip
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - ip
+                                x-kubernetes-list-type: map
+                              hostIPC:
+                                description: |-
+                                  Use the host's ipc namespace.
+                                  Optional: Default to false.
+                                type: boolean
+                              hostNetwork:
+                                description: |-
+                                  Host networking requested for this pod. Use the host's network namespace.
+                                  When using HostNetwork you should specify ports so the scheduler is aware.
+                                  When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`,
+                                  and unspecified `hostPort` fields in port definitions are defaulted to match `containerPort`.
+                                  Default to false.
+                                type: boolean
+                              hostPID:
+                                description: |-
+                                  Use the host's pid namespace.
+                                  Optional: Default to false.
+                                type: boolean
+                              hostUsers:
+                                description: |-
+                                  Use the host's user namespace.
+                                  Optional: Default to true.
+                                  If set to true or not present, the pod will be run in the host user namespace, useful
+                                  for when the pod needs a feature only available to the host user namespace, such as
+                                  loading a kernel module with CAP_SYS_MODULE.
+                                  When set to false, a new userns is created for the pod. Setting false is useful for
+                                  mitigating container breakout vulnerabilities even allowing users to run their
+                                  containers as root without actually having root privileges on the host.
+                                  This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
+                                type: boolean
+                              hostname:
+                                description: |-
+                                  Specifies the hostname of the Pod
+                                  If not specified, the pod's hostname will be set to a system-defined value.
+                                type: string
+                              hostnameOverride:
+                                description: |-
+                                  HostnameOverride specifies an explicit override for the pod's hostname as perceived by the pod.
+                                  This field only specifies the pod's hostname and does not affect its DNS records.
+                                  When this field is set to a non-empty string:
+                                  - It takes precedence over the values set in `hostname` and `subdomain`.
+                                  - The Pod's hostname will be set to this value.
+                                  - `setHostnameAsFQDN` must be nil or set to false.
+                                  - `hostNetwork` must be set to false.
+
+                                  This field must be a valid DNS subdomain as defined in RFC 1123 and contain at most 64 characters.
+                                  Requires the HostnameOverride feature gate to be enabled.
+                                type: string
+                              imagePullSecrets:
+                                description: |-
+                                  ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                  If specified, these secrets will be passed to individual puller implementations for them to use.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                items:
+                                  description: |-
+                                    LocalObjectReference contains enough information to let you locate the
+                                    referenced object inside the same namespace.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              initContainers:
+                                description: |-
+                                  List of initialization containers belonging to the pod.
+                                  Init containers are executed in order prior to containers being started. If any
+                                  init container fails, the pod is considered to have failed and is handled according
+                                  to its restartPolicy. The name for an init container or normal container must be
+                                  unique among all containers.
+                                  Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                                  The resourceRequirements of an init container are taken into account during scheduling
+                                  by finding the highest request/limit for each resource type, and then using the max of
+                                  that value or the sum of the normal containers. Limits are applied to init containers
+                                  in a similar fashion.
+                                  Init containers cannot currently be added or removed.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                                items:
+                                  description: A single application container that
+                                    you want to run within a pod.
+                                  properties:
+                                    args:
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The container image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The container image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
+                                      items:
+                                        description: EnvFromSource represents the
+                                          source of a set of ConfigMaps or Secrets
+                                        properties:
+                                          configMapRef:
+                                            description: The ConfigMap to select from
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            description: |-
+                                              Optional text to prepend to the name of each environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          secretRef:
+                                            description: The Secret to select from
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      description: |-
+                                        Container image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level config management to default or override
+                                        container images in workload controllers like Deployments and StatefulSets.
+                                      type: string
+                                    imagePullPolicy:
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                      type: string
+                                    lifecycle:
+                                      description: |-
+                                        Actions that the management system should take in response to container lifecycle events.
+                                        Cannot be updated.
+                                      properties:
+                                        postStart:
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                          properties:
+                                            exec:
+                                              description: Exec specifies a command
+                                                to execute in the container.
+                                              properties:
+                                                command:
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
+                                              properties:
+                                                host:
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                          properties:
+                                            exec:
+                                              description: Exec specifies a command
+                                                to execute in the container.
+                                              properties:
+                                                command:
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
+                                              properties:
+                                                host:
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        stopSignal:
+                                          description: |-
+                                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                                            If not specified, the default is defined by the container runtime in use.
+                                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                          type: string
+                                      type: object
+                                    livenessProbe:
+                                      description: |-
+                                        Periodic probe of container liveness.
+                                        Container will be restarted if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      description: |-
+                                        Name of the container specified as a DNS_LABEL.
+                                        Each container in a pod must have a unique name (DNS_LABEL).
+                                        Cannot be updated.
+                                      type: string
+                                    ports:
+                                      description: |-
+                                        List of ports to expose from the container. Not specifying a port here
+                                        DOES NOT prevent that port from being exposed. Any port which is
+                                        listening on the default "0.0.0.0" address inside a container will be
+                                        accessible from the network.
+                                        Modifying this array with strategic merge patch may corrupt the data.
+                                        For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                        Cannot be updated.
+                                      items:
+                                        description: ContainerPort represents a network
+                                          port in a single container.
+                                        properties:
+                                          containerPort:
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            description: What host IP to bind the
+                                              external port to.
+                                            type: string
+                                          hostPort:
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      description: |-
+                                        Periodic probe of container service readiness.
+                                        Container will be removed from service endpoints if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      description: |-
+                                        Resources resize policy for the container.
+                                        This field cannot be set on ephemeral containers.
+                                      items:
+                                        description: ContainerResizePolicy represents
+                                          resource resize policy for the container.
+                                        properties:
+                                          resourceName:
+                                            description: |-
+                                              Name of the resource to which this resource resize policy applies.
+                                              Supported values: cpu, memory.
+                                            type: string
+                                          restartPolicy:
+                                            description: |-
+                                              Restart policy to apply when specified resource is resized.
+                                              If not specified, it defaults to NotRequired.
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      description: |-
+                                        Compute Resources required by this container.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      properties:
+                                        claims:
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+                                            This field depends on the
+                                            DynamicResourceAllocation feature gate.
+
+                                            This field is immutable. It can only be set for containers.
+                                          items:
+                                            description: ResourceClaim references
+                                              one entry in PodSpec.ResourceClaims.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                                  the Pod where this field is used. It makes that resource available
+                                                  inside a container.
+                                                type: string
+                                              request:
+                                                description: |-
+                                                  Request is the name chosen for a request in the referenced claim.
+                                                  If empty, everything from the claim is made available, otherwise
+                                                  only the result of this request.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      description: |-
+                                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                                        This overrides the pod-level restart policy. When this field is not specified,
+                                        the restart behavior is defined by the Pod's restart policy and the container type.
+                                        Additionally, setting the RestartPolicy as "Always" for the init container will
+                                        have the following effect:
+                                        this init container will be continually restarted on
+                                        exit until all regular containers have terminated. Once all regular
+                                        containers have completed, all init containers with restartPolicy "Always"
+                                        will be shut down. This lifecycle differs from normal init containers and
+                                        is often referred to as a "sidecar" container. Although this init
+                                        container still starts in the init container sequence, it does not wait
+                                        for the container to complete before proceeding to the next init
+                                        container. Instead, the next init container starts immediately after this
+                                        init container is started, or after any startupProbe has successfully
+                                        completed.
+                                      type: string
+                                    restartPolicyRules:
+                                      description: |-
+                                        Represents a list of rules to be checked to determine if the
+                                        container should be restarted on exit. The rules are evaluated in
+                                        order. Once a rule matches a container exit condition, the remaining
+                                        rules are ignored. If no rule matches the container exit condition,
+                                        the Container-level restart policy determines the whether the container
+                                        is restarted or not. Constraints on the rules:
+                                        - At most 20 rules are allowed.
+                                        - Rules can have the same action.
+                                        - Identical rules are not forbidden in validations.
+                                        When rules are specified, container MUST set RestartPolicy explicitly
+                                        even it if matches the Pod's RestartPolicy.
+                                      items:
+                                        description: ContainerRestartRule describes
+                                          how a container exit is handled.
+                                        properties:
+                                          action:
+                                            description: |-
+                                              Specifies the action taken on a container exit if the requirements
+                                              are satisfied. The only possible value is "Restart" to restart the
+                                              container.
+                                            type: string
+                                          exitCodes:
+                                            description: Represents the exit codes
+                                              to check on container exits.
+                                            properties:
+                                              operator:
+                                                description: |-
+                                                  Represents the relationship between the container exit code(s) and the
+                                                  specified values. Possible values are:
+                                                  - In: the requirement is satisfied if the container exit code is in the
+                                                    set of specified values.
+                                                  - NotIn: the requirement is satisfied if the container exit code is
+                                                    not in the set of specified values.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  Specifies the set of values to check for container exit codes.
+                                                  At most 255 elements are allowed.
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    securityContext:
+                                      description: |-
+                                        SecurityContext defines the security options the container should be run with.
+                                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        appArmorProfile:
+                                          description: |-
+                                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                            overrides the pod's appArmorProfile.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile loaded on the node that should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must match the loaded name of the profile.
+                                                Must be set if and only if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of AppArmor profile will be applied.
+                                                Valid options are:
+                                                  Localhost - a profile pre-loaded on the node.
+                                                  RuntimeDefault - the container runtime's default profile.
+                                                  Unconfined - no AppArmor enforcement.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        procMount:
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default value is Default which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      description: |-
+                                        StartupProbe indicates that the Pod has successfully initialized.
+                                        If specified, no other probes are executed until this completes successfully.
+                                        If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                        This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                        when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                        This cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
+                                      type: boolean
+                                    stdinOnce:
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
+                                      type: boolean
+                                    terminationMessagePath:
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
+                                      type: string
+                                    terminationMessagePolicy:
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
+                                      type: string
+                                    tty:
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
+                                      type: boolean
+                                    volumeDevices:
+                                      description: volumeDevices is the list of block
+                                        devices to be used by the container.
+                                      items:
+                                        description: volumeDevice describes a mapping
+                                          of a raw block device within a container.
+                                        properties:
+                                          devicePath:
+                                            description: devicePath is the path inside
+                                              of the container that the device will
+                                              be mapped to.
+                                            type: string
+                                          name:
+                                            description: name must match the name
+                                              of a persistentVolumeClaim in the pod
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem.
+                                        Cannot be updated.
+                                      items:
+                                        description: VolumeMount describes a mounting
+                                          of a Volume within a container.
+                                        properties:
+                                          mountPath:
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
+                                              not contain ':'.
+                                            type: string
+                                          mountPropagation:
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
+                                              to container and the other way around.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
+                                              When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                              (which defaults to None).
+                                            type: string
+                                          name:
+                                            description: This must match the Name
+                                              of a Volume.
+                                            type: string
+                                          readOnly:
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                                              Defaults to false.
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            description: |-
+                                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                                              recursively.
+
+                                              If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                              If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                              recursively read-only.  If this field is set to IfPossible, the mount is made
+                                              recursively read-only, if it is supported by the container runtime.  If this
+                                              field is set to Enabled, the mount is made recursively read-only if it is
+                                              supported by the container runtime, otherwise the pod will not be started and
+                                              an error will be generated to indicate the reason.
+
+                                              If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                              None (or be unspecified, which defaults to None).
+
+                                              If this field is not specified, it is treated as an equivalent of Disabled.
+                                            type: string
+                                          subPath:
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
+                                            type: string
+                                          subPathExpr:
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              nodeName:
+                                description: |-
+                                  NodeName indicates in which node this pod is scheduled.
+                                  If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.
+                                  Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.
+                                  This field should not be used to express a desire for the pod to be scheduled on a specific node.
+                                  https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
+                                type: string
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  NodeSelector is a selector which must be true for the pod to fit on a node.
+                                  Selector which must match a node's labels for the pod to be scheduled on that node.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              os:
+                                description: |-
+                                  Specifies the OS of the containers in the pod.
+                                  Some pod and container fields are restricted if this is set.
+
+                                  If the OS field is set to linux, the following fields must be unset:
+                                  -securityContext.windowsOptions
+
+                                  If the OS field is set to windows, following fields must be unset:
+                                  - spec.hostPID
+                                  - spec.hostIPC
+                                  - spec.hostUsers
+                                  - spec.resources
+                                  - spec.securityContext.appArmorProfile
+                                  - spec.securityContext.seLinuxOptions
+                                  - spec.securityContext.seccompProfile
+                                  - spec.securityContext.fsGroup
+                                  - spec.securityContext.fsGroupChangePolicy
+                                  - spec.securityContext.sysctls
+                                  - spec.shareProcessNamespace
+                                  - spec.securityContext.runAsUser
+                                  - spec.securityContext.runAsGroup
+                                  - spec.securityContext.supplementalGroups
+                                  - spec.securityContext.supplementalGroupsPolicy
+                                  - spec.containers[*].securityContext.appArmorProfile
+                                  - spec.containers[*].securityContext.seLinuxOptions
+                                  - spec.containers[*].securityContext.seccompProfile
+                                  - spec.containers[*].securityContext.capabilities
+                                  - spec.containers[*].securityContext.readOnlyRootFilesystem
+                                  - spec.containers[*].securityContext.privileged
+                                  - spec.containers[*].securityContext.allowPrivilegeEscalation
+                                  - spec.containers[*].securityContext.procMount
+                                  - spec.containers[*].securityContext.runAsUser
+                                  - spec.containers[*].securityContext.runAsGroup
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name is the name of the operating system. The currently supported values are linux and windows.
+                                      Additional value may be defined in future and can be one of:
+                                      https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                      Clients should expect to handle additional values and treat unrecognized values in this field as os: null
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              overhead:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                                  This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                                  the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                                  The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                                  set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                                  defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                                  More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+                                type: object
+                              preemptionPolicy:
+                                description: |-
+                                  PreemptionPolicy is the Policy for preempting pods with lower priority.
+                                  One of Never, PreemptLowerPriority.
+                                  Defaults to PreemptLowerPriority if unset.
+                                type: string
+                              priority:
+                                description: |-
+                                  The priority value. Various system components use this field to find the
+                                  priority of the pod. When Priority Admission Controller is enabled, it
+                                  prevents users from setting this field. The admission controller populates
+                                  this field from PriorityClassName.
+                                  The higher the value, the higher the priority.
+                                format: int32
+                                type: integer
+                              priorityClassName:
+                                description: |-
+                                  If specified, indicates the pod's priority. "system-node-critical" and
+                                  "system-cluster-critical" are two special keywords which indicate the
+                                  highest priorities with the former being the highest priority. Any other
+                                  name must be defined by creating a PriorityClass object with that name.
+                                  If not specified, the pod priority will be default or zero if there is no
+                                  default.
+                                type: string
+                              readinessGates:
+                                description: |-
+                                  If specified, all readiness gates will be evaluated for pod readiness.
+                                  A pod is ready when all its containers are ready AND
+                                  all conditions specified in the readiness gates have status equal to "True"
+                                  More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
+                                items:
+                                  description: PodReadinessGate contains the reference
+                                    to a pod condition
+                                  properties:
+                                    conditionType:
+                                      description: ConditionType refers to a condition
+                                        in the pod's condition list with matching
+                                        type.
+                                      type: string
+                                  required:
+                                  - conditionType
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              resourceClaims:
+                                description: |-
+                                  ResourceClaims defines which ResourceClaims must be allocated
+                                  and reserved before the Pod is allowed to start. The resources
+                                  will be made available to those containers which consume them
+                                  by name.
+
+                                  This is a stable field but requires that the
+                                  DynamicResourceAllocation feature gate is enabled.
+
+                                  This field is immutable.
+                                items:
+                                  description: |-
+                                    PodResourceClaim references exactly one ResourceClaim, either directly
+                                    or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                                    for the pod.
+
+                                    It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                                    Containers that need access to the ResourceClaim reference it with this name.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name uniquely identifies this resource claim inside the pod.
+                                        This must be a DNS_LABEL.
+                                      type: string
+                                    resourceClaimName:
+                                      description: |-
+                                        ResourceClaimName is the name of a ResourceClaim object in the same
+                                        namespace as this pod.
+
+                                        Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                        be set.
+                                      type: string
+                                    resourceClaimTemplateName:
+                                      description: |-
+                                        ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                        object in the same namespace as this pod.
+
+                                        The template will be used to create a new ResourceClaim, which will
+                                        be bound to this pod. When this pod is deleted, the ResourceClaim
+                                        will also be deleted. The pod name and resource name, along with a
+                                        generated component, will be used to form a unique name for the
+                                        ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                        This field is immutable and no changes will be made to the
+                                        corresponding ResourceClaim by the control plane after creating the
+                                        ResourceClaim.
+
+                                        Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                        be set.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              resources:
+                                description: |-
+                                  Resources is the total amount of CPU and Memory resources required by all
+                                  containers in the pod. It supports specifying Requests and Limits for
+                                  "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
+
+                                  This field enables fine-grained control over resource allocation for the
+                                  entire pod, allowing resource sharing among containers in a pod.
+
+                                  This is an alpha field and requires enabling the PodLevelResources feature
+                                  gate.
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+                                      This field depends on the
+                                      DynamicResourceAllocation feature gate.
+
+                                      This field is immutable. It can only be set for containers.
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                type: object
+                              restartPolicy:
+                                description: |-
+                                  Restart policy for all containers within the pod.
+                                  One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                                  Default to Always.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+                                type: string
+                              runtimeClassName:
+                                description: |-
+                                  RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                                  to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                                  If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                                  empty definition that uses the default runtime handler.
+                                  More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+                                type: string
+                              schedulerName:
+                                description: |-
+                                  If specified, the pod will be dispatched by specified scheduler.
+                                  If not specified, the pod will be dispatched by default scheduler.
+                                type: string
+                              schedulingGates:
+                                description: |-
+                                  SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                                  If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                                  scheduler will not attempt to schedule the pod.
+
+                                  SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+                                items:
+                                  description: PodSchedulingGate is associated to
+                                    a Pod to guard its scheduling.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the scheduling gate.
+                                        Each scheduling gate must have a unique name field.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              securityContext:
+                                description: |-
+                                  SecurityContext holds pod-level security attributes and common container settings.
+                                  Optional: Defaults to empty.  See type description for default values of each field.
+                                properties:
+                                  appArmorProfile:
+                                    description: |-
+                                      appArmorProfile is the AppArmor options to use by the containers in this pod.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile loaded on the node that should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must match the loaded name of the profile.
+                                          Must be set if and only if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of AppArmor profile will be applied.
+                                          Valid options are:
+                                            Localhost - a profile pre-loaded on the node.
+                                            RuntimeDefault - the container runtime's default profile.
+                                            Unconfined - no AppArmor enforcement.
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  fsGroup:
+                                    description: |-
+                                      A special supplemental group that applies to all containers in a pod.
+                                      Some volume types allow the Kubelet to change the ownership of that volume
+                                      to be owned by the pod:
+
+                                      1. The owning GID will be the FSGroup
+                                      2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                      3. The permission bits are OR'd with rw-rw----
+
+                                      If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  fsGroupChangePolicy:
+                                    description: |-
+                                      fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                      before being exposed inside Pod. This field will only apply to
+                                      volume types which support fsGroup based ownership(and permissions).
+                                      It will have no effect on ephemeral volume types such as: secret, configmaps
+                                      and emptydir.
+                                      Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
+                                  runAsGroup:
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence
+                                      for that container.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence
+                                      for that container.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  seLinuxChangePolicy:
+                                    description: |-
+                                      seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                                      It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                                      Valid values are "MountOption" and "Recursive".
+
+                                      "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                                      This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                                      "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                                      This requires all Pods that share the same volume to use the same SELinux label.
+                                      It is not possible to share the same volume among privileged and unprivileged Pods.
+                                      Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                                      whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                                      CSIDriver instance. Other volumes are always re-labelled recursively.
+                                      "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                                      If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                                      If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                                      and "Recursive" for all other volumes.
+
+                                      This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                                      All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
+                                  seLinuxOptions:
+                                    description: |-
+                                      The SELinux context to be applied to all containers.
+                                      If unspecified, the container runtime will allocate a random SELinux context for each
+                                      container.  May also be set in SecurityContext.  If set in
+                                      both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                      takes precedence for that container.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label
+                                          that applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label
+                                          that applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label
+                                          that applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label
+                                          that applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: |-
+                                      The seccomp options to use by the containers in this pod.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  supplementalGroups:
+                                    description: |-
+                                      A list of groups applied to the first process run in each container, in
+                                      addition to the container's primary GID and fsGroup (if specified).  If
+                                      the SupplementalGroupsPolicy feature is enabled, the
+                                      supplementalGroupsPolicy field determines whether these are in addition
+                                      to or instead of any group memberships defined in the container image.
+                                      If unspecified, no additional groups are added, though group memberships
+                                      defined in the container image may still be used, depending on the
+                                      supplementalGroupsPolicy field.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    items:
+                                      format: int64
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  supplementalGroupsPolicy:
+                                    description: |-
+                                      Defines how supplemental groups of the first container processes are calculated.
+                                      Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                                      (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                                      and the container runtime must implement support for this feature.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
+                                  sysctls:
+                                    description: |-
+                                      Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                      sysctls (by the container runtime) might fail to launch.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    items:
+                                      description: Sysctl defines a kernel parameter
+                                        to be set
+                                      properties:
+                                        name:
+                                          description: Name of a property to set
+                                          type: string
+                                        value:
+                                          description: Value of a property to set
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  windowsOptions:
+                                    description: |-
+                                      The Windows specific settings applied to all containers.
+                                      If unspecified, the options within a container's SecurityContext will be used.
+                                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is linux.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: |-
+                                          GMSACredentialSpec is where the GMSA admission webhook
+                                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                          GMSA credential spec named by the GMSACredentialSpecName field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the
+                                          name of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: |-
+                                          HostProcess determines if a container should be run as a 'Host Process' container.
+                                          All of a Pod's containers must have the same effective HostProcess value
+                                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: |-
+                                          The UserName in Windows to run the entrypoint of the container process.
+                                          Defaults to the user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              serviceAccount:
+                                description: |-
+                                  DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.
+                                  Deprecated: Use serviceAccountName instead.
+                                type: string
+                              serviceAccountName:
+                                description: |-
+                                  ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                                type: string
+                              setHostnameAsFQDN:
+                                description: |-
+                                  If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                                  In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                                  In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                                  If a pod does not have FQDN, this has no effect.
+                                  Default to false.
+                                type: boolean
+                              shareProcessNamespace:
+                                description: |-
+                                  Share a single process namespace between all of the containers in a pod.
+                                  When this is set containers will be able to view and signal processes from other containers
+                                  in the same pod, and the first process in each container will not be assigned PID 1.
+                                  HostPID and ShareProcessNamespace cannot both be set.
+                                  Optional: Default to false.
+                                type: boolean
+                              subdomain:
+                                description: |-
+                                  If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                                  If not specified, the pod will not have a domainname at all.
+                                type: string
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  If this value is nil, the default grace period will be used instead.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  Defaults to 30 seconds.
+                                format: int64
+                                type: integer
+                              tolerations:
+                                description: If specified, the pod's tolerations.
+                                items:
+                                  description: |-
+                                    The pod this Toleration is attached to tolerates any taint that matches
+                                    the triple <key,value,effect> using the matching operator <operator>.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: |-
+                                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        Operator represents a key's relationship to the value.
+                                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                        Exists is equivalent to wildcard for value, so that a pod can
+                                        tolerate all taints of a particular category.
+                                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                                      type: string
+                                    tolerationSeconds:
+                                      description: |-
+                                        TolerationSeconds represents the period of time the toleration (which must be
+                                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                        negative values will be treated as 0 (evict immediately) by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: |-
+                                        Value is the taint value the toleration matches to.
+                                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              topologySpreadConstraints:
+                                description: |-
+                                  TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                  domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                  All topologySpreadConstraints are ANDed.
+                                items:
+                                  description: TopologySpreadConstraint specifies
+                                    how to spread matching pods among the given topology.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is used to find matching pods.
+                                        Pods that match this label selector are counted to determine the number of pods
+                                        in their corresponding topology domain.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select the pods over which
+                                        spreading will be calculated. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are ANDed with labelSelector
+                                        to select the group of existing pods over which spreading will be calculated
+                                        for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        Keys that don't exist in the incoming pod labels will
+                                        be ignored. A null or empty list means only match against labelSelector.
+
+                                        This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    maxSkew:
+                                      description: |-
+                                        MaxSkew describes the degree to which pods may be unevenly distributed.
+                                        When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                        between the number of matching pods in the target topology and the global minimum.
+                                        The global minimum is the minimum number of matching pods in an eligible domain
+                                        or zero if the number of eligible domains is less than MinDomains.
+                                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                        labelSelector spread as 2/2/1:
+                                        In this case, the global minimum is 1.
+                                        | zone1 | zone2 | zone3 |
+                                        |  P P  |  P P  |   P   |
+                                        - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                        scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                        violate MaxSkew(1).
+                                        - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                        When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                        to topologies that satisfy it.
+                                        It's a required field. Default value is 1 and 0 is not allowed.
+                                      format: int32
+                                      type: integer
+                                    minDomains:
+                                      description: |-
+                                        MinDomains indicates a minimum number of eligible domains.
+                                        When the number of eligible domains with matching topology keys is less than minDomains,
+                                        Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                        And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                        this value has no effect on scheduling.
+                                        As a result, when the number of eligible domains is less than minDomains,
+                                        scheduler won't schedule more than maxSkew Pods to those domains.
+                                        If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                        Valid values are integers greater than 0.
+                                        When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                        For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                        labelSelector spread as 2/2/2:
+                                        | zone1 | zone2 | zone3 |
+                                        |  P P  |  P P  |  P P  |
+                                        The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                        In this situation, new pod with the same labelSelector cannot be scheduled,
+                                        because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                        it will violate MaxSkew.
+                                      format: int32
+                                      type: integer
+                                    nodeAffinityPolicy:
+                                      description: |-
+                                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                        when calculating pod topology spread skew. Options are:
+                                        - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                        - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                        If this value is nil, the behavior is equivalent to the Honor policy.
+                                      type: string
+                                    nodeTaintsPolicy:
+                                      description: |-
+                                        NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                        pod topology spread skew. Options are:
+                                        - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                        has a toleration, are included.
+                                        - Ignore: node taints are ignored. All nodes are included.
+
+                                        If this value is nil, the behavior is equivalent to the Ignore policy.
+                                      type: string
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey is the key of node labels. Nodes that have a label with this key
+                                        and identical values are considered to be in the same topology.
+                                        We consider each <key, value> as a "bucket", and try to put balanced number
+                                        of pods into each bucket.
+                                        We define a domain as a particular instance of a topology.
+                                        Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                        nodeAffinityPolicy and nodeTaintsPolicy.
+                                        e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                        And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                        It's a required field.
+                                      type: string
+                                    whenUnsatisfiable:
+                                      description: |-
+                                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                        the spread constraint.
+                                        - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                        - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                          but giving higher precedence to topologies that would help reduce the
+                                          skew.
+                                        A constraint is considered "Unsatisfiable" for an incoming pod
+                                        if and only if every possible node assignment for that pod would violate
+                                        "MaxSkew" on some topology.
+                                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                        labelSelector spread as 3/1/1:
+                                        | zone1 | zone2 | zone3 |
+                                        | P P P |   P   |   P   |
+                                        If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                        to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                        MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                        won't make it *more* imbalanced.
+                                        It's a required field.
+                                      type: string
+                                  required:
+                                  - maxSkew
+                                  - topologyKey
+                                  - whenUnsatisfiable
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - topologyKey
+                                - whenUnsatisfiable
+                                x-kubernetes-list-type: map
+                              volumes:
+                                description: |-
+                                  List of volumes that can be mounted by containers belonging to the pod.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes
+                                items:
+                                  description: Volume represents a named volume in
+                                    a pod that may be accessed by any container in
+                                    the pod.
+                                  properties:
+                                    awsElasticBlockStore:
+                                      description: |-
+                                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                        awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          type: string
+                                        partition:
+                                          description: |-
+                                            partition is the partition in the volume that you want to mount.
+                                            If omitted, the default is to mount by volume name.
+                                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: |-
+                                            readOnly value true will force the readOnly setting in VolumeMounts.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          type: boolean
+                                        volumeID:
+                                          description: |-
+                                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    azureDisk:
+                                      description: |-
+                                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                        Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                        are redirected to the disk.csi.azure.com CSI driver.
+                                      properties:
+                                        cachingMode:
+                                          description: 'cachingMode is the Host Caching
+                                            mode: None, Read Only, Read Write.'
+                                          type: string
+                                        diskName:
+                                          description: diskName is the Name of the
+                                            data disk in the blob storage
+                                          type: string
+                                        diskURI:
+                                          description: diskURI is the URI of data
+                                            disk in the blob storage
+                                          type: string
+                                        fsType:
+                                          default: ext4
+                                          description: |-
+                                            fsType is Filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        kind:
+                                          description: 'kind expected values are Shared:
+                                            multiple blob disks per storage account  Dedicated:
+                                            single blob disk per storage account  Managed:
+                                            azure managed data disk (only in managed
+                                            availability set). defaults to shared'
+                                          type: string
+                                        readOnly:
+                                          default: false
+                                          description: |-
+                                            readOnly Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                      required:
+                                      - diskName
+                                      - diskURI
+                                      type: object
+                                    azureFile:
+                                      description: |-
+                                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                        Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                        are redirected to the file.csi.azure.com CSI driver.
+                                      properties:
+                                        readOnly:
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretName:
+                                          description: secretName is the  name of
+                                            secret that contains Azure Storage Account
+                                            Name and Key
+                                          type: string
+                                        shareName:
+                                          description: shareName is the azure share
+                                            Name
+                                          type: string
+                                      required:
+                                      - secretName
+                                      - shareName
+                                      type: object
+                                    cephfs:
+                                      description: |-
+                                        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                        Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                                      properties:
+                                        monitors:
+                                          description: |-
+                                            monitors is Required: Monitors is a collection of Ceph monitors
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: 'path is Optional: Used as
+                                            the mounted root, rather than the full
+                                            Ceph tree, default is /'
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                          type: boolean
+                                        secretFile:
+                                          description: |-
+                                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                          type: string
+                                        secretRef:
+                                          description: |-
+                                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          description: |-
+                                            user is optional: User is the rados user name, default is admin
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                          type: string
+                                      required:
+                                      - monitors
+                                      type: object
+                                    cinder:
+                                      description: |-
+                                        cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                        Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                        are redirected to the cinder.csi.openstack.org CSI driver.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                          type: boolean
+                                        secretRef:
+                                          description: |-
+                                            secretRef is optional: points to a secret object containing parameters used to connect
+                                            to OpenStack.
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeID:
+                                          description: |-
+                                            volumeID used to identify the volume in cinder.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    configMap:
+                                      description: configMap represents a configMap
+                                        that should populate this volume
+                                      properties:
+                                        defaultMode:
+                                          description: |-
+                                            defaultMode is optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: |-
+                                            items if unspecified, each key-value pair in the Data field of the referenced
+                                            ConfigMap will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the ConfigMap,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: |-
+                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: |-
+                                                  path is the relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    csi:
+                                      description: csi (Container Storage Interface)
+                                        represents ephemeral storage that is handled
+                                        by certain external CSI drivers.
+                                      properties:
+                                        driver:
+                                          description: |-
+                                            driver is the name of the CSI driver that handles this volume.
+                                            Consult with your admin for the correct name as registered in the cluster.
+                                          type: string
+                                        fsType:
+                                          description: |-
+                                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                            If not provided, the empty value is passed to the associated CSI driver
+                                            which will determine the default filesystem to apply.
+                                          type: string
+                                        nodePublishSecretRef:
+                                          description: |-
+                                            nodePublishSecretRef is a reference to the secret object containing
+                                            sensitive information to pass to the CSI driver to complete the CSI
+                                            NodePublishVolume and NodeUnpublishVolume calls.
+                                            This field is optional, and  may be empty if no secret is required. If the
+                                            secret object contains more than one secret, all secret references are passed.
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        readOnly:
+                                          description: |-
+                                            readOnly specifies a read-only configuration for the volume.
+                                            Defaults to false (read/write).
+                                          type: boolean
+                                        volumeAttributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            volumeAttributes stores driver-specific properties that are passed to the CSI
+                                            driver. Consult your driver's documentation for supported values.
+                                          type: object
+                                      required:
+                                      - driver
+                                      type: object
+                                    downwardAPI:
+                                      description: downwardAPI represents downward
+                                        API about the pod that should populate this
+                                        volume
+                                      properties:
+                                        defaultMode:
+                                          description: |-
+                                            Optional: mode bits to use on created files by default. Must be a
+                                            Optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: Items is a list of downward
+                                            API volume file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name, namespace and uid
+                                                  are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              mode:
+                                                description: |-
+                                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                                  between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    emptyDir:
+                                      description: |-
+                                        emptyDir represents a temporary directory that shares a pod's lifetime.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                      properties:
+                                        medium:
+                                          description: |-
+                                            medium represents what type of storage medium should back this directory.
+                                            The default is "" which means to use the node's default medium.
+                                            Must be an empty string (default) or Memory.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                          type: string
+                                        sizeLimit:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                            The size limit is also applicable for memory medium.
+                                            The maximum usage on memory medium EmptyDir would be the minimum value between
+                                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                            The default is nil which means that the limit is undefined.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    ephemeral:
+                                      description: |-
+                                        ephemeral represents a volume that is handled by a cluster storage driver.
+                                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                        and deleted when the pod is removed.
+
+                                        Use this if:
+                                        a) the volume is only needed while the pod runs,
+                                        b) features of normal volumes like restoring from snapshot or capacity
+                                           tracking are needed,
+                                        c) the storage driver is specified through a storage class, and
+                                        d) the storage driver supports dynamic volume provisioning through
+                                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                           information on the connection between this volume type
+                                           and PersistentVolumeClaim).
+
+                                        Use PersistentVolumeClaim or one of the vendor-specific
+                                        APIs for volumes that persist for longer than the lifecycle
+                                        of an individual pod.
+
+                                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                        be used that way - see the documentation of the driver for
+                                        more information.
+
+                                        A pod can use both types of ephemeral volumes and
+                                        persistent volumes at the same time.
+                                      properties:
+                                        volumeClaimTemplate:
+                                          description: |-
+                                            Will be used to create a stand-alone PVC to provision the volume.
+                                            The pod in which this EphemeralVolumeSource is embedded will be the
+                                            owner of the PVC, i.e. the PVC will be deleted together with the
+                                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                            `<volume name>` is the name from the `PodSpec.Volumes` array
+                                            entry. Pod validation will reject the pod if the concatenated name
+                                            is not valid for a PVC (for example, too long).
+
+                                            An existing PVC with that name that is not owned by the pod
+                                            will *not* be used for the pod to avoid using an unrelated
+                                            volume by mistake. Starting the pod is then blocked until
+                                            the unrelated PVC is removed. If such a pre-created PVC is
+                                            meant to be used by the pod, the PVC has to updated with an
+                                            owner reference to the pod once the pod exists. Normally
+                                            this should not be necessary, but it may be useful when
+                                            manually reconstructing a broken cluster.
+
+                                            This field is read-only and no changes will be made by Kubernetes
+                                            to the PVC after it has been created.
+
+                                            Required, must not be nil.
+                                          properties:
+                                            metadata:
+                                              description: |-
+                                                May contain labels and annotations that will be copied into the PVC
+                                                when creating it. No other fields are allowed and will be rejected during
+                                                validation.
+                                              type: object
+                                            spec:
+                                              description: |-
+                                                The specification for the PersistentVolumeClaim. The entire content is
+                                                copied unchanged into the PVC that gets created from this
+                                                template. The same fields as in a PersistentVolumeClaim
+                                                are also valid here.
+                                              properties:
+                                                accessModes:
+                                                  description: |-
+                                                    accessModes contains the desired access modes the volume should have.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                dataSource:
+                                                  description: |-
+                                                    dataSource field can be used to specify either:
+                                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                    * An existing PVC (PersistentVolumeClaim)
+                                                    If the provisioner or an external controller can support the specified data source,
+                                                    it will create a new volume based on the contents of the specified data source.
+                                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                                  properties:
+                                                    apiGroup:
+                                                      description: |-
+                                                        APIGroup is the group for the resource being referenced.
+                                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                        For any other third-party types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type
+                                                        of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name
+                                                        of resource being referenced
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                dataSourceRef:
+                                                  description: |-
+                                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                    volume is desired. This may be any object from a non-empty API group (non
+                                                    core object) or a PersistentVolumeClaim object.
+                                                    When this field is specified, volume binding will only succeed if the type of
+                                                    the specified object matches some installed volume populator or dynamic
+                                                    provisioner.
+                                                    This field will replace the functionality of the dataSource field and as such
+                                                    if both fields are non-empty, they must have the same value. For backwards
+                                                    compatibility, when namespace isn't specified in dataSourceRef,
+                                                    both fields (dataSource and dataSourceRef) will be set to the same
+                                                    value automatically if one of them is empty and the other is non-empty.
+                                                    When namespace is specified in dataSourceRef,
+                                                    dataSource isn't set to the same value and must be empty.
+                                                    There are three important differences between dataSource and dataSourceRef:
+                                                    * While dataSource only allows two specific types of objects, dataSourceRef
+                                                      allows any non-core object, as well as PersistentVolumeClaim objects.
+                                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                                      preserves all values, and generates an error if a disallowed value is
+                                                      specified.
+                                                    * While dataSource only allows local objects, dataSourceRef allows objects
+                                                      in any namespaces.
+                                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                  properties:
+                                                    apiGroup:
+                                                      description: |-
+                                                        APIGroup is the group for the resource being referenced.
+                                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                        For any other third-party types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type
+                                                        of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name
+                                                        of resource being referenced
+                                                      type: string
+                                                    namespace:
+                                                      description: |-
+                                                        Namespace is the namespace of resource being referenced
+                                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                resources:
+                                                  description: |-
+                                                    resources represents the minimum resources the volume should have.
+                                                    Users are allowed to specify resource requirements
+                                                    that are lower than previous value but must still be higher than capacity recorded in the
+                                                    status field of the claim.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: |-
+                                                        Limits describes the maximum amount of compute resources allowed.
+                                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: |-
+                                                        Requests describes the minimum amount of compute resources required.
+                                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  description: selector is a label
+                                                    query over volumes to consider
+                                                    for binding.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                storageClassName:
+                                                  description: |-
+                                                    storageClassName is the name of the StorageClass required by the claim.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                                  type: string
+                                                volumeAttributesClassName:
+                                                  description: |-
+                                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                                    If specified, the CSI driver will create or update the volume with the attributes defined
+                                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                                    it can be changed after the claim is created. An empty string or nil value indicates that no
+                                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                                    this field can be reset to its previous value (including nil) to cancel the modification.
+                                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                                    exists.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                                  type: string
+                                                volumeMode:
+                                                  description: |-
+                                                    volumeMode defines what type of volume is required by the claim.
+                                                    Value of Filesystem is implied when not included in claim spec.
+                                                  type: string
+                                                volumeName:
+                                                  description: volumeName is the binding
+                                                    reference to the PersistentVolume
+                                                    backing this claim.
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - spec
+                                          type: object
+                                      type: object
+                                    fc:
+                                      description: fc represents a Fibre Channel resource
+                                        that is attached to a kubelet's host machine
+                                        and then exposed to the pod.
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        lun:
+                                          description: 'lun is Optional: FC target
+                                            lun number'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: |-
+                                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        targetWWNs:
+                                          description: 'targetWWNs is Optional: FC
+                                            target worldwide names (WWNs)'
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        wwids:
+                                          description: |-
+                                            wwids Optional: FC volume world wide identifiers (wwids)
+                                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    flexVolume:
+                                      description: |-
+                                        flexVolume represents a generic volume resource that is
+                                        provisioned/attached using an exec based plugin.
+                                        Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                                      properties:
+                                        driver:
+                                          description: driver is the name of the driver
+                                            to use for this volume.
+                                          type: string
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                          type: string
+                                        options:
+                                          additionalProperties:
+                                            type: string
+                                          description: 'options is Optional: this
+                                            field holds extra command options if any.'
+                                          type: object
+                                        readOnly:
+                                          description: |-
+                                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: |-
+                                            secretRef is Optional: secretRef is reference to the secret object containing
+                                            sensitive information to pass to the plugin scripts. This may be
+                                            empty if no secret object is specified. If the secret object
+                                            contains more than one secret, all secrets are passed to the plugin
+                                            scripts.
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - driver
+                                      type: object
+                                    flocker:
+                                      description: |-
+                                        flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                        Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                                      properties:
+                                        datasetName:
+                                          description: |-
+                                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                            should be considered as deprecated
+                                          type: string
+                                        datasetUUID:
+                                          description: datasetUUID is the UUID of
+                                            the dataset. This is unique identifier
+                                            of a Flocker dataset
+                                          type: string
+                                      type: object
+                                    gcePersistentDisk:
+                                      description: |-
+                                        gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                        gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          type: string
+                                        partition:
+                                          description: |-
+                                            partition is the partition in the volume that you want to mount.
+                                            If omitted, the default is to mount by volume name.
+                                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          format: int32
+                                          type: integer
+                                        pdName:
+                                          description: |-
+                                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          type: boolean
+                                      required:
+                                      - pdName
+                                      type: object
+                                    gitRepo:
+                                      description: |-
+                                        gitRepo represents a git repository at a particular revision.
+                                        Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                        into the Pod's container.
+                                      properties:
+                                        directory:
+                                          description: |-
+                                            directory is the target directory name.
+                                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                            git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                            the subdirectory with the given name.
+                                          type: string
+                                        repository:
+                                          description: repository is the URL
+                                          type: string
+                                        revision:
+                                          description: revision is the commit hash
+                                            for the specified revision.
+                                          type: string
+                                      required:
+                                      - repository
+                                      type: object
+                                    glusterfs:
+                                      description: |-
+                                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                        Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                                      properties:
+                                        endpoints:
+                                          description: endpoints is the endpoint name
+                                            that details Glusterfs topology.
+                                          type: string
+                                        path:
+                                          description: |-
+                                            path is the Glusterfs volume path.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                            Defaults to false.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                          type: boolean
+                                      required:
+                                      - endpoints
+                                      - path
+                                      type: object
+                                    hostPath:
+                                      description: |-
+                                        hostPath represents a pre-existing file or directory on the host
+                                        machine that is directly exposed to the container. This is generally
+                                        used for system agents or other privileged things that are allowed
+                                        to see the host machine. Most containers will NOT need this.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                      properties:
+                                        path:
+                                          description: |-
+                                            path of the directory on the host.
+                                            If the path is a symlink, it will follow the link to the real path.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type for HostPath Volume
+                                            Defaults to ""
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    image:
+                                      description: |-
+                                        image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                                        The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                                        - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                        - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                        - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                                        The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                                        A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                                        The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                                        The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                                        The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                                      properties:
+                                        pullPolicy:
+                                          description: |-
+                                            Policy for pulling OCI objects. Possible values are:
+                                            Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                            Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                            IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                            Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                          type: string
+                                        reference:
+                                          description: |-
+                                            Required: Image or artifact reference to be used.
+                                            Behaves in the same way as pod.spec.containers[*].image.
+                                            Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                            More info: https://kubernetes.io/docs/concepts/containers/images
+                                            This field is optional to allow higher level config management to default or override
+                                            container images in workload controllers like Deployments and StatefulSets.
+                                          type: string
+                                      type: object
+                                    iscsi:
+                                      description: |-
+                                        iscsi represents an ISCSI Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                                      properties:
+                                        chapAuthDiscovery:
+                                          description: chapAuthDiscovery defines whether
+                                            support iSCSI Discovery CHAP authentication
+                                          type: boolean
+                                        chapAuthSession:
+                                          description: chapAuthSession defines whether
+                                            support iSCSI Session CHAP authentication
+                                          type: boolean
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          type: string
+                                        initiatorName:
+                                          description: |-
+                                            initiatorName is the custom iSCSI Initiator Name.
+                                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                            <target portal>:<volume name> will be created for the connection.
+                                          type: string
+                                        iqn:
+                                          description: iqn is the target iSCSI Qualified
+                                            Name.
+                                          type: string
+                                        iscsiInterface:
+                                          default: default
+                                          description: |-
+                                            iscsiInterface is the interface Name that uses an iSCSI transport.
+                                            Defaults to 'default' (tcp).
+                                          type: string
+                                        lun:
+                                          description: lun represents iSCSI Target
+                                            Lun number.
+                                          format: int32
+                                          type: integer
+                                        portals:
+                                          description: |-
+                                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                            is other than default (typically TCP ports 860 and 3260).
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        readOnly:
+                                          description: |-
+                                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef is the CHAP Secret
+                                            for iSCSI target and initiator authentication
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        targetPortal:
+                                          description: |-
+                                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                            is other than default (typically TCP ports 860 and 3260).
+                                          type: string
+                                      required:
+                                      - iqn
+                                      - lun
+                                      - targetPortal
+                                      type: object
+                                    name:
+                                      description: |-
+                                        name of the volume.
+                                        Must be a DNS_LABEL and unique within the pod.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    nfs:
+                                      description: |-
+                                        nfs represents an NFS mount on the host that shares a pod's lifetime
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                      properties:
+                                        path:
+                                          description: |-
+                                            path that is exported by the NFS server.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly here will force the NFS export to be mounted with read-only permissions.
+                                            Defaults to false.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                          type: boolean
+                                        server:
+                                          description: |-
+                                            server is the hostname or IP address of the NFS server.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                          type: string
+                                      required:
+                                      - path
+                                      - server
+                                      type: object
+                                    persistentVolumeClaim:
+                                      description: |-
+                                        persistentVolumeClaimVolumeSource represents a reference to a
+                                        PersistentVolumeClaim in the same namespace.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                      properties:
+                                        claimName:
+                                          description: |-
+                                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                                            Default false.
+                                          type: boolean
+                                      required:
+                                      - claimName
+                                      type: object
+                                    photonPersistentDisk:
+                                      description: |-
+                                        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                        Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        pdID:
+                                          description: pdID is the ID that identifies
+                                            Photon Controller persistent disk
+                                          type: string
+                                      required:
+                                      - pdID
+                                      type: object
+                                    portworxVolume:
+                                      description: |-
+                                        portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                        Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                                        is on.
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fSType represents the filesystem type to mount
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        volumeID:
+                                          description: volumeID uniquely identifies
+                                            a Portworx volume
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    projected:
+                                      description: projected items for all in one
+                                        resources secrets, configmaps, and downward
+                                        API
+                                      properties:
+                                        defaultMode:
+                                          description: |-
+                                            defaultMode are the mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        sources:
+                                          description: |-
+                                            sources is the list of volume projections. Each entry in this list
+                                            handles one source.
+                                          items:
+                                            description: |-
+                                              Projection that may be projected along with other supported volume types.
+                                              Exactly one of these fields must be set.
+                                            properties:
+                                              clusterTrustBundle:
+                                                description: |-
+                                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                                  of ClusterTrustBundle objects in an auto-updating file.
+
+                                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                                  ClusterTrustBundle objects can either be selected by name, or by the
+                                                  combination of signer name and a label selector.
+
+                                                  Kubelet performs aggressive normalization of the PEM contents written
+                                                  into the pod filesystem.  Esoteric PEM features such as inter-block
+                                                  comments and block headers are stripped.  Certificates are deduplicated.
+                                                  The ordering of certificates within the file is arbitrary, and Kubelet
+                                                  may change the order over time.
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      Select all ClusterTrustBundles that match this label selector.  Only has
+                                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                                      interpreted as "match nothing".  If set but empty, interpreted as "match
+                                                      everything".
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions
+                                                          is a list of label selector
+                                                          requirements. The requirements
+                                                          are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is
+                                                                the label key that
+                                                                the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  name:
+                                                    description: |-
+                                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                                      with signerName and labelSelector.
+                                                    type: string
+                                                  optional:
+                                                    description: |-
+                                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                                      aren't available.  If using name, then the named ClusterTrustBundle is
+                                                      allowed not to exist.  If using signerName, then the combination of
+                                                      signerName and labelSelector is allowed to match zero
+                                                      ClusterTrustBundles.
+                                                    type: boolean
+                                                  path:
+                                                    description: Relative path from
+                                                      the volume root to write the
+                                                      bundle.
+                                                    type: string
+                                                  signerName:
+                                                    description: |-
+                                                      Select all ClusterTrustBundles that match this signer name.
+                                                      Mutually-exclusive with name.  The contents of all selected
+                                                      ClusterTrustBundles will be unified and deduplicated.
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                              configMap:
+                                                description: configMap information
+                                                  about the configMap data to project
+                                                properties:
+                                                  items:
+                                                    description: |-
+                                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                                      ConfigMap will be projected into the volume as a file whose name is the
+                                                      key and content is the value. If specified, the listed keys will be
+                                                      projected into the specified paths, and unlisted keys will not be
+                                                      present. If a key is specified which is not present in the ConfigMap,
+                                                      the volume setup will error unless it is marked optional. Paths must be
+                                                      relative and may not contain the '..' path or start with '..'.
+                                                    items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: |-
+                                                            mode is Optional: mode bits used to set permissions on this file.
+                                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                            If not specified, the volume defaultMode will be used.
+                                                            This might be in conflict with other options that affect the file
+                                                            mode, like fsGroup, and the result can be other mode bits set.
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: |-
+                                                            path is the relative path of the file to map the key to.
+                                                            May not be an absolute path.
+                                                            May not contain the path element '..'.
+                                                            May not start with the string '..'.
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: optional specify
+                                                      whether the ConfigMap or its
+                                                      keys must be defined
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              downwardAPI:
+                                                description: downwardAPI information
+                                                  about the downwardAPI data to project
+                                                properties:
+                                                  items:
+                                                    description: Items is a list of
+                                                      DownwardAPIVolume file
+                                                    items:
+                                                      description: DownwardAPIVolumeFile
+                                                        represents information to
+                                                        create the file containing
+                                                        the pod field
+                                                      properties:
+                                                        fieldRef:
+                                                          description: 'Required:
+                                                            Selects a field of the
+                                                            pod: only annotations,
+                                                            labels, name, namespace
+                                                            and uid are supported.'
+                                                          properties:
+                                                            apiVersion:
+                                                              description: Version
+                                                                of the schema the
+                                                                FieldPath is written
+                                                                in terms of, defaults
+                                                                to "v1".
+                                                              type: string
+                                                            fieldPath:
+                                                              description: Path of
+                                                                the field to select
+                                                                in the specified API
+                                                                version.
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        mode:
+                                                          description: |-
+                                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                                            between 0000 and 0777 or a decimal value between 0 and 511.
+                                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                            If not specified, the volume defaultMode will be used.
+                                                            This might be in conflict with other options that affect the file
+                                                            mode, like fsGroup, and the result can be other mode bits set.
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: 'Required:
+                                                            Path is  the relative
+                                                            path name of the file
+                                                            to be created. Must not
+                                                            be absolute or contain
+                                                            the ''..'' path. Must
+                                                            be utf-8 encoded. The
+                                                            first item of the relative
+                                                            path must not start with
+                                                            ''..'''
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          description: |-
+                                                            Selects a resource of the container: only resources limits and requests
+                                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                          properties:
+                                                            containerName:
+                                                              description: 'Container
+                                                                name: required for
+                                                                volumes, optional
+                                                                for env vars'
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              description: Specifies
+                                                                the output format
+                                                                of the exposed resources,
+                                                                defaults to "1"
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              description: 'Required:
+                                                                resource to select'
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              podCertificate:
+                                                description: |-
+                                                  Projects an auto-rotating credential bundle (private key and certificate
+                                                  chain) that the pod can use either as a TLS client or server.
+
+                                                  Kubelet generates a private key and uses it to send a
+                                                  PodCertificateRequest to the named signer.  Once the signer approves the
+                                                  request and issues a certificate chain, Kubelet writes the key and
+                                                  certificate chain to the pod filesystem.  The pod does not start until
+                                                  certificates have been issued for each podCertificate projected volume
+                                                  source in its spec.
+
+                                                  Kubelet will begin trying to rotate the certificate at the time indicated
+                                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                                  timestamp.
+
+                                                  Kubelet can write a single file, indicated by the credentialBundlePath
+                                                  field, or separate files, indicated by the keyPath and
+                                                  certificateChainPath fields.
+
+                                                  The credential bundle is a single file in PEM format.  The first PEM
+                                                  entry is the private key (in PKCS#8 format), and the remaining PEM
+                                                  entries are the certificate chain issued by the signer (typically,
+                                                  signers will return their certificate chain in leaf-to-root order).
+
+                                                  Prefer using the credential bundle format, since your application code
+                                                  can read it atomically.  If you use keyPath and certificateChainPath,
+                                                  your application must make two separate file reads. If these coincide
+                                                  with a certificate rotation, it is possible that the private key and leaf
+                                                  certificate you read may not correspond to each other.  Your application
+                                                  will need to check for this condition, and re-read until they are
+                                                  consistent.
+
+                                                  The named signer controls chooses the format of the certificate it
+                                                  issues; consult the signer implementation's documentation to learn how to
+                                                  use the certificates it issues.
+                                                properties:
+                                                  certificateChainPath:
+                                                    description: |-
+                                                      Write the certificate chain at this path in the projected volume.
+
+                                                      Most applications should use credentialBundlePath.  When using keyPath
+                                                      and certificateChainPath, your application needs to check that the key
+                                                      and leaf certificate are consistent, because it is possible to read the
+                                                      files mid-rotation.
+                                                    type: string
+                                                  credentialBundlePath:
+                                                    description: |-
+                                                      Write the credential bundle at this path in the projected volume.
+
+                                                      The credential bundle is a single file that contains multiple PEM blocks.
+                                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                                      key.
+
+                                                      The remaining blocks are CERTIFICATE blocks, containing the issued
+                                                      certificate chain from the signer (leaf and any intermediates).
+
+                                                      Using credentialBundlePath lets your Pod's application code make a single
+                                                      atomic read that retrieves a consistent key and certificate chain.  If you
+                                                      project them to separate files, your application code will need to
+                                                      additionally check that the leaf certificate was issued to the key.
+                                                    type: string
+                                                  keyPath:
+                                                    description: |-
+                                                      Write the key at this path in the projected volume.
+
+                                                      Most applications should use credentialBundlePath.  When using keyPath
+                                                      and certificateChainPath, your application needs to check that the key
+                                                      and leaf certificate are consistent, because it is possible to read the
+                                                      files mid-rotation.
+                                                    type: string
+                                                  keyType:
+                                                    description: |-
+                                                      The type of keypair Kubelet will generate for the pod.
+
+                                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                                      "ECDSAP521", and "ED25519".
+                                                    type: string
+                                                  maxExpirationSeconds:
+                                                    description: |-
+                                                      maxExpirationSeconds is the maximum lifetime permitted for the
+                                                      certificate.
+
+                                                      Kubelet copies this value verbatim into the PodCertificateRequests it
+                                                      generates for this projection.
+
+                                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                                      value is 7862400 (91 days).
+
+                                                      The signer implementation is then free to issue a certificate with any
+                                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                                      `kubernetes.io` signers will never issue certificates with a lifetime
+                                                      longer than 24 hours.
+                                                    format: int32
+                                                    type: integer
+                                                  signerName:
+                                                    description: Kubelet's generated
+                                                      CSRs will be addressed to this
+                                                      signer.
+                                                    type: string
+                                                  userAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      userAnnotations allow pod authors to pass additional information to
+                                                      the signer implementation.  Kubernetes does not restrict or validate this
+                                                      metadata in any way.
+
+                                                      These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                      the PodCertificateRequest objects that Kubelet creates.
+
+                                                      Entries are subject to the same validation as object metadata annotations,
+                                                      with the addition that all keys must be domain-prefixed. No restrictions
+                                                      are placed on values, except an overall size limitation on the entire field.
+
+                                                      Signers should document the keys and values they support. Signers should
+                                                      deny requests that contain keys they do not recognize.
+                                                    type: object
+                                                required:
+                                                - keyType
+                                                - signerName
+                                                type: object
+                                              secret:
+                                                description: secret information about
+                                                  the secret data to project
+                                                properties:
+                                                  items:
+                                                    description: |-
+                                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                                      Secret will be projected into the volume as a file whose name is the
+                                                      key and content is the value. If specified, the listed keys will be
+                                                      projected into the specified paths, and unlisted keys will not be
+                                                      present. If a key is specified which is not present in the Secret,
+                                                      the volume setup will error unless it is marked optional. Paths must be
+                                                      relative and may not contain the '..' path or start with '..'.
+                                                    items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: |-
+                                                            mode is Optional: mode bits used to set permissions on this file.
+                                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                            If not specified, the volume defaultMode will be used.
+                                                            This might be in conflict with other options that affect the file
+                                                            mode, like fsGroup, and the result can be other mode bits set.
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: |-
+                                                            path is the relative path of the file to map the key to.
+                                                            May not be an absolute path.
+                                                            May not contain the path element '..'.
+                                                            May not start with the string '..'.
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: optional field specify
+                                                      whether the Secret or its key
+                                                      must be defined
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              serviceAccountToken:
+                                                description: serviceAccountToken is
+                                                  information about the serviceAccountToken
+                                                  data to project
+                                                properties:
+                                                  audience:
+                                                    description: |-
+                                                      audience is the intended audience of the token. A recipient of a token
+                                                      must identify itself with an identifier specified in the audience of the
+                                                      token, and otherwise should reject the token. The audience defaults to the
+                                                      identifier of the apiserver.
+                                                    type: string
+                                                  expirationSeconds:
+                                                    description: |-
+                                                      expirationSeconds is the requested duration of validity of the service
+                                                      account token. As the token approaches expiration, the kubelet volume
+                                                      plugin will proactively rotate the service account token. The kubelet will
+                                                      start trying to rotate the token if the token is older than 80 percent of
+                                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                      and must be at least 10 minutes.
+                                                    format: int64
+                                                    type: integer
+                                                  path:
+                                                    description: |-
+                                                      path is the path relative to the mount point of the file to project the
+                                                      token into.
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    quobyte:
+                                      description: |-
+                                        quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                        Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                                      properties:
+                                        group:
+                                          description: |-
+                                            group to map volume access to
+                                            Default is no group
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                            Defaults to false.
+                                          type: boolean
+                                        registry:
+                                          description: |-
+                                            registry represents a single or multiple Quobyte Registry services
+                                            specified as a string as host:port pair (multiple entries are separated with commas)
+                                            which acts as the central registry for volumes
+                                          type: string
+                                        tenant:
+                                          description: |-
+                                            tenant owning the given Quobyte volume in the Backend
+                                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                          type: string
+                                        user:
+                                          description: |-
+                                            user to map volume access to
+                                            Defaults to serivceaccount user
+                                          type: string
+                                        volume:
+                                          description: volume is a string that references
+                                            an already created Quobyte volume by name.
+                                          type: string
+                                      required:
+                                      - registry
+                                      - volume
+                                      type: object
+                                    rbd:
+                                      description: |-
+                                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                        Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          type: string
+                                        image:
+                                          description: |-
+                                            image is the rados image name.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          type: string
+                                        keyring:
+                                          default: /etc/ceph/keyring
+                                          description: |-
+                                            keyring is the path to key ring for RBDUser.
+                                            Default is /etc/ceph/keyring.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          type: string
+                                        monitors:
+                                          description: |-
+                                            monitors is a collection of Ceph monitors.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        pool:
+                                          default: rbd
+                                          description: |-
+                                            pool is the rados pool name.
+                                            Default is rbd.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          type: boolean
+                                        secretRef:
+                                          description: |-
+                                            secretRef is name of the authentication secret for RBDUser. If provided
+                                            overrides keyring.
+                                            Default is nil.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          default: admin
+                                          description: |-
+                                            user is the rados user name.
+                                            Default is admin.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          type: string
+                                      required:
+                                      - image
+                                      - monitors
+                                      type: object
+                                    scaleIO:
+                                      description: |-
+                                        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                        Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                                      properties:
+                                        fsType:
+                                          default: xfs
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs".
+                                            Default is "xfs".
+                                          type: string
+                                        gateway:
+                                          description: gateway is the host address
+                                            of the ScaleIO API Gateway.
+                                          type: string
+                                        protectionDomain:
+                                          description: protectionDomain is the name
+                                            of the ScaleIO Protection Domain for the
+                                            configured storage.
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: |-
+                                            secretRef references to the secret for ScaleIO user and other
+                                            sensitive information. If this is not provided, Login operation will fail.
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        sslEnabled:
+                                          description: sslEnabled Flag enable/disable
+                                            SSL communication with Gateway, default
+                                            false
+                                          type: boolean
+                                        storageMode:
+                                          default: ThinProvisioned
+                                          description: |-
+                                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                            Default is ThinProvisioned.
+                                          type: string
+                                        storagePool:
+                                          description: storagePool is the ScaleIO
+                                            Storage Pool associated with the protection
+                                            domain.
+                                          type: string
+                                        system:
+                                          description: system is the name of the storage
+                                            system as configured in ScaleIO.
+                                          type: string
+                                        volumeName:
+                                          description: |-
+                                            volumeName is the name of a volume already created in the ScaleIO system
+                                            that is associated with this volume source.
+                                          type: string
+                                      required:
+                                      - gateway
+                                      - secretRef
+                                      - system
+                                      type: object
+                                    secret:
+                                      description: |-
+                                        secret represents a secret that should populate this volume.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                      properties:
+                                        defaultMode:
+                                          description: |-
+                                            defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values
+                                            for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: |-
+                                            items If unspecified, each key-value pair in the Data field of the referenced
+                                            Secret will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the Secret,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: |-
+                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: |-
+                                                  path is the relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its keys must be defined
+                                          type: boolean
+                                        secretName:
+                                          description: |-
+                                            secretName is the name of the secret in the pod's namespace to use.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                          type: string
+                                      type: object
+                                    storageos:
+                                      description: |-
+                                        storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                        Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: |-
+                                            secretRef specifies the secret to use for obtaining the StorageOS API
+                                            credentials.  If not specified, default values will be attempted.
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeName:
+                                          description: |-
+                                            volumeName is the human-readable name of the StorageOS volume.  Volume
+                                            names are only unique within a namespace.
+                                          type: string
+                                        volumeNamespace:
+                                          description: |-
+                                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                            namespace is specified then the Pod's namespace will be used.  This allows the
+                                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                            Set VolumeName to any name to override the default behaviour.
+                                            Set to "default" if you are not using namespaces within StorageOS.
+                                            Namespaces that do not pre-exist within StorageOS will be created.
+                                          type: string
+                                      type: object
+                                    vsphereVolume:
+                                      description: |-
+                                        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                        Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                        are redirected to the csi.vsphere.vmware.com CSI driver.
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        storagePolicyID:
+                                          description: storagePolicyID is the storage
+                                            Policy Based Management (SPBM) profile
+                                            ID associated with the StoragePolicyName.
+                                          type: string
+                                        storagePolicyName:
+                                          description: storagePolicyName is the storage
+                                            Policy Based Management (SPBM) profile
+                                            name.
+                                          type: string
+                                        volumePath:
+                                          description: volumePath is the path that
+                                            identifies vSphere volume vmdk
+                                          type: string
+                                      required:
+                                      - volumePath
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              workloadRef:
+                                description: |-
+                                  WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                                  This field is used by the scheduler to identify the PodGroup and apply the
+                                  correct group scheduling policies. The Workload object referenced
+                                  by this field may not exist at the time the Pod is created.
+                                  This field is immutable, but a Workload object with the same name
+                                  may be recreated with different policies. Doing this during pod scheduling
+                                  may result in the placement not conforming to the expected policies.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name defines the name of the Workload object this Pod belongs to.
+                                      Workload must be in the same namespace as the Pod.
+                                      If it doesn't match any existing Workload, the Pod will remain unschedulable
+                                      until a Workload object is created and observed by the kube-scheduler.
+                                      It must be a DNS subdomain.
+                                    type: string
+                                  podGroup:
+                                    description: |-
+                                      PodGroup is the name of the PodGroup within the Workload that this Pod
+                                      belongs to. If it doesn't match any existing PodGroup within the Workload,
+                                      the Pod will remain unschedulable until the Workload object is recreated
+                                      and observed by the kube-scheduler. It must be a DNS label.
+                                    type: string
+                                  podGroupReplicaKey:
+                                    description: |-
+                                      PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                                      Pod belongs. It is used to distinguish pods belonging to different replicas
+                                      of the same pod group. The pod group policy is applied separately to each replica.
+                                      When set, it must be a DNS label.
+                                    type: string
+                                required:
+                                - name
+                                - podGroup
+                                type: object
+                            required:
+                            - containers
+                            type: object
+                        type: object
+                      ttlSecondsAfterFinished:
+                        description: |-
+                          ttlSecondsAfterFinished limits the lifetime of a Job that has finished
+                          execution (either Complete or Failed). If this field is set,
+                          ttlSecondsAfterFinished after the Job finishes, it is eligible to be
+                          automatically deleted. When the Job is being deleted, its lifecycle
+                          guarantees (e.g. finalizers) will be honored. If this field is unset,
+                          the Job won't be automatically deleted. If this field is set to zero,
+                          the Job becomes eligible to be deleted immediately after it finishes.
+                        format: int32
+                        type: integer
+                    required:
+                    - template
+                    type: object
+                type: object
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels는 BackupResult 메타데이터에 첨부될 K8s 스타일 레이블.
+                type: object
+              repo:
+                description: Repo는 다중 저장소 환경에서 어느 repo를 쓸지 식별.
+                minLength: 1
+                type: string
+              restore:
+                description: Restore는 Type=restore 시 PITR 설정 (RFC 0004 §5.1).
+                properties:
+                  backupID:
+                    description: BackupID는 복구 대상 백업 식별자 (TargetTime 대신 직접 지정).
+                    type: string
+                  targetTime:
+                    description: TargetTime은 복구 대상 시각 (UTC, ISO 8601 RFC3339).
+                    format: date-time
+                    type: string
+                type: object
+              retention:
+                description: Retention은 백업 보존 정책.
+                properties:
+                  keepFull:
+                    description: KeepFull은 보존할 full 백업 개수. 0이면 무제한 (plugin 기본).
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  keepIncremental:
+                    description: KeepIncremental은 보존할 incremental/differential 백업
+                      개수.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
+              tool:
+                description: |-
+                  Tool은 사용할 백업 도구 이름. BackupPlugin.Name()과 일치해야 한다.
+                  예: "pgbackrest" (RFC 0004 §4 1차 reference), "walg", "barman".
+                minLength: 1
+                type: string
+              type:
+                description: Type은 백업 종류.
+                enum:
+                - full
+                - incremental
+                - differential
+                - restore
+                type: string
+            required:
+            - cluster
+            - repo
+            - tool
+            - type
+            type: object
+          status:
+            description: BackupJobStatus는 BackupJob의 관찰 상태.
+            properties:
+              backupID:
+                description: BackupID는 plugin이 부여한 고유 식별자 (Succeeded 후).
+                type: string
+              bytes:
+                description: Bytes는 백업 크기 (bytes). 0 허용 (스트리밍 도구).
+                format: int64
+                type: integer
+              conditions:
+                description: Conditions는 K8s 표준 상태 (Ready, Available, Progressing).
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              endedAt:
+                description: EndedAt은 백업 종료 시각.
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration은 reconcile이 마지막 처리한 spec generation.
+                format: int64
+                type: integer
+              phase:
+                description: Phase는 BackupJob 진행 단계.
+                enum:
+                - Pending
+                - Running
+                - Succeeded
+                - Failed
+                type: string
+              runnerJobName:
+                description: RunnerJobName은 ExecutionMode="job"에서 생성한 batch/v1 Job
+                  이름이다.
+                type: string
+              startedAt:
+                description: StartedAt은 백업 시작 시각.
+                format: date-time
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_clusterimagecatalogs.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_clusterimagecatalogs.yaml
@@ -1,0 +1,124 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  creationTimestamp: null
+  name: clusterimagecatalogs.postgres.keiailab.io
+spec:
+  group: postgres.keiailab.io
+  names:
+    categories:
+    - postgres
+    - image
+    - all
+    kind: ClusterImageCatalog
+    listKind: ClusterImageCatalogList
+    plural: clusterimagecatalogs
+    shortNames:
+    - pgcic
+    singular: clusterimagecatalog
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.images[*].major
+      name: Images
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ClusterImageCatalog 는 cluster 전체에서 공유하는 PostgreSQL image catalog
+          다.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImageCatalogSpec 은 namespaced/cluster-wide catalog 가 공유하는
+              spec 이다.
+            properties:
+              images:
+                description: Images 는 PostgreSQL major version 별 image 목록이다.
+                items:
+                  description: ImageCatalogEntry 는 PostgreSQL major version 하나에 대응하는
+                    operand image 다.
+                  properties:
+                    extensions:
+                      description: |-
+                        Extensions 는 이 이미지와 함께 사용할 수 있는 extension image 후보 목록이다.
+                        0.3.0-alpha 에서는 저장/검증 표면만 제공하고, 실제 volume-extension mount 는
+                        후속 단계에서 연결한다.
+                      items:
+                        description: ImageCatalogExtension 은 catalog entry 에 연결된 extension
+                          image metadata 다.
+                        properties:
+                          image:
+                            description: Image 는 extension image reference 다.
+                            properties:
+                              reference:
+                                description: Reference 는 OCI image reference 다.
+                                minLength: 1
+                                type: string
+                            required:
+                            - reference
+                            type: object
+                          name:
+                            description: Name 은 extension 식별자다.
+                            minLength: 1
+                            type: string
+                        required:
+                        - image
+                        - name
+                        type: object
+                      type: array
+                    image:
+                      description: |-
+                        Image 는 해당 major 에 사용할 immutable image reference 다. production catalog 는
+                        digest pin 을 권장한다.
+                      minLength: 1
+                      type: string
+                    major:
+                      description: Major 는 PostgreSQL major version 이다. catalog 안에서
+                        유일해야 한다.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                  required:
+                  - image
+                  - major
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - major
+                x-kubernetes-list-type: map
+            required:
+            - images
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_imagecatalogs.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_imagecatalogs.yaml
@@ -1,0 +1,123 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  creationTimestamp: null
+  name: imagecatalogs.postgres.keiailab.io
+spec:
+  group: postgres.keiailab.io
+  names:
+    categories:
+    - postgres
+    - image
+    - all
+    kind: ImageCatalog
+    listKind: ImageCatalogList
+    plural: imagecatalogs
+    shortNames:
+    - pgic
+    singular: imagecatalog
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.images[*].major
+      name: Images
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ImageCatalog 는 namespace 단위 PostgreSQL image catalog 다.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ImageCatalogSpec 은 namespaced/cluster-wide catalog 가 공유하는
+              spec 이다.
+            properties:
+              images:
+                description: Images 는 PostgreSQL major version 별 image 목록이다.
+                items:
+                  description: ImageCatalogEntry 는 PostgreSQL major version 하나에 대응하는
+                    operand image 다.
+                  properties:
+                    extensions:
+                      description: |-
+                        Extensions 는 이 이미지와 함께 사용할 수 있는 extension image 후보 목록이다.
+                        0.3.0-alpha 에서는 저장/검증 표면만 제공하고, 실제 volume-extension mount 는
+                        후속 단계에서 연결한다.
+                      items:
+                        description: ImageCatalogExtension 은 catalog entry 에 연결된 extension
+                          image metadata 다.
+                        properties:
+                          image:
+                            description: Image 는 extension image reference 다.
+                            properties:
+                              reference:
+                                description: Reference 는 OCI image reference 다.
+                                minLength: 1
+                                type: string
+                            required:
+                            - reference
+                            type: object
+                          name:
+                            description: Name 은 extension 식별자다.
+                            minLength: 1
+                            type: string
+                        required:
+                        - image
+                        - name
+                        type: object
+                      type: array
+                    image:
+                      description: |-
+                        Image 는 해당 major 에 사용할 immutable image reference 다. production catalog 는
+                        digest pin 을 권장한다.
+                      minLength: 1
+                      type: string
+                    major:
+                      description: Major 는 PostgreSQL major version 이다. catalog 안에서
+                        유일해야 한다.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                  required:
+                  - image
+                  - major
+                  type: object
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - major
+                x-kubernetes-list-type: map
+            required:
+            - images
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_poolers.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_poolers.yaml
@@ -1,0 +1,9232 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  creationTimestamp: null
+  name: poolers.postgres.keiailab.io
+spec:
+  group: postgres.keiailab.io
+  names:
+    categories:
+    - postgres
+    - pooler
+    - all
+    kind: Pooler
+    listKind: PoolerList
+    plural: poolers
+    shortNames:
+    - pool
+    singular: pooler
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .spec.type
+      name: Type
+      type: string
+    - jsonPath: .spec.instances
+      name: Instances
+      type: integer
+    - jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Pooler 는 PgBouncer 기반 PostgreSQL connection pool 계층이다.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PoolerSpec 은 CNPG Pooler 의 핵심 운영 표면을 본 operator 모델로 이식한다.
+            properties:
+              cluster:
+                description: Cluster 는 PgBouncer 가 바라볼 PostgresCluster 이다.
+                properties:
+                  name:
+                    description: Name 은 PostgresCluster.metadata.name.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              deploymentStrategy:
+                description: DeploymentStrategy 는 PgBouncer Deployment 교체 전략이다. 빈
+                  값이면 zero-unavailable rolling update 를 사용한다.
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      Rolling update config params. Present only if DeploymentStrategyType =
+                      RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of pods that can be scheduled above the desired number of
+                          pods.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 25%.
+                          Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                          the rolling update starts, such that the total number of old and new pods do not exceed
+                          130% of desired pods. Once old pods have been killed,
+                          new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                          at any time during the update is at most 130% of desired pods.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          The maximum number of pods that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 25%.
+                          Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                          immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                          can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                          that the total number of pods available at all times during the update is at
+                          least 70% of desired pods.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: Type of deployment. Can be "Recreate" or "RollingUpdate".
+                      Default is RollingUpdate.
+                    type: string
+                type: object
+              instances:
+                default: 1
+                description: Instances 는 PgBouncer Pod 수다.
+                format: int32
+                minimum: 1
+                type: integer
+              paused:
+                default: false
+                description: |-
+                  Paused 는 PgBouncer PAUSE/RESUME 상태를 선언적으로 제어한다.
+                  true 로 바뀌면 operator 가 준비된 PgBouncer Pod 에 PAUSE 를 적용하고,
+                  false 로 돌아오면 RESUME 을 적용한다.
+                type: boolean
+              pgbouncer:
+                description: PgBouncer 는 PgBouncer 설정이다.
+                properties:
+                  authSecretRef:
+                    description: |-
+                      AuthSecretRef 는 userlist.txt 를 제공하는 Secret 이름이다.
+                      비어 있으면 operator 가 built-in auth path 를 활성화한다 — PostgresCluster
+                      의 ready primary Pod 에 `keiailab_pooler_pgbouncer` LOGIN role 을 random
+                      password 로 자동 생성하고, userlist.txt 를 담은 `<pooler-name>-builtin-auth`
+                      Secret 을 Pooler OwnerReference 와 함께 생성한다 (CNPG `cnpg_pooler_pgbouncer`
+                      패턴 호환). 사용자가 명시한 Secret 이 우선한다.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  autoTLS:
+                    description: |-
+                      AutoTLS 는 cert-manager 통합을 통해 server/client TLS Secret 을 자동 발급한다.
+                      본 표면이 설정되어 있고 ServerTLSSecret/ClientTLSSecret 이 비어 있으면
+                      operator 가 cert-manager Certificate CR 을 생성해 Secret 발급을 위임한다.
+                      CNPG 의 cert-manager 통합 패턴과 호환되는 표면 (T29).
+                    properties:
+                      clientEnabled:
+                        default: true
+                        description: ClientEnabled=true 이면 client (외부 application
+                          연결 수용) TLS Secret 을 자동 발급한다.
+                        type: boolean
+                      commonName:
+                        description: CommonName 은 발급될 Certificate 의 commonName 이다.
+                          빈 값이면 Pooler Service DNS 를 사용한다.
+                        type: string
+                      dnsNames:
+                        description: |-
+                          DNSNames 는 발급될 Certificate 의 추가 SANs 이다. 기본값은 Pooler Service 의
+                          `<pooler>.<ns>.svc` 와 `<pooler>.<ns>.svc.cluster.local` 이며, 사용자 지정 항목이 있으면
+                          기본값에 union 된다.
+                        items:
+                          type: string
+                        type: array
+                      issuerRef:
+                        description: IssuerRef 는 cert-manager Issuer 또는 ClusterIssuer
+                          참조다.
+                        properties:
+                          kind:
+                            default: Issuer
+                            description: Kind 는 `Issuer` (namespace-scoped) 또는 `ClusterIssuer`
+                              (cluster-scoped) 중 하나다.
+                            enum:
+                            - Issuer
+                            - ClusterIssuer
+                            type: string
+                          name:
+                            description: Name 은 cert-manager Issuer/ClusterIssuer
+                              이름이다.
+                            minLength: 1
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      serverEnabled:
+                        default: false
+                        description: ServerEnabled=true 이면 server (PostgreSQL backend
+                          연결용) TLS Secret 을 자동 발급한다.
+                        type: boolean
+                    required:
+                    - issuerRef
+                    type: object
+                  clientCASecret:
+                    description: ClientCASecret 은 클라이언트 인증서를 검증할 ca.crt Secret 이다.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  clientTLSSecret:
+                    description: ClientTLSSecret 은 클라이언트 TLS 연결을 받을 때 사용할 tls.crt/tls.key
+                      Secret 이다.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  exporter:
+                    description: Exporter 는 PgBouncer Prometheus exporter sidecar
+                      설정이다.
+                    properties:
+                      args:
+                        description: Args 는 exporter 컨테이너 args override 다.
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: Env 는 exporter 컨테이너 환경 변수다.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image 는 exporter 컨테이너 이미지다.
+                        minLength: 1
+                        type: string
+                      port:
+                        default: 9127
+                        description: Port 는 exporter HTTP metrics port 다. 빈 값이면 9127.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      resources:
+                        description: Resources 는 exporter 컨테이너 리소스 요청/제한이다.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    required:
+                    - image
+                    type: object
+                  image:
+                    description: Image 는 PgBouncer 컨테이너 이미지다. PgBouncer 1.19+ 를 요구한다.
+                    minLength: 1
+                    type: string
+                  parameters:
+                    additionalProperties:
+                      type: string
+                    description: Parameters 는 pgbouncer.ini [pgbouncer] 섹션에 병합할 자유형식
+                      설정이다.
+                    type: object
+                  pg_hba:
+                    description: PgHBA 는 PgBouncer HBA 파일에 기록할 접근 제어 규칙이다.
+                    items:
+                      type: string
+                    type: array
+                  poolMode:
+                    default: session
+                    description: PoolMode 는 PgBouncer pool_mode 값이다.
+                    enum:
+                    - session
+                    - transaction
+                    - statement
+                    type: string
+                  serverCASecret:
+                    description: ServerCASecret 은 PostgreSQL 서버 인증서를 검증할 ca.crt Secret
+                      이다.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  serverTLSSecret:
+                    description: ServerTLSSecret 은 PostgreSQL 서버에 mTLS 로 접속할 때 사용할
+                      tls.crt/tls.key Secret 이다.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - image
+                type: object
+              serviceAccountName:
+                description: ServiceAccountName 은 Pooler Pod 가 사용할 기존 ServiceAccount
+                  이름이다.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                type: string
+              serviceTemplate:
+                description: ServiceTemplate 은 PgBouncer Service override 다.
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations 는 Service metadata.annotations 에 추가된다.
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels 는 Service metadata.labels 에 추가된다.
+                    type: object
+                  ports:
+                    description: |-
+                      Ports 는 Service 에 추가할 포트 목록이다. pgbouncer 기본 포트와 name 또는 port 가
+                      충돌하면 사용자가 지정한 포트를 우선한다.
+                    items:
+                      description: ServicePort contains information on service's port.
+                      properties:
+                        appProtocol:
+                          description: |-
+                            The application protocol for this port.
+                            This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                            This field follows standard Kubernetes label syntax.
+                            Valid values are either:
+
+                            * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                            RFC-6335 and https://www.iana.org/assignments/service-names).
+
+                            * Kubernetes-defined prefixed names:
+                              * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                              * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                              * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+
+                            * Other protocols should use implementation-defined prefixed names such as
+                            mycompany.com/my-custom-protocol.
+                          type: string
+                        name:
+                          description: |-
+                            The name of this port within the service. This must be a DNS_LABEL.
+                            All ports within a ServiceSpec must have unique names. When considering
+                            the endpoints for a Service, this must match the 'name' field in the
+                            EndpointPort.
+                            Optional if only one ServicePort is defined on this service.
+                          type: string
+                        nodePort:
+                          description: |-
+                            The port on each node on which this service is exposed when type is
+                            NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                            specified, in-range, and not in use it will be used, otherwise the
+                            operation will fail.  If not specified, a port will be allocated if this
+                            Service requires one.  If this field is specified when creating a
+                            Service which does not need it, creation will fail. This field will be
+                            wiped when updating a Service to no longer need it (e.g. changing type
+                            from NodePort to ClusterIP).
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+                          format: int32
+                          type: integer
+                        port:
+                          description: The port that will be exposed by this service.
+                          format: int32
+                          type: integer
+                        protocol:
+                          default: TCP
+                          description: |-
+                            The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                            Default is TCP.
+                          type: string
+                        targetPort:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            Number or name of the port to access on the pods targeted by the service.
+                            Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                            If this is a string, it will be looked up as a named port in the
+                            target Pod's container ports. If this is not specified, the value
+                            of the 'port' field is used (an identity map).
+                            This field is ignored for services with clusterIP=None, and should be
+                            omitted or set equal to the 'port' field.
+                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+                          x-kubernetes-int-or-string: true
+                      required:
+                      - port
+                      type: object
+                    type: array
+                  type:
+                    description: Type 은 Service type 이다. 빈 값이면 ClusterIP.
+                    type: string
+                type: object
+              template:
+                description: Template 은 PgBouncer Pod template override 다.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the pod.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      activeDeadlineSeconds:
+                        description: |-
+                          Optional duration in seconds the pod may be active on the node relative to
+                          StartTime before the system will actively try to mark it failed and kill associated containers.
+                          Value must be a positive integer.
+                        format: int64
+                        type: integer
+                      affinity:
+                        description: If specified, the pod's scheduling constraints
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and subtracting
+                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      automountServiceAccountToken:
+                        description: AutomountServiceAccountToken indicates whether
+                          a service account token should be automatically mounted.
+                        type: boolean
+                      containers:
+                        description: |-
+                          List of containers belonging to the pod.
+                          Containers cannot currently be added or removed.
+                          There must be at least one container in a Pod.
+                          Cannot be updated.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: |-
+                                Arguments to the entrypoint.
+                                The container image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The container image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable.
+                                      May consist of any printable ASCII characters except '='.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        description: |-
+                                          FileKeyRef selects a key of the env file.
+                                          Requires the EnvFiles feature gate to be enabled.
+                                        properties:
+                                          key:
+                                            description: |-
+                                              The key within the env file. An invalid key will prevent the pod from starting.
+                                              The keys defined within a source may consist of any printable ASCII characters except '='.
+                                              During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                            type: string
+                                          optional:
+                                            default: false
+                                            description: |-
+                                              Specify whether the file or its key must be defined. If the file or key
+                                              does not exist, then the env var is not published.
+                                              If optional is set to true and the specified key does not exist,
+                                              the environment variable will not be set in the Pod's containers.
+
+                                              If optional is set to false and the specified key does not exist,
+                                              an error will be returned during Pod creation.
+                                            type: boolean
+                                          path:
+                                            description: |-
+                                              The path within the volume from which to select the file.
+                                              Must be relative and may not contain the '..' path or start with '..'.
+                                            type: string
+                                          volumeName:
+                                            description: The name of the volume mount
+                                              containing the env file.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps or Secrets
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  prefix:
+                                    description: |-
+                                      Optional text to prepend to the name of each environment variable.
+                                      May consist of any printable ASCII characters except '='.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            image:
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                              type: string
+                            lifecycle:
+                              description: |-
+                                Actions that the management system should take in response to container lifecycle events.
+                                Cannot be updated.
+                              properties:
+                                postStart:
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
+                                    tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
+                                    tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                stopSignal:
+                                  description: |-
+                                    StopSignal defines which signal will be sent to a container when it is being stopped.
+                                    If not specified, the default is defined by the container runtime in use.
+                                    StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                  type: string
+                              type: object
+                            livenessProbe:
+                              description: |-
+                                Periodic probe of container liveness.
+                                Container will be restarted if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: |-
+                                Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: |-
+                                List of ports to expose from the container. Not specifying a port here
+                                DOES NOT prevent that port from being exposed. Any port which is
+                                listening on the default "0.0.0.0" address inside a container will be
+                                accessible from the network.
+                                Modifying this array with strategic merge patch may corrupt the data.
+                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: |-
+                                Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resizePolicy:
+                              description: |-
+                                Resources resize policy for the container.
+                                This field cannot be set on ephemeral containers.
+                              items:
+                                description: ContainerResizePolicy represents resource
+                                  resize policy for the container.
+                                properties:
+                                  resourceName:
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
+                                    type: string
+                                  restartPolicy:
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            resources:
+                              description: |-
+                                Compute Resources required by this container.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This field depends on the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry
+                                      in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            restartPolicy:
+                              description: |-
+                                RestartPolicy defines the restart behavior of individual containers in a pod.
+                                This overrides the pod-level restart policy. When this field is not specified,
+                                the restart behavior is defined by the Pod's restart policy and the container type.
+                                Additionally, setting the RestartPolicy as "Always" for the init container will
+                                have the following effect:
+                                this init container will be continually restarted on
+                                exit until all regular containers have terminated. Once all regular
+                                containers have completed, all init containers with restartPolicy "Always"
+                                will be shut down. This lifecycle differs from normal init containers and
+                                is often referred to as a "sidecar" container. Although this init
+                                container still starts in the init container sequence, it does not wait
+                                for the container to complete before proceeding to the next init
+                                container. Instead, the next init container starts immediately after this
+                                init container is started, or after any startupProbe has successfully
+                                completed.
+                              type: string
+                            restartPolicyRules:
+                              description: |-
+                                Represents a list of rules to be checked to determine if the
+                                container should be restarted on exit. The rules are evaluated in
+                                order. Once a rule matches a container exit condition, the remaining
+                                rules are ignored. If no rule matches the container exit condition,
+                                the Container-level restart policy determines the whether the container
+                                is restarted or not. Constraints on the rules:
+                                - At most 20 rules are allowed.
+                                - Rules can have the same action.
+                                - Identical rules are not forbidden in validations.
+                                When rules are specified, container MUST set RestartPolicy explicitly
+                                even it if matches the Pod's RestartPolicy.
+                              items:
+                                description: ContainerRestartRule describes how a
+                                  container exit is handled.
+                                properties:
+                                  action:
+                                    description: |-
+                                      Specifies the action taken on a container exit if the requirements
+                                      are satisfied. The only possible value is "Restart" to restart the
+                                      container.
+                                    type: string
+                                  exitCodes:
+                                    description: Represents the exit codes to check
+                                      on container exits.
+                                    properties:
+                                      operator:
+                                        description: |-
+                                          Represents the relationship between the container exit code(s) and the
+                                          specified values. Possible values are:
+                                          - In: the requirement is satisfied if the container exit code is in the
+                                            set of specified values.
+                                          - NotIn: the requirement is satisfied if the container exit code is
+                                            not in the set of specified values.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          Specifies the set of values to check for container exit codes.
+                                          At most 255 elements are allowed.
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            securityContext:
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                    overrides the pod's appArmorProfile.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                capabilities:
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                procMount:
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default value is Default which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: |-
+                                StartupProbe indicates that the Pod has successfully initialized.
+                                If specified, no other probes are executed until this completes successfully.
+                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                This cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
+                              type: string
+                            tty:
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: |-
+                                Pod volumes to mount into the container's filesystem.
+                                Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
+                                  subPath:
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      dnsConfig:
+                        description: |-
+                          Specifies the DNS parameters of a pod.
+                          Parameters specified here will be merged to the generated DNS
+                          configuration based on DNSPolicy.
+                        properties:
+                          nameservers:
+                            description: |-
+                              A list of DNS name server IP addresses.
+                              This will be appended to the base nameservers generated from DNSPolicy.
+                              Duplicated nameservers will be removed.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          options:
+                            description: |-
+                              A list of DNS resolver options.
+                              This will be merged with the base options generated from DNSPolicy.
+                              Duplicated entries will be removed. Resolution options given in Options
+                              will override those that appear in the base DNSPolicy.
+                            items:
+                              description: PodDNSConfigOption defines DNS resolver
+                                options of a pod.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is this DNS resolver option's name.
+                                    Required.
+                                  type: string
+                                value:
+                                  description: Value is this DNS resolver option's
+                                    value.
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          searches:
+                            description: |-
+                              A list of DNS search domains for host-name lookup.
+                              This will be appended to the base search paths generated from DNSPolicy.
+                              Duplicated search paths will be removed.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      dnsPolicy:
+                        description: |-
+                          Set DNS policy for the pod.
+                          Defaults to "ClusterFirst".
+                          Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                          DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                          To have DNS options set along with hostNetwork, you have to specify DNS policy
+                          explicitly to 'ClusterFirstWithHostNet'.
+                        type: string
+                      enableServiceLinks:
+                        description: |-
+                          EnableServiceLinks indicates whether information about services should be injected into pod's
+                          environment variables, matching the syntax of Docker links.
+                          Optional: Defaults to true.
+                        type: boolean
+                      ephemeralContainers:
+                        description: |-
+                          List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                          pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                          creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                          ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
+                        items:
+                          description: |-
+                            An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                            user-initiated activities such as debugging. Ephemeral containers have no resource or
+                            scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                            removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                            Pod to exceed its resource allocation.
+
+                            To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+                            Pod. Ephemeral containers may not be removed or restarted.
+                          properties:
+                            args:
+                              description: |-
+                                Arguments to the entrypoint.
+                                The image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable.
+                                      May consist of any printable ASCII characters except '='.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        description: |-
+                                          FileKeyRef selects a key of the env file.
+                                          Requires the EnvFiles feature gate to be enabled.
+                                        properties:
+                                          key:
+                                            description: |-
+                                              The key within the env file. An invalid key will prevent the pod from starting.
+                                              The keys defined within a source may consist of any printable ASCII characters except '='.
+                                              During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                            type: string
+                                          optional:
+                                            default: false
+                                            description: |-
+                                              Specify whether the file or its key must be defined. If the file or key
+                                              does not exist, then the env var is not published.
+                                              If optional is set to true and the specified key does not exist,
+                                              the environment variable will not be set in the Pod's containers.
+
+                                              If optional is set to false and the specified key does not exist,
+                                              an error will be returned during Pod creation.
+                                            type: boolean
+                                          path:
+                                            description: |-
+                                              The path within the volume from which to select the file.
+                                              Must be relative and may not contain the '..' path or start with '..'.
+                                            type: string
+                                          volumeName:
+                                            description: The name of the volume mount
+                                              containing the env file.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps or Secrets
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  prefix:
+                                    description: |-
+                                      Optional text to prepend to the name of each environment variable.
+                                      May consist of any printable ASCII characters except '='.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            image:
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                              type: string
+                            lifecycle:
+                              description: Lifecycle is not allowed for ephemeral
+                                containers.
+                              properties:
+                                postStart:
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
+                                    tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
+                                    tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                stopSignal:
+                                  description: |-
+                                    StopSignal defines which signal will be sent to a container when it is being stopped.
+                                    If not specified, the default is defined by the container runtime in use.
+                                    StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                  type: string
+                              type: object
+                            livenessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: |-
+                                Name of the ephemeral container specified as a DNS_LABEL.
+                                This name must be unique among all containers, init containers and ephemeral containers.
+                              type: string
+                            ports:
+                              description: Ports are not allowed for ephemeral containers.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resizePolicy:
+                              description: Resources resize policy for the container.
+                              items:
+                                description: ContainerResizePolicy represents resource
+                                  resize policy for the container.
+                                properties:
+                                  resourceName:
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
+                                    type: string
+                                  restartPolicy:
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            resources:
+                              description: |-
+                                Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
+                                already allocated to the pod.
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This field depends on the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry
+                                      in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            restartPolicy:
+                              description: |-
+                                Restart policy for the container to manage the restart behavior of each
+                                container within a pod.
+                                You cannot set this field on ephemeral containers.
+                              type: string
+                            restartPolicyRules:
+                              description: |-
+                                Represents a list of rules to be checked to determine if the
+                                container should be restarted on exit. You cannot set this field on
+                                ephemeral containers.
+                              items:
+                                description: ContainerRestartRule describes how a
+                                  container exit is handled.
+                                properties:
+                                  action:
+                                    description: |-
+                                      Specifies the action taken on a container exit if the requirements
+                                      are satisfied. The only possible value is "Restart" to restart the
+                                      container.
+                                    type: string
+                                  exitCodes:
+                                    description: Represents the exit codes to check
+                                      on container exits.
+                                    properties:
+                                      operator:
+                                        description: |-
+                                          Represents the relationship between the container exit code(s) and the
+                                          specified values. Possible values are:
+                                          - In: the requirement is satisfied if the container exit code is in the
+                                            set of specified values.
+                                          - NotIn: the requirement is satisfied if the container exit code is
+                                            not in the set of specified values.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          Specifies the set of values to check for container exit codes.
+                                          At most 255 elements are allowed.
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            securityContext:
+                              description: |-
+                                Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                    overrides the pod's appArmorProfile.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                capabilities:
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                procMount:
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default value is Default which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: Probes are not allowed for ephemeral containers.
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
+                              type: boolean
+                            targetContainerName:
+                              description: |-
+                                If set, the name of the container from PodSpec that this ephemeral container targets.
+                                The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                                The container runtime must implement support for this feature. If the runtime does not
+                                support namespace targeting then the result of setting this field is undefined.
+                              type: string
+                            terminationMessagePath:
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
+                              type: string
+                            tty:
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: |-
+                                Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
+                                  subPath:
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      hostAliases:
+                        description: |-
+                          HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                          file if specified.
+                        items:
+                          description: |-
+                            HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                            pod's hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          required:
+                          - ip
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - ip
+                        x-kubernetes-list-type: map
+                      hostIPC:
+                        description: |-
+                          Use the host's ipc namespace.
+                          Optional: Default to false.
+                        type: boolean
+                      hostNetwork:
+                        description: |-
+                          Host networking requested for this pod. Use the host's network namespace.
+                          When using HostNetwork you should specify ports so the scheduler is aware.
+                          When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`,
+                          and unspecified `hostPort` fields in port definitions are defaulted to match `containerPort`.
+                          Default to false.
+                        type: boolean
+                      hostPID:
+                        description: |-
+                          Use the host's pid namespace.
+                          Optional: Default to false.
+                        type: boolean
+                      hostUsers:
+                        description: |-
+                          Use the host's user namespace.
+                          Optional: Default to true.
+                          If set to true or not present, the pod will be run in the host user namespace, useful
+                          for when the pod needs a feature only available to the host user namespace, such as
+                          loading a kernel module with CAP_SYS_MODULE.
+                          When set to false, a new userns is created for the pod. Setting false is useful for
+                          mitigating container breakout vulnerabilities even allowing users to run their
+                          containers as root without actually having root privileges on the host.
+                          This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
+                        type: boolean
+                      hostname:
+                        description: |-
+                          Specifies the hostname of the Pod
+                          If not specified, the pod's hostname will be set to a system-defined value.
+                        type: string
+                      hostnameOverride:
+                        description: |-
+                          HostnameOverride specifies an explicit override for the pod's hostname as perceived by the pod.
+                          This field only specifies the pod's hostname and does not affect its DNS records.
+                          When this field is set to a non-empty string:
+                          - It takes precedence over the values set in `hostname` and `subdomain`.
+                          - The Pod's hostname will be set to this value.
+                          - `setHostnameAsFQDN` must be nil or set to false.
+                          - `hostNetwork` must be set to false.
+
+                          This field must be a valid DNS subdomain as defined in RFC 1123 and contain at most 64 characters.
+                          Requires the HostnameOverride feature gate to be enabled.
+                        type: string
+                      imagePullSecrets:
+                        description: |-
+                          ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                          If specified, these secrets will be passed to individual puller implementations for them to use.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                        items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      initContainers:
+                        description: |-
+                          List of initialization containers belonging to the pod.
+                          Init containers are executed in order prior to containers being started. If any
+                          init container fails, the pod is considered to have failed and is handled according
+                          to its restartPolicy. The name for an init container or normal container must be
+                          unique among all containers.
+                          Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                          The resourceRequirements of an init container are taken into account during scheduling
+                          by finding the highest request/limit for each resource type, and then using the max of
+                          that value or the sum of the normal containers. Limits are applied to init containers
+                          in a similar fashion.
+                          Init containers cannot currently be added or removed.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                        items:
+                          description: A single application container that you want
+                            to run within a pod.
+                          properties:
+                            args:
+                              description: |-
+                                Arguments to the entrypoint.
+                                The container image's CMD is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            command:
+                              description: |-
+                                Entrypoint array. Not executed within a shell.
+                                The container image's ENTRYPOINT is used if this is not provided.
+                                Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Cannot be updated.
+                                More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            env:
+                              description: |-
+                                List of environment variables to set in the container.
+                                Cannot be updated.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the environment variable.
+                                      May consist of any printable ASCII characters except '='.
+                                    type: string
+                                  value:
+                                    description: |-
+                                      Variable references $(VAR_NAME) are expanded
+                                      using the previously defined environment variables in the container and
+                                      any service environment variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                      "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                      Escaped references will never be expanded, regardless of whether the variable
+                                      exists or not.
+                                      Defaults to "".
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fieldRef:
+                                        description: |-
+                                          Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                          spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        description: |-
+                                          FileKeyRef selects a key of the env file.
+                                          Requires the EnvFiles feature gate to be enabled.
+                                        properties:
+                                          key:
+                                            description: |-
+                                              The key within the env file. An invalid key will prevent the pod from starting.
+                                              The keys defined within a source may consist of any printable ASCII characters except '='.
+                                              During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                            type: string
+                                          optional:
+                                            default: false
+                                            description: |-
+                                              Specify whether the file or its key must be defined. If the file or key
+                                              does not exist, then the env var is not published.
+                                              If optional is set to true and the specified key does not exist,
+                                              the environment variable will not be set in the Pod's containers.
+
+                                              If optional is set to false and the specified key does not exist,
+                                              an error will be returned during Pod creation.
+                                            type: boolean
+                                          path:
+                                            description: |-
+                                              The path within the volume from which to select the file.
+                                              Must be relative and may not contain the '..' path or start with '..'.
+                                            type: string
+                                          volumeName:
+                                            description: The name of the volume mount
+                                              containing the env file.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in
+                                          the pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to
+                                              select from.  Must be a valid secret
+                                              key.
+                                            type: string
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                        - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            envFrom:
+                              description: |-
+                                List of sources to populate environment variables in the container.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                When a key exists in multiple
+                                sources, the value associated with the last source will take precedence.
+                                Values defined by an Env with a duplicate key will take precedence.
+                                Cannot be updated.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps or Secrets
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap
+                                          must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  prefix:
+                                    description: |-
+                                      Optional text to prepend to the name of each environment variable.
+                                      May consist of any printable ASCII characters except '='.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            image:
+                              description: |-
+                                Container image name.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
+                              type: string
+                            imagePullPolicy:
+                              description: |-
+                                Image pull policy.
+                                One of Always, Never, IfNotPresent.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                              type: string
+                            lifecycle:
+                              description: |-
+                                Actions that the management system should take in response to container lifecycle events.
+                                Cannot be updated.
+                              properties:
+                                postStart:
+                                  description: |-
+                                    PostStart is called immediately after a container is created. If the handler fails,
+                                    the container is terminated and restarted according to its restart policy.
+                                    Other management of the container blocks until the hook completes.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
+                                    tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                preStop:
+                                  description: |-
+                                    PreStop is called immediately before a container is terminated due to an
+                                    API request or management event such as liveness/startup probe failure,
+                                    preemption, resource contention, etc. The handler is not called if the
+                                    container crashes or exits. The Pod's termination grace period countdown begins before the
+                                    PreStop hook is executed. Regardless of the outcome of the handler, the
+                                    container will eventually terminate within the Pod's termination grace
+                                    period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                    or until the termination grace period is reached.
+                                    More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute
+                                        in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request
+                                        to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the
+                                            request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom
+                                              header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP
+                                            server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    sleep:
+                                      description: Sleep represents a duration that
+                                        the container should sleep.
+                                      properties:
+                                        seconds:
+                                          description: Seconds is the number of seconds
+                                            to sleep.
+                                          format: int64
+                                          type: integer
+                                      required:
+                                      - seconds
+                                      type: object
+                                    tcpSocket:
+                                      description: |-
+                                        Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                        for backward compatibility. There is no validation of this field and
+                                        lifecycle hooks will fail at runtime when it is specified.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect
+                                            to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                  type: object
+                                stopSignal:
+                                  description: |-
+                                    StopSignal defines which signal will be sent to a container when it is being stopped.
+                                    If not specified, the default is defined by the container runtime in use.
+                                    StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                  type: string
+                              type: object
+                            livenessProbe:
+                              description: |-
+                                Periodic probe of container liveness.
+                                Container will be restarted if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: |-
+                                Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                                Cannot be updated.
+                              type: string
+                            ports:
+                              description: |-
+                                List of ports to expose from the container. Not specifying a port here
+                                DOES NOT prevent that port from being exposed. Any port which is
+                                listening on the default "0.0.0.0" address inside a container will be
+                                accessible from the network.
+                                Modifying this array with strategic merge patch may corrupt the data.
+                                For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                Cannot be updated.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: |-
+                                      Number of port to expose on the pod's IP address.
+                                      This must be a valid port number, 0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external
+                                      port to.
+                                    type: string
+                                  hostPort:
+                                    description: |-
+                                      Number of port to expose on the host.
+                                      If specified, this must be a valid port number, 0 < x < 65536.
+                                      If HostNetwork is specified, this must match ContainerPort.
+                                      Most containers do not need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: |-
+                                      If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                      named port in a pod must have a unique name. Name for the port that can be
+                                      referred to by services.
+                                    type: string
+                                  protocol:
+                                    default: TCP
+                                    description: |-
+                                      Protocol for port. Must be UDP, TCP, or SCTP.
+                                      Defaults to "TCP".
+                                    type: string
+                                required:
+                                - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - containerPort
+                              - protocol
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: |-
+                                Periodic probe of container service readiness.
+                                Container will be removed from service endpoints if the probe fails.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resizePolicy:
+                              description: |-
+                                Resources resize policy for the container.
+                                This field cannot be set on ephemeral containers.
+                              items:
+                                description: ContainerResizePolicy represents resource
+                                  resize policy for the container.
+                                properties:
+                                  resourceName:
+                                    description: |-
+                                      Name of the resource to which this resource resize policy applies.
+                                      Supported values: cpu, memory.
+                                    type: string
+                                  restartPolicy:
+                                    description: |-
+                                      Restart policy to apply when specified resource is resized.
+                                      If not specified, it defaults to NotRequired.
+                                    type: string
+                                required:
+                                - resourceName
+                                - restartPolicy
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            resources:
+                              description: |-
+                                Compute Resources required by this container.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This field depends on the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry
+                                      in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            restartPolicy:
+                              description: |-
+                                RestartPolicy defines the restart behavior of individual containers in a pod.
+                                This overrides the pod-level restart policy. When this field is not specified,
+                                the restart behavior is defined by the Pod's restart policy and the container type.
+                                Additionally, setting the RestartPolicy as "Always" for the init container will
+                                have the following effect:
+                                this init container will be continually restarted on
+                                exit until all regular containers have terminated. Once all regular
+                                containers have completed, all init containers with restartPolicy "Always"
+                                will be shut down. This lifecycle differs from normal init containers and
+                                is often referred to as a "sidecar" container. Although this init
+                                container still starts in the init container sequence, it does not wait
+                                for the container to complete before proceeding to the next init
+                                container. Instead, the next init container starts immediately after this
+                                init container is started, or after any startupProbe has successfully
+                                completed.
+                              type: string
+                            restartPolicyRules:
+                              description: |-
+                                Represents a list of rules to be checked to determine if the
+                                container should be restarted on exit. The rules are evaluated in
+                                order. Once a rule matches a container exit condition, the remaining
+                                rules are ignored. If no rule matches the container exit condition,
+                                the Container-level restart policy determines the whether the container
+                                is restarted or not. Constraints on the rules:
+                                - At most 20 rules are allowed.
+                                - Rules can have the same action.
+                                - Identical rules are not forbidden in validations.
+                                When rules are specified, container MUST set RestartPolicy explicitly
+                                even it if matches the Pod's RestartPolicy.
+                              items:
+                                description: ContainerRestartRule describes how a
+                                  container exit is handled.
+                                properties:
+                                  action:
+                                    description: |-
+                                      Specifies the action taken on a container exit if the requirements
+                                      are satisfied. The only possible value is "Restart" to restart the
+                                      container.
+                                    type: string
+                                  exitCodes:
+                                    description: Represents the exit codes to check
+                                      on container exits.
+                                    properties:
+                                      operator:
+                                        description: |-
+                                          Represents the relationship between the container exit code(s) and the
+                                          specified values. Possible values are:
+                                          - In: the requirement is satisfied if the container exit code is in the
+                                            set of specified values.
+                                          - NotIn: the requirement is satisfied if the container exit code is
+                                            not in the set of specified values.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          Specifies the set of values to check for container exit codes.
+                                          At most 255 elements are allowed.
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            securityContext:
+                              description: |-
+                                SecurityContext defines the security options the container should be run with.
+                                If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                              properties:
+                                allowPrivilegeEscalation:
+                                  description: |-
+                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                    privileges than its parent process. This bool directly controls if
+                                    the no_new_privs flag will be set on the container process.
+                                    AllowPrivilegeEscalation is true always when the container is:
+                                    1) run as Privileged
+                                    2) has CAP_SYS_ADMIN
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                    overrides the pod's appArmorProfile.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                capabilities:
+                                  description: |-
+                                    The capabilities to add/drop when running containers.
+                                    Defaults to the default set of capabilities granted by the container runtime.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    add:
+                                      description: Added capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    drop:
+                                      description: Removed capabilities
+                                      items:
+                                        description: Capability represent POSIX capabilities
+                                          type
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                privileged:
+                                  description: |-
+                                    Run container in privileged mode.
+                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                    Defaults to false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                procMount:
+                                  description: |-
+                                    procMount denotes the type of proc mount to use for the containers.
+                                    The default value is Default which uses the container runtime defaults for
+                                    readonly paths and masked paths.
+                                    This requires the ProcMountType feature flag to be enabled.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: string
+                                readOnlyRootFilesystem:
+                                  description: |-
+                                    Whether this container has a read-only root filesystem.
+                                    Default is false.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: boolean
+                                runAsGroup:
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: |-
+                                    The SELinux context to be applied to the container.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: |-
+                                    The seccomp options to use by this container. If seccomp options are
+                                    provided at both the pod & container level, the container options
+                                    override the pod options.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                windowsOptions:
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options from the PodSecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: |-
+                                StartupProbe indicates that the Pod has successfully initialized.
+                                If specified, no other probes are executed until this completes successfully.
+                                If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                This cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute
+                                    in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                failureThreshold:
+                                  description: |-
+                                    Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                grpc:
+                                  description: GRPC specifies a GRPC HealthCheckRequest.
+                                  properties:
+                                    port:
+                                      description: Port number of the gRPC service.
+                                        Number must be in the range 1 to 65535.
+                                      format: int32
+                                      type: integer
+                                    service:
+                                      default: ""
+                                      description: |-
+                                        Service is the name of the service to place in the gRPC HealthCheckRequest
+                                        (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                        If this is not specified, the default behavior is defined by gRPC.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request
+                                    to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom
+                                          header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: |-
+                                    Number of seconds after the container has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: |-
+                                    How often (in seconds) to perform the probe.
+                                    Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: |-
+                                    Minimum consecutive successes for the probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: TCPSocket specifies a connection to
+                                    a TCP port.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                                terminationGracePeriodSeconds:
+                                  description: |-
+                                    Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                    The grace period is the duration in seconds after the processes running in the pod are sent
+                                    a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                    Set this value longer than the expected cleanup time for your process.
+                                    If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                    value overrides the value provided by the pod spec.
+                                    Value must be non-negative integer. The value zero indicates stop immediately via
+                                    the kill signal (no opportunity to shut down).
+                                    This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                    Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                  format: int64
+                                  type: integer
+                                timeoutSeconds:
+                                  description: |-
+                                    Number of seconds after which the probe times out.
+                                    Defaults to 1 second. Minimum value is 1.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  format: int32
+                                  type: integer
+                              type: object
+                            stdin:
+                              description: |-
+                                Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                is not set, reads from stdin in the container will always result in EOF.
+                                Default is false.
+                              type: boolean
+                            stdinOnce:
+                              description: |-
+                                Whether the container runtime should close the stdin channel after it has been opened by
+                                a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                at which time stdin is closed and remains closed until the container is restarted. If this
+                                flag is false, a container processes that reads from stdin will never receive an EOF.
+                                Default is false
+                              type: boolean
+                            terminationMessagePath:
+                              description: |-
+                                Optional: Path at which the file to which the container's termination message
+                                will be written is mounted into the container's filesystem.
+                                Message written is intended to be brief final status, such as an assertion failure message.
+                                Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                all containers will be limited to 12kb.
+                                Defaults to /dev/termination-log.
+                                Cannot be updated.
+                              type: string
+                            terminationMessagePolicy:
+                              description: |-
+                                Indicate how the termination message should be populated. File will use the contents of
+                                terminationMessagePath to populate the container status message on both success and failure.
+                                FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                message file is empty and the container exited with an error.
+                                The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                Defaults to File.
+                                Cannot be updated.
+                              type: string
+                            tty:
+                              description: |-
+                                Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                Default is false.
+                              type: boolean
+                            volumeDevices:
+                              description: volumeDevices is the list of block devices
+                                to be used by the container.
+                              items:
+                                description: volumeDevice describes a mapping of a
+                                  raw block device within a container.
+                                properties:
+                                  devicePath:
+                                    description: devicePath is the path inside of
+                                      the container that the device will be mapped
+                                      to.
+                                    type: string
+                                  name:
+                                    description: name must match the name of a persistentVolumeClaim
+                                      in the pod
+                                    type: string
+                                required:
+                                - devicePath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - devicePath
+                              x-kubernetes-list-type: map
+                            volumeMounts:
+                              description: |-
+                                Pod volumes to mount into the container's filesystem.
+                                Cannot be updated.
+                              items:
+                                description: VolumeMount describes a mounting of a
+                                  Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
+                                  subPath:
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
+                                    type: string
+                                required:
+                                - mountPath
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - mountPath
+                              x-kubernetes-list-type: map
+                            workingDir:
+                              description: |-
+                                Container's working directory.
+                                If not specified, the container runtime's default will be used, which
+                                might be configured in the container image.
+                                Cannot be updated.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      nodeName:
+                        description: |-
+                          NodeName indicates in which node this pod is scheduled.
+                          If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.
+                          Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.
+                          This field should not be used to express a desire for the pod to be scheduled on a specific node.
+                          https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
+                        type: string
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          NodeSelector is a selector which must be true for the pod to fit on a node.
+                          Selector which must match a node's labels for the pod to be scheduled on that node.
+                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      os:
+                        description: |-
+                          Specifies the OS of the containers in the pod.
+                          Some pod and container fields are restricted if this is set.
+
+                          If the OS field is set to linux, the following fields must be unset:
+                          -securityContext.windowsOptions
+
+                          If the OS field is set to windows, following fields must be unset:
+                          - spec.hostPID
+                          - spec.hostIPC
+                          - spec.hostUsers
+                          - spec.resources
+                          - spec.securityContext.appArmorProfile
+                          - spec.securityContext.seLinuxOptions
+                          - spec.securityContext.seccompProfile
+                          - spec.securityContext.fsGroup
+                          - spec.securityContext.fsGroupChangePolicy
+                          - spec.securityContext.sysctls
+                          - spec.shareProcessNamespace
+                          - spec.securityContext.runAsUser
+                          - spec.securityContext.runAsGroup
+                          - spec.securityContext.supplementalGroups
+                          - spec.securityContext.supplementalGroupsPolicy
+                          - spec.containers[*].securityContext.appArmorProfile
+                          - spec.containers[*].securityContext.seLinuxOptions
+                          - spec.containers[*].securityContext.seccompProfile
+                          - spec.containers[*].securityContext.capabilities
+                          - spec.containers[*].securityContext.readOnlyRootFilesystem
+                          - spec.containers[*].securityContext.privileged
+                          - spec.containers[*].securityContext.allowPrivilegeEscalation
+                          - spec.containers[*].securityContext.procMount
+                          - spec.containers[*].securityContext.runAsUser
+                          - spec.containers[*].securityContext.runAsGroup
+                        properties:
+                          name:
+                            description: |-
+                              Name is the name of the operating system. The currently supported values are linux and windows.
+                              Additional value may be defined in future and can be one of:
+                              https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                              Clients should expect to handle additional values and treat unrecognized values in this field as os: null
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      overhead:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                          This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                          the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                          The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                          set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                          defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+                        type: object
+                      preemptionPolicy:
+                        description: |-
+                          PreemptionPolicy is the Policy for preempting pods with lower priority.
+                          One of Never, PreemptLowerPriority.
+                          Defaults to PreemptLowerPriority if unset.
+                        type: string
+                      priority:
+                        description: |-
+                          The priority value. Various system components use this field to find the
+                          priority of the pod. When Priority Admission Controller is enabled, it
+                          prevents users from setting this field. The admission controller populates
+                          this field from PriorityClassName.
+                          The higher the value, the higher the priority.
+                        format: int32
+                        type: integer
+                      priorityClassName:
+                        description: |-
+                          If specified, indicates the pod's priority. "system-node-critical" and
+                          "system-cluster-critical" are two special keywords which indicate the
+                          highest priorities with the former being the highest priority. Any other
+                          name must be defined by creating a PriorityClass object with that name.
+                          If not specified, the pod priority will be default or zero if there is no
+                          default.
+                        type: string
+                      readinessGates:
+                        description: |-
+                          If specified, all readiness gates will be evaluated for pod readiness.
+                          A pod is ready when all its containers are ready AND
+                          all conditions specified in the readiness gates have status equal to "True"
+                          More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
+                        items:
+                          description: PodReadinessGate contains the reference to
+                            a pod condition
+                          properties:
+                            conditionType:
+                              description: ConditionType refers to a condition in
+                                the pod's condition list with matching type.
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      resourceClaims:
+                        description: |-
+                          ResourceClaims defines which ResourceClaims must be allocated
+                          and reserved before the Pod is allowed to start. The resources
+                          will be made available to those containers which consume them
+                          by name.
+
+                          This is a stable field but requires that the
+                          DynamicResourceAllocation feature gate is enabled.
+
+                          This field is immutable.
+                        items:
+                          description: |-
+                            PodResourceClaim references exactly one ResourceClaim, either directly
+                            or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                            for the pod.
+
+                            It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                            Containers that need access to the ResourceClaim reference it with this name.
+                          properties:
+                            name:
+                              description: |-
+                                Name uniquely identifies this resource claim inside the pod.
+                                This must be a DNS_LABEL.
+                              type: string
+                            resourceClaimName:
+                              description: |-
+                                ResourceClaimName is the name of a ResourceClaim object in the same
+                                namespace as this pod.
+
+                                Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                be set.
+                              type: string
+                            resourceClaimTemplateName:
+                              description: |-
+                                ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                object in the same namespace as this pod.
+
+                                The template will be used to create a new ResourceClaim, which will
+                                be bound to this pod. When this pod is deleted, the ResourceClaim
+                                will also be deleted. The pod name and resource name, along with a
+                                generated component, will be used to form a unique name for the
+                                ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                This field is immutable and no changes will be made to the
+                                corresponding ResourceClaim by the control plane after creating the
+                                ResourceClaim.
+
+                                Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                be set.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      resources:
+                        description: |-
+                          Resources is the total amount of CPU and Memory resources required by all
+                          containers in the pod. It supports specifying Requests and Limits for
+                          "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
+
+                          This field enables fine-grained control over resource allocation for the
+                          entire pod, allowing resource sharing among containers in a pod.
+
+                          This is an alpha field and requires enabling the PodLevelResources feature
+                          gate.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      restartPolicy:
+                        description: |-
+                          Restart policy for all containers within the pod.
+                          One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                          Default to Always.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+                        type: string
+                      runtimeClassName:
+                        description: |-
+                          RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                          to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                          If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                          empty definition that uses the default runtime handler.
+                          More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+                        type: string
+                      schedulerName:
+                        description: |-
+                          If specified, the pod will be dispatched by specified scheduler.
+                          If not specified, the pod will be dispatched by default scheduler.
+                        type: string
+                      schedulingGates:
+                        description: |-
+                          SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                          If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                          scheduler will not attempt to schedule the pod.
+
+                          SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+                        items:
+                          description: PodSchedulingGate is associated to a Pod to
+                            guard its scheduling.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the scheduling gate.
+                                Each scheduling gate must have a unique name field.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      securityContext:
+                        description: |-
+                          SecurityContext holds pod-level security attributes and common container settings.
+                          Optional: Defaults to empty.  See type description for default values of each field.
+                        properties:
+                          appArmorProfile:
+                            description: |-
+                              appArmorProfile is the AppArmor options to use by the containers in this pod.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile loaded on the node that should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must match the loaded name of the profile.
+                                  Must be set if and only if type is "Localhost".
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of AppArmor profile will be applied.
+                                  Valid options are:
+                                    Localhost - a profile pre-loaded on the node.
+                                    RuntimeDefault - the container runtime's default profile.
+                                    Unconfined - no AppArmor enforcement.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          fsGroup:
+                            description: |-
+                              A special supplemental group that applies to all containers in a pod.
+                              Some volume types allow the Kubelet to change the ownership of that volume
+                              to be owned by the pod:
+
+                              1. The owning GID will be the FSGroup
+                              2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                              3. The permission bits are OR'd with rw-rw----
+
+                              If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            description: |-
+                              fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                              before being exposed inside Pod. This field will only apply to
+                              volume types which support fsGroup based ownership(and permissions).
+                              It will have no effect on ephemeral volume types such as: secret, configmaps
+                              and emptydir.
+                              Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: string
+                          runAsGroup:
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence
+                              for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence
+                              for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            format: int64
+                            type: integer
+                          seLinuxChangePolicy:
+                            description: |-
+                              seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                              It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                              Valid values are "MountOption" and "Recursive".
+
+                              "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                              This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                              "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                              This requires all Pods that share the same volume to use the same SELinux label.
+                              It is not possible to share the same volume among privileged and unprivileged Pods.
+                              Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                              whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                              CSIDriver instance. Other volumes are always re-labelled recursively.
+                              "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                              If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                              If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                              and "Recursive" for all other volumes.
+
+                              This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                              All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: string
+                          seLinuxOptions:
+                            description: |-
+                              The SELinux context to be applied to all containers.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in SecurityContext.  If set in
+                              both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: |-
+                              The seccomp options to use by the containers in this pod.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            properties:
+                              localhostProfile:
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
+                                type: string
+                              type:
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
+                                type: string
+                            required:
+                            - type
+                            type: object
+                          supplementalGroups:
+                            description: |-
+                              A list of groups applied to the first process run in each container, in
+                              addition to the container's primary GID and fsGroup (if specified).  If
+                              the SupplementalGroupsPolicy feature is enabled, the
+                              supplementalGroupsPolicy field determines whether these are in addition
+                              to or instead of any group memberships defined in the container image.
+                              If unspecified, no additional groups are added, though group memberships
+                              defined in the container image may still be used, depending on the
+                              supplementalGroupsPolicy field.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          supplementalGroupsPolicy:
+                            description: |-
+                              Defines how supplemental groups of the first container processes are calculated.
+                              Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                              (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                              and the container runtime must implement support for this feature.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            type: string
+                          sysctls:
+                            description: |-
+                              Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                              sysctls (by the container runtime) might fail to launch.
+                              Note that this field cannot be set when spec.os.name is windows.
+                            items:
+                              description: Sysctl defines a kernel parameter to be
+                                set
+                              properties:
+                                name:
+                                  description: Name of a property to set
+                                  type: string
+                                value:
+                                  description: Value of a property to set
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          windowsOptions:
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options within a container's SecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
+                                type: string
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of
+                                  the GMSA credential spec to use.
+                                type: string
+                              hostProcess:
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                type: boolean
+                              runAsUserName:
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                type: string
+                            type: object
+                        type: object
+                      serviceAccount:
+                        description: |-
+                          DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.
+                          Deprecated: Use serviceAccountName instead.
+                        type: string
+                      serviceAccountName:
+                        description: |-
+                          ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                        type: string
+                      setHostnameAsFQDN:
+                        description: |-
+                          If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                          In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                          In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                          If a pod does not have FQDN, this has no effect.
+                          Default to false.
+                        type: boolean
+                      shareProcessNamespace:
+                        description: |-
+                          Share a single process namespace between all of the containers in a pod.
+                          When this is set containers will be able to view and signal processes from other containers
+                          in the same pod, and the first process in each container will not be assigned PID 1.
+                          HostPID and ShareProcessNamespace cannot both be set.
+                          Optional: Default to false.
+                        type: boolean
+                      subdomain:
+                        description: |-
+                          If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                          If not specified, the pod will not have a domainname at all.
+                        type: string
+                      terminationGracePeriodSeconds:
+                        description: |-
+                          Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                          Value must be non-negative integer. The value zero indicates stop immediately via
+                          the kill signal (no opportunity to shut down).
+                          If this value is nil, the default grace period will be used instead.
+                          The grace period is the duration in seconds after the processes running in the pod are sent
+                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                          Set this value longer than the expected cleanup time for your process.
+                          Defaults to 30 seconds.
+                        format: int64
+                        type: integer
+                      tolerations:
+                        description: If specified, the pod's tolerations.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                                Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      topologySpreadConstraints:
+                        description: |-
+                          TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                          domains. Scheduler will schedule pods in a way which abides by the constraints.
+                          All topologySpreadConstraints are ANDed.
+                        items:
+                          description: TopologySpreadConstraint specifies how to spread
+                            matching pods among the given topology.
+                          properties:
+                            labelSelector:
+                              description: |-
+                                LabelSelector is used to find matching pods.
+                                Pods that match this label selector are counted to determine the number of pods
+                                in their corresponding topology domain.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select the pods over which
+                                spreading will be calculated. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are ANDed with labelSelector
+                                to select the group of existing pods over which spreading will be calculated
+                                for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                Keys that don't exist in the incoming pod labels will
+                                be ignored. A null or empty list means only match against labelSelector.
+
+                                This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            maxSkew:
+                              description: |-
+                                MaxSkew describes the degree to which pods may be unevenly distributed.
+                                When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                between the number of matching pods in the target topology and the global minimum.
+                                The global minimum is the minimum number of matching pods in an eligible domain
+                                or zero if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 2/2/1:
+                                In this case, the global minimum is 1.
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |   P   |
+                                - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                to topologies that satisfy it.
+                                It's a required field. Default value is 1 and 0 is not allowed.
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: |-
+                                MinDomains indicates a minimum number of eligible domains.
+                                When the number of eligible domains with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                this value has no effect on scheduling.
+                                As a result, when the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to those domains.
+                                If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                Valid values are integers greater than 0.
+                                When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 |
+                                |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                In this situation, new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                it will violate MaxSkew.
+                              format: int32
+                              type: integer
+                            nodeAffinityPolicy:
+                              description: |-
+                                NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                when calculating pod topology spread skew. Options are:
+                                - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                If this value is nil, the behavior is equivalent to the Honor policy.
+                              type: string
+                            nodeTaintsPolicy:
+                              description: |-
+                                NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                pod topology spread skew. Options are:
+                                - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                has a toleration, are included.
+                                - Ignore: node taints are ignored. All nodes are included.
+
+                                If this value is nil, the behavior is equivalent to the Ignore policy.
+                              type: string
+                            topologyKey:
+                              description: |-
+                                TopologyKey is the key of node labels. Nodes that have a label with this key
+                                and identical values are considered to be in the same topology.
+                                We consider each <key, value> as a "bucket", and try to put balanced number
+                                of pods into each bucket.
+                                We define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                nodeAffinityPolicy and nodeTaintsPolicy.
+                                e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                It's a required field.
+                              type: string
+                            whenUnsatisfiable:
+                              description: |-
+                                WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                the spread constraint.
+                                - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                  but giving higher precedence to topologies that would help reduce the
+                                  skew.
+                                A constraint is considered "Unsatisfiable" for an incoming pod
+                                if and only if every possible node assignment for that pod would violate
+                                "MaxSkew" on some topology.
+                                For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                labelSelector spread as 3/1/1:
+                                | zone1 | zone2 | zone3 |
+                                | P P P |   P   |   P   |
+                                If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                won't make it *more* imbalanced.
+                                It's a required field.
+                              type: string
+                          required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - topologyKey
+                        - whenUnsatisfiable
+                        x-kubernetes-list-type: map
+                      volumes:
+                        description: |-
+                          List of volumes that can be mounted by containers belonging to the pod.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes
+                        items:
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
+                          properties:
+                            awsElasticBlockStore:
+                              description: |-
+                                awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  type: string
+                                partition:
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: |-
+                                    readOnly value true will force the readOnly setting in VolumeMounts.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  type: boolean
+                                volumeID:
+                                  description: |-
+                                    volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            azureDisk:
+                              description: |-
+                                azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                are redirected to the disk.csi.azure.com CSI driver.
+                              properties:
+                                cachingMode:
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
+                                  type: string
+                                diskName:
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
+                                  type: string
+                                diskURI:
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
+                                  type: string
+                                fsType:
+                                  default: ext4
+                                  description: |-
+                                    fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                kind:
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
+                                  type: string
+                                readOnly:
+                                  default: false
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                              required:
+                              - diskName
+                              - diskURI
+                              type: object
+                            azureFile:
+                              description: |-
+                                azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                are redirected to the file.csi.azure.com CSI driver.
+                              properties:
+                                readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretName:
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
+                                  type: string
+                                shareName:
+                                  description: shareName is the azure share Name
+                                  type: string
+                              required:
+                              - secretName
+                              - shareName
+                              type: object
+                            cephfs:
+                              description: |-
+                                cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                              properties:
+                                monitors:
+                                  description: |-
+                                    monitors is Required: Monitors is a collection of Ceph monitors
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  type: boolean
+                                secretFile:
+                                  description: |-
+                                    secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  description: |-
+                                    user is optional: User is the rados user name, default is admin
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                  type: string
+                              required:
+                              - monitors
+                              type: object
+                            cinder:
+                              description: |-
+                                cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                are redirected to the cinder.csi.openstack.org CSI driver.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef is optional: points to a secret object containing parameters used to connect
+                                    to OpenStack.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  description: |-
+                                    volumeID used to identify the volume in cinder.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            configMap:
+                              description: configMap represents a configMap that should
+                                populate this volume
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    defaultMode is optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: |-
+                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                    ConfigMap will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the ConfigMap,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              description: csi (Container Storage Interface) represents
+                                ephemeral storage that is handled by certain external
+                                CSI drivers.
+                              properties:
+                                driver:
+                                  description: |-
+                                    driver is the name of the CSI driver that handles this volume.
+                                    Consult with your admin for the correct name as registered in the cluster.
+                                  type: string
+                                fsType:
+                                  description: |-
+                                    fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                    If not provided, the empty value is passed to the associated CSI driver
+                                    which will determine the default filesystem to apply.
+                                  type: string
+                                nodePublishSecretRef:
+                                  description: |-
+                                    nodePublishSecretRef is a reference to the secret object containing
+                                    sensitive information to pass to the CSI driver to complete the CSI
+                                    NodePublishVolume and NodeUnpublishVolume calls.
+                                    This field is optional, and  may be empty if no secret is required. If the
+                                    secret object contains more than one secret, all secret references are passed.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  description: |-
+                                    readOnly specifies a read-only configuration for the volume.
+                                    Defaults to false (read/write).
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    volumeAttributes stores driver-specific properties that are passed to the CSI
+                                    driver. Consult your driver's documentation for supported values.
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            downwardAPI:
+                              description: downwardAPI represents downward API about
+                                the pod that should populate this volume
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    Optional: mode bits to use on created files by default. Must be a
+                                    Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: Items is a list of downward API volume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name,
+                                          namespace and uid are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        description: |-
+                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: |-
+                                          Selects a resource of the container: only resources limits and requests
+                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            emptyDir:
+                              description: |-
+                                emptyDir represents a temporary directory that shares a pod's lifetime.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                              properties:
+                                medium:
+                                  description: |-
+                                    medium represents what type of storage medium should back this directory.
+                                    The default is "" which means to use the node's default medium.
+                                    Must be an empty string (default) or Memory.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                    The size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would be the minimum value between
+                                    the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                    The default is nil which means that the limit is undefined.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              description: |-
+                                ephemeral represents a volume that is handled by a cluster storage driver.
+                                The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                and deleted when the pod is removed.
+
+                                Use this if:
+                                a) the volume is only needed while the pod runs,
+                                b) features of normal volumes like restoring from snapshot or capacity
+                                   tracking are needed,
+                                c) the storage driver is specified through a storage class, and
+                                d) the storage driver supports dynamic volume provisioning through
+                                   a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                   information on the connection between this volume type
+                                   and PersistentVolumeClaim).
+
+                                Use PersistentVolumeClaim or one of the vendor-specific
+                                APIs for volumes that persist for longer than the lifecycle
+                                of an individual pod.
+
+                                Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                be used that way - see the documentation of the driver for
+                                more information.
+
+                                A pod can use both types of ephemeral volumes and
+                                persistent volumes at the same time.
+                              properties:
+                                volumeClaimTemplate:
+                                  description: |-
+                                    Will be used to create a stand-alone PVC to provision the volume.
+                                    The pod in which this EphemeralVolumeSource is embedded will be the
+                                    owner of the PVC, i.e. the PVC will be deleted together with the
+                                    pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                    `<volume name>` is the name from the `PodSpec.Volumes` array
+                                    entry. Pod validation will reject the pod if the concatenated name
+                                    is not valid for a PVC (for example, too long).
+
+                                    An existing PVC with that name that is not owned by the pod
+                                    will *not* be used for the pod to avoid using an unrelated
+                                    volume by mistake. Starting the pod is then blocked until
+                                    the unrelated PVC is removed. If such a pre-created PVC is
+                                    meant to be used by the pod, the PVC has to updated with an
+                                    owner reference to the pod once the pod exists. Normally
+                                    this should not be necessary, but it may be useful when
+                                    manually reconstructing a broken cluster.
+
+                                    This field is read-only and no changes will be made by Kubernetes
+                                    to the PVC after it has been created.
+
+                                    Required, must not be nil.
+                                  properties:
+                                    metadata:
+                                      description: |-
+                                        May contain labels and annotations that will be copied into the PVC
+                                        when creating it. No other fields are allowed and will be rejected during
+                                        validation.
+                                      type: object
+                                    spec:
+                                      description: |-
+                                        The specification for the PersistentVolumeClaim. The entire content is
+                                        copied unchanged into the PVC that gets created from this
+                                        template. The same fields as in a PersistentVolumeClaim
+                                        are also valid here.
+                                      properties:
+                                        accessModes:
+                                          description: |-
+                                            accessModes contains the desired access modes the volume should have.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        dataSource:
+                                          description: |-
+                                            dataSource field can be used to specify either:
+                                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                            * An existing PVC (PersistentVolumeClaim)
+                                            If the provisioner or an external controller can support the specified data source,
+                                            it will create a new volume based on the contents of the specified data source.
+                                            When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                            and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                            If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                          properties:
+                                            apiGroup:
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          description: |-
+                                            dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                            volume is desired. This may be any object from a non-empty API group (non
+                                            core object) or a PersistentVolumeClaim object.
+                                            When this field is specified, volume binding will only succeed if the type of
+                                            the specified object matches some installed volume populator or dynamic
+                                            provisioner.
+                                            This field will replace the functionality of the dataSource field and as such
+                                            if both fields are non-empty, they must have the same value. For backwards
+                                            compatibility, when namespace isn't specified in dataSourceRef,
+                                            both fields (dataSource and dataSourceRef) will be set to the same
+                                            value automatically if one of them is empty and the other is non-empty.
+                                            When namespace is specified in dataSourceRef,
+                                            dataSource isn't set to the same value and must be empty.
+                                            There are three important differences between dataSource and dataSourceRef:
+                                            * While dataSource only allows two specific types of objects, dataSourceRef
+                                              allows any non-core object, as well as PersistentVolumeClaim objects.
+                                            * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                              preserves all values, and generates an error if a disallowed value is
+                                              specified.
+                                            * While dataSource only allows local objects, dataSourceRef allows objects
+                                              in any namespaces.
+                                            (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                            (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                          properties:
+                                            apiGroup:
+                                              description: |-
+                                                APIGroup is the group for the resource being referenced.
+                                                If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                For any other third-party types, APIGroup is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                            namespace:
+                                              description: |-
+                                                Namespace is the namespace of resource being referenced
+                                                Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                        resources:
+                                          description: |-
+                                            resources represents the minimum resources the volume should have.
+                                            Users are allowed to specify resource requirements
+                                            that are lower than previous value but must still be higher than capacity recorded in the
+                                            status field of the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: |-
+                                                Limits describes the maximum amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: |-
+                                                Requests describes the minimum amount of compute resources required.
+                                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                              type: object
+                                          type: object
+                                        selector:
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          description: |-
+                                            storageClassName is the name of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                          type: string
+                                        volumeAttributesClassName:
+                                          description: |-
+                                            volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                            If specified, the CSI driver will create or update the volume with the attributes defined
+                                            in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                            it can be changed after the claim is created. An empty string or nil value indicates that no
+                                            VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                            this field can be reset to its previous value (including nil) to cancel the modification.
+                                            If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                            set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                            exists.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                          type: string
+                                        volumeMode:
+                                          description: |-
+                                            volumeMode defines what type of volume is required by the claim.
+                                            Value of Filesystem is implied when not included in claim spec.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the binding reference
+                                            to the PersistentVolume backing this claim.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - spec
+                                  type: object
+                              type: object
+                            fc:
+                              description: fc represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                lun:
+                                  description: 'lun is Optional: FC target lun number'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: |-
+                                    readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                targetWWNs:
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                wwids:
+                                  description: |-
+                                    wwids Optional: FC volume world wide identifiers (wwids)
+                                    Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            flexVolume:
+                              description: |-
+                                flexVolume represents a generic volume resource that is
+                                provisioned/attached using an exec based plugin.
+                                Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                              properties:
+                                driver:
+                                  description: driver is the name of the driver to
+                                    use for this volume.
+                                  type: string
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
+                                  type: object
+                                readOnly:
+                                  description: |-
+                                    readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef is Optional: secretRef is reference to the secret object containing
+                                    sensitive information to pass to the plugin scripts. This may be
+                                    empty if no secret object is specified. If the secret object
+                                    contains more than one secret, all secrets are passed to the plugin
+                                    scripts.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - driver
+                              type: object
+                            flocker:
+                              description: |-
+                                flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                              properties:
+                                datasetName:
+                                  description: |-
+                                    datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                    should be considered as deprecated
+                                  type: string
+                                datasetUUID:
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              description: |-
+                                gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  type: string
+                                partition:
+                                  description: |-
+                                    partition is the partition in the volume that you want to mount.
+                                    If omitted, the default is to mount by volume name.
+                                    Examples: For volume /dev/sda1, you specify the partition as "1".
+                                    Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  description: |-
+                                    pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  type: boolean
+                              required:
+                              - pdName
+                              type: object
+                            gitRepo:
+                              description: |-
+                                gitRepo represents a git repository at a particular revision.
+                                Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                into the Pod's container.
+                              properties:
+                                directory:
+                                  description: |-
+                                    directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                    git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                    the subdirectory with the given name.
+                                  type: string
+                                repository:
+                                  description: repository is the URL
+                                  type: string
+                                revision:
+                                  description: revision is the commit hash for the
+                                    specified revision.
+                                  type: string
+                              required:
+                              - repository
+                              type: object
+                            glusterfs:
+                              description: |-
+                                glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                              properties:
+                                endpoints:
+                                  description: endpoints is the endpoint name that
+                                    details Glusterfs topology.
+                                  type: string
+                                path:
+                                  description: |-
+                                    path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                  type: boolean
+                              required:
+                              - endpoints
+                              - path
+                              type: object
+                            hostPath:
+                              description: |-
+                                hostPath represents a pre-existing file or directory on the host
+                                machine that is directly exposed to the container. This is generally
+                                used for system agents or other privileged things that are allowed
+                                to see the host machine. Most containers will NOT need this.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              properties:
+                                path:
+                                  description: |-
+                                    path of the directory on the host.
+                                    If the path is a symlink, it will follow the link to the real path.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  type: string
+                                type:
+                                  description: |-
+                                    type for HostPath Volume
+                                    Defaults to ""
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            image:
+                              description: |-
+                                image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                                The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                                - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                                The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                                A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                                The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                                The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                                The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                                The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                              properties:
+                                pullPolicy:
+                                  description: |-
+                                    Policy for pulling OCI objects. Possible values are:
+                                    Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  type: string
+                                reference:
+                                  description: |-
+                                    Required: Image or artifact reference to be used.
+                                    Behaves in the same way as pod.spec.containers[*].image.
+                                    Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                              type: object
+                            iscsi:
+                              description: |-
+                                iscsi represents an ISCSI Disk resource that is attached to a
+                                kubelet's host machine and then exposed to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                              properties:
+                                chapAuthDiscovery:
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
+                                  type: boolean
+                                chapAuthSession:
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
+                                  type: boolean
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                  type: string
+                                initiatorName:
+                                  description: |-
+                                    initiatorName is the custom iSCSI Initiator Name.
+                                    If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                    <target portal>:<volume name> will be created for the connection.
+                                  type: string
+                                iqn:
+                                  description: iqn is the target iSCSI Qualified Name.
+                                  type: string
+                                iscsiInterface:
+                                  default: default
+                                  description: |-
+                                    iscsiInterface is the interface Name that uses an iSCSI transport.
+                                    Defaults to 'default' (tcp).
+                                  type: string
+                                lun:
+                                  description: lun represents iSCSI Target Lun number.
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  description: |-
+                                    portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  description: |-
+                                    targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                    is other than default (typically TCP ports 860 and 3260).
+                                  type: string
+                              required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                              type: object
+                            name:
+                              description: |-
+                                name of the volume.
+                                Must be a DNS_LABEL and unique within the pod.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            nfs:
+                              description: |-
+                                nfs represents an NFS mount on the host that shares a pod's lifetime
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              properties:
+                                path:
+                                  description: |-
+                                    path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the NFS export to be mounted with read-only permissions.
+                                    Defaults to false.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: boolean
+                                server:
+                                  description: |-
+                                    server is the hostname or IP address of the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
+                            persistentVolumeClaim:
+                              description: |-
+                                persistentVolumeClaimVolumeSource represents a reference to a
+                                PersistentVolumeClaim in the same namespace.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                              properties:
+                                claimName:
+                                  description: |-
+                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            photonPersistentDisk:
+                              description: |-
+                                photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                pdID:
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
+                                  type: string
+                              required:
+                              - pdID
+                              type: object
+                            portworxVolume:
+                              description: |-
+                                portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                                is on.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fSType represents the filesystem type to mount
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                volumeID:
+                                  description: volumeID uniquely identifies a Portworx
+                                    volume
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            projected:
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    defaultMode are the mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  description: |-
+                                    sources is the list of volume projections. Each entry in this list
+                                    handles one source.
+                                  items:
+                                    description: |-
+                                      Projection that may be projected along with other supported volume types.
+                                      Exactly one of these fields must be set.
+                                    properties:
+                                      clusterTrustBundle:
+                                        description: |-
+                                          ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                          of ClusterTrustBundle objects in an auto-updating file.
+
+                                          Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                          ClusterTrustBundle objects can either be selected by name, or by the
+                                          combination of signer name and a label selector.
+
+                                          Kubelet performs aggressive normalization of the PEM contents written
+                                          into the pod filesystem.  Esoteric PEM features such as inter-block
+                                          comments and block headers are stripped.  Certificates are deduplicated.
+                                          The ordering of certificates within the file is arbitrary, and Kubelet
+                                          may change the order over time.
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              Select all ClusterTrustBundles that match this label selector.  Only has
+                                              effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                              interpreted as "match nothing".  If set but empty, interpreted as "match
+                                              everything".
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          name:
+                                            description: |-
+                                              Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                              with signerName and labelSelector.
+                                            type: string
+                                          optional:
+                                            description: |-
+                                              If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                              aren't available.  If using name, then the named ClusterTrustBundle is
+                                              allowed not to exist.  If using signerName, then the combination of
+                                              signerName and labelSelector is allowed to match zero
+                                              ClusterTrustBundles.
+                                            type: boolean
+                                          path:
+                                            description: Relative path from the volume
+                                              root to write the bundle.
+                                            type: string
+                                          signerName:
+                                            description: |-
+                                              Select all ClusterTrustBundles that match this signer name.
+                                              Mutually-exclusive with name.  The contents of all selected
+                                              ClusterTrustBundles will be unified and deduplicated.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                      configMap:
+                                        description: configMap information about the
+                                          configMap data to project
+                                        properties:
+                                          items:
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              ConfigMap will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the ConfigMap,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
+                                        properties:
+                                          items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name, namespace and uid
+                                                    are supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  description: |-
+                                                    Optional: mode bits used to set permissions on this file, must be an octal value
+                                                    between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      podCertificate:
+                                        description: |-
+                                          Projects an auto-rotating credential bundle (private key and certificate
+                                          chain) that the pod can use either as a TLS client or server.
+
+                                          Kubelet generates a private key and uses it to send a
+                                          PodCertificateRequest to the named signer.  Once the signer approves the
+                                          request and issues a certificate chain, Kubelet writes the key and
+                                          certificate chain to the pod filesystem.  The pod does not start until
+                                          certificates have been issued for each podCertificate projected volume
+                                          source in its spec.
+
+                                          Kubelet will begin trying to rotate the certificate at the time indicated
+                                          by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                          timestamp.
+
+                                          Kubelet can write a single file, indicated by the credentialBundlePath
+                                          field, or separate files, indicated by the keyPath and
+                                          certificateChainPath fields.
+
+                                          The credential bundle is a single file in PEM format.  The first PEM
+                                          entry is the private key (in PKCS#8 format), and the remaining PEM
+                                          entries are the certificate chain issued by the signer (typically,
+                                          signers will return their certificate chain in leaf-to-root order).
+
+                                          Prefer using the credential bundle format, since your application code
+                                          can read it atomically.  If you use keyPath and certificateChainPath,
+                                          your application must make two separate file reads. If these coincide
+                                          with a certificate rotation, it is possible that the private key and leaf
+                                          certificate you read may not correspond to each other.  Your application
+                                          will need to check for this condition, and re-read until they are
+                                          consistent.
+
+                                          The named signer controls chooses the format of the certificate it
+                                          issues; consult the signer implementation's documentation to learn how to
+                                          use the certificates it issues.
+                                        properties:
+                                          certificateChainPath:
+                                            description: |-
+                                              Write the certificate chain at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          credentialBundlePath:
+                                            description: |-
+                                              Write the credential bundle at this path in the projected volume.
+
+                                              The credential bundle is a single file that contains multiple PEM blocks.
+                                              The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                              key.
+
+                                              The remaining blocks are CERTIFICATE blocks, containing the issued
+                                              certificate chain from the signer (leaf and any intermediates).
+
+                                              Using credentialBundlePath lets your Pod's application code make a single
+                                              atomic read that retrieves a consistent key and certificate chain.  If you
+                                              project them to separate files, your application code will need to
+                                              additionally check that the leaf certificate was issued to the key.
+                                            type: string
+                                          keyPath:
+                                            description: |-
+                                              Write the key at this path in the projected volume.
+
+                                              Most applications should use credentialBundlePath.  When using keyPath
+                                              and certificateChainPath, your application needs to check that the key
+                                              and leaf certificate are consistent, because it is possible to read the
+                                              files mid-rotation.
+                                            type: string
+                                          keyType:
+                                            description: |-
+                                              The type of keypair Kubelet will generate for the pod.
+
+                                              Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                              "ECDSAP521", and "ED25519".
+                                            type: string
+                                          maxExpirationSeconds:
+                                            description: |-
+                                              maxExpirationSeconds is the maximum lifetime permitted for the
+                                              certificate.
+
+                                              Kubelet copies this value verbatim into the PodCertificateRequests it
+                                              generates for this projection.
+
+                                              If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                              will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                              value is 7862400 (91 days).
+
+                                              The signer implementation is then free to issue a certificate with any
+                                              lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                              seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                              `kubernetes.io` signers will never issue certificates with a lifetime
+                                              longer than 24 hours.
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            description: Kubelet's generated CSRs
+                                              will be addressed to this signer.
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              userAnnotations allow pod authors to pass additional information to
+                                              the signer implementation.  Kubernetes does not restrict or validate this
+                                              metadata in any way.
+
+                                              These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                              the PodCertificateRequest objects that Kubelet creates.
+
+                                              Entries are subject to the same validation as object metadata annotations,
+                                              with the addition that all keys must be domain-prefixed. No restrictions
+                                              are placed on values, except an overall size limitation on the entire field.
+
+                                              Signers should document the keys and values they support. Signers should
+                                              deny requests that contain keys they do not recognize.
+                                            type: object
+                                        required:
+                                        - keyType
+                                        - signerName
+                                        type: object
+                                      secret:
+                                        description: secret information about the
+                                          secret data to project
+                                        properties:
+                                          items:
+                                            description: |-
+                                              items if unspecified, each key-value pair in the Data field of the referenced
+                                              Secret will be projected into the volume as a file whose name is the
+                                              key and content is the value. If specified, the listed keys will be
+                                              projected into the specified paths, and unlisted keys will not be
+                                              present. If a key is specified which is not present in the Secret,
+                                              the volume setup will error unless it is marked optional. Paths must be
+                                              relative and may not contain the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: |-
+                                                    mode is Optional: mode bits used to set permissions on this file.
+                                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                    If not specified, the volume defaultMode will be used.
+                                                    This might be in conflict with other options that affect the file
+                                                    mode, like fsGroup, and the result can be other mode bits set.
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: |-
+                                                    path is the relative path of the file to map the key to.
+                                                    May not be an absolute path.
+                                                    May not contain the path element '..'.
+                                                    May not start with the string '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
+                                        properties:
+                                          audience:
+                                            description: |-
+                                              audience is the intended audience of the token. A recipient of a token
+                                              must identify itself with an identifier specified in the audience of the
+                                              token, and otherwise should reject the token. The audience defaults to the
+                                              identifier of the apiserver.
+                                            type: string
+                                          expirationSeconds:
+                                            description: |-
+                                              expirationSeconds is the requested duration of validity of the service
+                                              account token. As the token approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service account token. The kubelet will
+                                              start trying to rotate the token if the token is older than 80 percent of
+                                              its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                              and must be at least 10 minutes.
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            description: |-
+                                              path is the path relative to the mount point of the file to project the
+                                              token into.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            quobyte:
+                              description: |-
+                                quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                              properties:
+                                group:
+                                  description: |-
+                                    group to map volume access to
+                                    Default is no group
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                  type: boolean
+                                registry:
+                                  description: |-
+                                    registry represents a single or multiple Quobyte Registry services
+                                    specified as a string as host:port pair (multiple entries are separated with commas)
+                                    which acts as the central registry for volumes
+                                  type: string
+                                tenant:
+                                  description: |-
+                                    tenant owning the given Quobyte volume in the Backend
+                                    Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                  type: string
+                                user:
+                                  description: |-
+                                    user to map volume access to
+                                    Defaults to serivceaccount user
+                                  type: string
+                                volume:
+                                  description: volume is a string that references
+                                    an already created Quobyte volume by name.
+                                  type: string
+                              required:
+                              - registry
+                              - volume
+                              type: object
+                            rbd:
+                              description: |-
+                                rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type of the volume that you want to mount.
+                                    Tip: Ensure that the filesystem type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                  type: string
+                                image:
+                                  description: |-
+                                    image is the rados image name.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: string
+                                keyring:
+                                  default: /etc/ceph/keyring
+                                  description: |-
+                                    keyring is the path to key ring for RBDUser.
+                                    Default is /etc/ceph/keyring.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: string
+                                monitors:
+                                  description: |-
+                                    monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                pool:
+                                  default: rbd
+                                  description: |-
+                                    pool is the rados pool name.
+                                    Default is rbd.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly here will force the ReadOnly setting in VolumeMounts.
+                                    Defaults to false.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef is name of the authentication secret for RBDUser. If provided
+                                    overrides keyring.
+                                    Default is nil.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  default: admin
+                                  description: |-
+                                    user is the rados user name.
+                                    Default is admin.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                  type: string
+                              required:
+                              - image
+                              - monitors
+                              type: object
+                            scaleIO:
+                              description: |-
+                                scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                              properties:
+                                fsType:
+                                  default: xfs
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs".
+                                    Default is "xfs".
+                                  type: string
+                                gateway:
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
+                                  type: string
+                                protectionDomain:
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly Defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef references to the secret for ScaleIO user and other
+                                    sensitive information. If this is not provided, Login operation will fail.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
+                                  type: boolean
+                                storageMode:
+                                  default: ThinProvisioned
+                                  description: |-
+                                    storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                    Default is ThinProvisioned.
+                                  type: string
+                                storagePool:
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
+                                  type: string
+                                system:
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
+                                  type: string
+                                volumeName:
+                                  description: |-
+                                    volumeName is the name of a volume already created in the ScaleIO system
+                                    that is associated with this volume source.
+                                  type: string
+                              required:
+                              - gateway
+                              - secretRef
+                              - system
+                              type: object
+                            secret:
+                              description: |-
+                                secret represents a secret that should populate this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values
+                                    for mode bits. Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: |-
+                                    items If unspecified, each key-value pair in the Data field of the referenced
+                                    Secret will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the Secret,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
+                                  type: boolean
+                                secretName:
+                                  description: |-
+                                    secretName is the name of the secret in the pod's namespace to use.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                  type: string
+                              type: object
+                            storageos:
+                              description: |-
+                                storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly defaults to false (read/write). ReadOnly here will force
+                                    the ReadOnly setting in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: |-
+                                    secretRef specifies the secret to use for obtaining the StorageOS API
+                                    credentials.  If not specified, default values will be attempted.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  description: |-
+                                    volumeName is the human-readable name of the StorageOS volume.  Volume
+                                    names are only unique within a namespace.
+                                  type: string
+                                volumeNamespace:
+                                  description: |-
+                                    volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                    namespace is specified then the Pod's namespace will be used.  This allows the
+                                    Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default behaviour.
+                                    Set to "default" if you are not using namespaces within StorageOS.
+                                    Namespaces that do not pre-exist within StorageOS will be created.
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              description: |-
+                                vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                are redirected to the csi.vsphere.vmware.com CSI driver.
+                              properties:
+                                fsType:
+                                  description: |-
+                                    fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host operating system.
+                                    Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                storagePolicyID:
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
+                                  type: string
+                                storagePolicyName:
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
+                                  type: string
+                                volumePath:
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
+                                  type: string
+                              required:
+                              - volumePath
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      workloadRef:
+                        description: |-
+                          WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                          This field is used by the scheduler to identify the PodGroup and apply the
+                          correct group scheduling policies. The Workload object referenced
+                          by this field may not exist at the time the Pod is created.
+                          This field is immutable, but a Workload object with the same name
+                          may be recreated with different policies. Doing this during pod scheduling
+                          may result in the placement not conforming to the expected policies.
+                        properties:
+                          name:
+                            description: |-
+                              Name defines the name of the Workload object this Pod belongs to.
+                              Workload must be in the same namespace as the Pod.
+                              If it doesn't match any existing Workload, the Pod will remain unschedulable
+                              until a Workload object is created and observed by the kube-scheduler.
+                              It must be a DNS subdomain.
+                            type: string
+                          podGroup:
+                            description: |-
+                              PodGroup is the name of the PodGroup within the Workload that this Pod
+                              belongs to. If it doesn't match any existing PodGroup within the Workload,
+                              the Pod will remain unschedulable until the Workload object is recreated
+                              and observed by the kube-scheduler. It must be a DNS label.
+                            type: string
+                          podGroupReplicaKey:
+                            description: |-
+                              PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                              Pod belongs. It is used to distinguish pods belonging to different replicas
+                              of the same pod group. The pod group policy is applied separately to each replica.
+                              When set, it must be a DNS label.
+                            type: string
+                        required:
+                        - name
+                        - podGroup
+                        type: object
+                    required:
+                    - containers
+                    type: object
+                type: object
+              type:
+                default: rw
+                description: Type 은 rw(primary) 또는 ro(replica) endpoint 선택이다.
+                enum:
+                - rw
+                - ro
+                type: string
+            required:
+            - cluster
+            - pgbouncer
+            type: object
+          status:
+            description: PoolerStatus 는 PgBouncer 하위 리소스 관찰 상태다.
+            properties:
+              backendTargets:
+                description: BackendTargets 는 현재 PgBouncer config 로 라우팅되는 PostgreSQL
+                  backend DNS 목록이다.
+                items:
+                  type: string
+                type: array
+              builtinAuthLastRotation:
+                description: |-
+                  BuiltinAuthLastRotation 은 operator-managed built-in auth 의 마지막 password
+                  rotation 시각이다. 사용자가 `postgres.keiailab.io/rotate-pooler-password=true`
+                  annotation 을 적용해 force rotation 을 트리거할 때마다 갱신된다. spec.pgbouncer.
+                  authSecretRef 가 명시된 user-supplied 경로에서는 사용하지 않는다.
+                format: date-time
+                type: string
+              conditions:
+                description: Conditions 는 K8s 표준 상태다.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              configHash:
+                description: ConfigHash 는 현재 PgBouncer config 의 sha256 이다.
+                type: string
+              instances:
+                description: Instances 는 PgBouncer Deployment 가 수렴하려는 replica 수다.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration 은 마지막 처리 generation 이다.
+                format: int64
+                type: integer
+              paused:
+                description: Paused 는 모든 준비된 PgBouncer Pod 에 마지막으로 수렴된 PAUSE/RESUME
+                  상태다.
+                type: boolean
+              phase:
+                description: Phase 는 Pooler reconcile 상태다.
+                enum:
+                - Pending
+                - Ready
+                - Failed
+                type: string
+              readyReplicas:
+                description: ReadyReplicas 는 observed Deployment 의 readyReplicas 값이다.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_postgresclusters.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_postgresclusters.yaml
@@ -1,0 +1,2080 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  creationTimestamp: null
+  name: postgresclusters.postgres.keiailab.io
+spec:
+  group: postgres.keiailab.io
+  names:
+    categories:
+    - postgres
+    - database
+    - all
+    kind: PostgresCluster
+    listKind: PostgresClusterList
+    plural: postgresclusters
+    shortNames:
+    - pgc
+    singular: postgrescluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .spec.shards.initialCount
+      name: Shards
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.postgresVersion
+      name: Version
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PostgresCluster 는 K8s-native 자체 분산 PostgreSQL 클러스터의 선언적 표현이다
+          (ADR 0001).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              PostgresClusterSpec 는 PostgresCluster CR 의 desired state 다 (RFC 0001 §3).
+
+              CEL 검증 (kubebuilder v0.15+):
+            properties:
+              autoSplit:
+                description: AutoSplit 은 자동 샤드 분할 정책.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enabled 는 자동 분할 활성화 여부. P2+ 에서 의미를 갖는다.
+                    type: boolean
+                  requireApproval:
+                    default: true
+                    description: |-
+                      RequireApproval 은 자동 분할 대상 후보를 ShardSplitJob 으로 제출하되 수동
+                      승인 annotation 후에만 실행하도록 강제한다 (production safety).
+                    type: boolean
+                  triggers:
+                    description: Triggers 는 분할 임계치 집합.
+                    properties:
+                      cpuPercent:
+                        description: CPUPercent 는 단일 샤드 평균 CPU 사용률 임계치 (%). 0 이면 미사용.
+                        format: int32
+                        maximum: 100
+                        minimum: 0
+                        type: integer
+                      durationMinutes:
+                        description: DurationMinutes 는 위 임계치들이 지속되어야 하는 시간 (분). 0
+                          이면 즉시.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      p99LatencyMs:
+                        description: P99LatencyMs 는 단일 샤드 P99 latency 임계치 (ms). 0
+                          이면 미사용.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                      sizeThresholdGB:
+                        description: SizeThresholdGB 는 단일 샤드 크기 임계치 (GB). 0 이면 미사용.
+                        format: int32
+                        minimum: 0
+                        type: integer
+                    type: object
+                type: object
+              backup:
+                description: Backup 은 백업/PITR 정책.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enabled 는 백업 정책 활성화 여부 (사용자 명시 opt-in).
+                    type: boolean
+                  repo:
+                    description: Repo 는 백업 저장소 설정.
+                    properties:
+                      bucket:
+                        description: Bucket 은 object storage 버킷 이름.
+                        type: string
+                      endpoint:
+                        description: Endpoint 는 S3 호환 endpoint URL (선택).
+                        type: string
+                      path:
+                        description: Path 는 filesystem 경로 (Type=filesystem).
+                        type: string
+                      region:
+                        description: Region 은 object storage 리전.
+                        type: string
+                      type:
+                        description: Type 은 저장소 종류 (s3 | gcs | azure | filesystem).
+                        enum:
+                        - s3
+                        - gcs
+                        - azure
+                        - filesystem
+                        type: string
+                    type: object
+                  retention:
+                    description: Retention 은 백업 보존 정책.
+                    properties:
+                      full:
+                        description: 'Full 은 full 백업 보존 기간 (duration: "7d", "168h"
+                          등).'
+                        type: string
+                      incremental:
+                        description: Incremental 은 incremental 백업 보존 기간.
+                        type: string
+                      walArchive:
+                        description: WALArchive 는 WAL 아카이브 보존 기간.
+                        type: string
+                    type: object
+                  schedule:
+                    description: 'Schedule 은 cron expression (예: "0 2 * * *").'
+                    type: string
+                type: object
+              bootstrap:
+                description: |-
+                  Bootstrap 은 initdb 외 bootstrap 방식을 정의한다. 현재 pg_basebackup 기반
+                  streaming bootstrap 을 지원한다.
+                properties:
+                  pg_basebackup:
+                    description: |-
+                      PgBaseBackup 은 streaming replication protocol 을 통해 외부 source 에서
+                      물리 base backup 을 가져오는 bootstrap 방식이다.
+                    properties:
+                      source:
+                        description: Source 는 spec.externalClusters[].name 을 참조한다.
+                        minLength: 1
+                        type: string
+                    required:
+                    - source
+                    type: object
+                type: object
+              extensions:
+                description: |-
+                  Extensions 는 활성화할 PostgreSQL extension 의 이름 목록이다 (RFC 0006 R1).
+                  비어 있으면 vanilla PG (image base 외 추가 extension 없음). 각 이름은 operator
+                  부트스트랩 시 Registry 에 등록된 ExtensionPlugin 이어야 하며, webhook 이 이를
+                  검증한다.
+
+                  예: ["pgaudit", "pgvector"] — postgres_v1alpha1 image 가 두 extension 의 .so 를
+                  보유한다는 전제. image 가 미보유 시 postgres FATAL — 사용자 책임.
+                items:
+                  type: string
+                type: array
+              externalClusters:
+                description: |-
+                  ExternalClusters 는 bootstrap/replica source 로 사용할 외부 PostgreSQL
+                  cluster 목록이다.
+                items:
+                  description: |-
+                    ExternalClusterSpec 는 replica cluster/bootstrap source 로 사용할 외부 PostgreSQL
+                    cluster 접속 정보를 정의한다. CloudNativePG 의 externalClusters 표면과 호환되는
+                    최소 streaming path 부터 제공한다.
+                  properties:
+                    connectionParameters:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        ConnectionParameters 는 PostgreSQL connection string key/value 이다.
+                        지원 key: host, port, user, dbname, sslmode. host 는 필수이고 port 는
+                        미지정 시 5432 로 default 된다.
+                      type: object
+                    name:
+                      description: Name 은 bootstrap/replica.source 에서 참조할 이름이다.
+                      minLength: 1
+                      type: string
+                    password:
+                      description: |-
+                        Password 는 libpq password 인증에 사용할 Secret key 참조다.
+                        CloudNativePG externalClusters[].password 와 같은 형태다.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    sslCert:
+                      description: SSLCert 는 client certificate 인증에 사용할 certificate
+                        Secret key 참조다.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    sslKey:
+                      description: SSLKey 는 client certificate 인증에 사용할 private key
+                        Secret key 참조다.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    sslRootCert:
+                      description: SSLRootCert 는 source cluster server certificate
+                        검증에 사용할 CA Secret key 참조다.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              imageCatalogRef:
+                description: |-
+                  ImageCatalogRef 는 PostgreSQL runtime image 를 ImageCatalog 또는
+                  ClusterImageCatalog 에서 선택한다. CNPG 의 spec.imageCatalogRef 와 같은
+                  필드 형태를 사용하며, 설정 시 PostgresVersion 대신 Major 가 image/bin dir
+                  선택의 단일 진실원이 된다.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup 은 catalog API group 이다. 빈 값, postgres.keiailab.io, postgresql.cnpg.io 를 허용한다.
+                      postgresql.cnpg.io 는 CNPG manifest 이식 편의를 위한 호환 입력이며, 실제 조회는
+                      keiailab CRD 에 대해 수행한다.
+                    type: string
+                  kind:
+                    description: Kind 는 ImageCatalog 또는 ClusterImageCatalog 이다.
+                    enum:
+                    - ImageCatalog
+                    - ClusterImageCatalog
+                    type: string
+                  major:
+                    description: Major 는 catalog 안에서 선택할 PostgreSQL major version
+                      이다.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  name:
+                    description: Name 은 catalog 이름이다.
+                    type: string
+                required:
+                - kind
+                - major
+                - name
+                type: object
+              monitoring:
+                description: Monitoring 은 monitoring 통합 설정.
+                properties:
+                  prometheusRule:
+                    description: PrometheusRule 은 알람 규칙 자동 배포.
+                    properties:
+                      enabled:
+                        default: true
+                        description: Enabled 는 PrometheusRule 생성 여부.
+                        type: boolean
+                    type: object
+                  serviceMonitor:
+                    description: ServiceMonitor 는 Prometheus operator ServiceMonitor
+                      자동 배포.
+                    properties:
+                      enabled:
+                        default: true
+                        description: Enabled 는 ServiceMonitor 생성 여부.
+                        type: boolean
+                      interval:
+                        default: 30s
+                        description: 'Interval 은 scrape interval (예: "30s").'
+                        type: string
+                    type: object
+                type: object
+              postgresVersion:
+                default: "18"
+                description: PostgresVersion 은 메이저 버전 문자열. 0.3.0-alpha 는 18 만 GA,
+                  17 호환 유지.
+                enum:
+                - "17"
+                - "18"
+                type: string
+              postgresql:
+                description: |-
+                  PostgreSQL 은 PostgreSQL runtime 설정이다. synchronous_standby_names 같은
+                  직접 설정 금지 GUC 는 이 구조화된 표면으로만 생성한다.
+                properties:
+                  synchronous:
+                    description: Synchronous 는 physical synchronous replication 설정이다.
+                      nil 이면 disabled.
+                    properties:
+                      dataDurability:
+                        allOf:
+                        - enum:
+                          - required
+                          - preferred
+                        - enum:
+                          - required
+                          - preferred
+                        default: required
+                        description: |-
+                          DataDurability 는 replica 부족 시 write 를 block 할지(required), Ready replica
+                          수에 맞춰 quorum 을 낮출지(preferred)를 결정한다.
+                        type: string
+                      method:
+                        description: Method 는 quorum(any) 또는 priority(first) 기반 동기
+                          standby 선택 방식이다.
+                        enum:
+                        - any
+                        - first
+                        type: string
+                      number:
+                        description: Number 는 commit 이 응답을 기다릴 synchronous standby
+                          수다.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                    required:
+                    - method
+                    - number
+                    type: object
+                type: object
+              replica:
+                description: Replica 는 standalone/distributed replica cluster 동작을
+                  정의한다.
+                properties:
+                  enabled:
+                    description: Enabled 는 standalone replica cluster continuous recovery
+                      를 활성화한다.
+                    type: boolean
+                  primary:
+                    description: |-
+                      Primary 는 distributed topology 에서 현재 global primary cluster 이름이다.
+                      0.3.0-alpha 에서는 API 표면만 제공하고 controlled switchover 는 후속 구현이다.
+                    type: string
+                  promotionToken:
+                    description: |-
+                      PromotionToken 은 controlled switchover/promotion 토큰이다.
+                      0.3.0-alpha 에서는 API 표면만 제공한다.
+                    type: string
+                  self:
+                    description: Self 는 resource name 과 다른 topology-local 이름을 쓸 때
+                      지정한다.
+                    type: string
+                  source:
+                    description: Source 는 spec.externalClusters[].name 을 참조한다.
+                    type: string
+                type: object
+              router:
+                description: Router 는 무상태 QueryRouter 풀. shardingMode=native 시에만 의미.
+                properties:
+                  autoscale:
+                    description: Autoscale 은 HPA 설정.
+                    properties:
+                      enabled:
+                        default: false
+                        description: Enabled 는 HPA 부착 여부.
+                        type: boolean
+                      maxReplicas:
+                        description: MaxReplicas 는 HPA 최대 복제본.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      minReplicas:
+                        description: MinReplicas 는 HPA 최소 복제본.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      targetActiveConnections:
+                        default: 1000
+                        description: TargetActiveConnections 는 HPA active connection
+                          목표.
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      targetCPU:
+                        default: 70
+                        description: TargetCPU 는 HPA CPU 사용률 목표 (%).
+                        format: int32
+                        maximum: 100
+                        minimum: 1
+                        type: integer
+                    type: object
+                  enabled:
+                    default: true
+                    description: Enabled 는 라우터 활성화 여부. shardingMode=native 시 default
+                      true.
+                    type: boolean
+                  replicas:
+                    default: 2
+                    description: Replicas 는 라우터 Pod 수. HPA 부착 시 minimum 역할.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  resources:
+                    description: Resources 는 라우터 컨테이너 리소스 요구사항.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              shardingMode:
+                default: none
+                description: ShardingMode 는 단일 샤드 (none) 또는 자체 분산 SQL (native).
+                enum:
+                - none
+                - native
+                type: string
+              shards:
+                description: Shards 는 샤드 토폴로지.
+                properties:
+                  affinity:
+                    description: Affinity 는 샤드 Pod 친화성 규칙.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and subtracting
+                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
+                  initialCount:
+                    description: InitialCount 는 클러스터 초기 샤드 수. P1 GA 는 1 만 보장. 1024
+                      까지 schema 허용.
+                    format: int32
+                    maximum: 1024
+                    minimum: 1
+                    type: integer
+                  priorityClassName:
+                    description: PriorityClassName 은 샤드 Pod priorityClass 명. modern
+                      HA Layer 3 (evict 우선순위).
+                    type: string
+                  replicas:
+                    default: 1
+                    description: Replicas 는 샤드당 비동기 복제본 수 (primary 제외). 0 이면 HA 미구성
+                      (개발용).
+                    format: int32
+                    maximum: 15
+                    minimum: 0
+                    type: integer
+                  resources:
+                    description: Resources 는 샤드 PG 컨테이너 리소스 요구사항.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  storage:
+                    description: Storage 는 샤드 PVC 사양.
+                    properties:
+                      accessModes:
+                        description: AccessModes 는 PVC 접근 모드 (빈 배열이면 ReadWriteOnce).
+                        items:
+                          type: string
+                        type: array
+                      size:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: 'Size 는 PVC 요청 크기 (예: "100Gi").'
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      storageClass:
+                        description: StorageClass 는 PVC StorageClass 이름. 빈 문자열이면 클러스터
+                          디폴트.
+                        type: string
+                    required:
+                    - size
+                    type: object
+                  tolerations:
+                    description: Tolerations 는 샤드 Pod 노드 toleration.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    description: TopologySpreadConstraints 는 샤드 Pod multi-node 분산
+                      정책. modern HA Layer 2 (SPOF 차단).
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: |-
+                            LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine the number of pods
+                            in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        matchLabelKeys:
+                          description: |-
+                            MatchLabelKeys is a set of pod label keys to select the pods over which
+                            spreading will be calculated. The keys are used to lookup values from the
+                            incoming pod labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading will be calculated
+                            for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                            MatchLabelKeys cannot be set when LabelSelector isn't set.
+                            Keys that don't exist in the incoming pod labels will
+                            be ignored. A null or empty list means only match against labelSelector.
+
+                            This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          description: |-
+                            MaxSkew describes the degree to which pods may be unevenly distributed.
+                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                            between the number of matching pods in the target topology and the global minimum.
+                            The global minimum is the minimum number of matching pods in an eligible domain
+                            or zero if the number of eligible domains is less than MinDomains.
+                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                            labelSelector spread as 2/2/1:
+                            In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 |
+                            |  P P  |  P P  |   P   |
+                            - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                            scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                            violate MaxSkew(1).
+                            - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                            When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                            to topologies that satisfy it.
+                            It's a required field. Default value is 1 and 0 is not allowed.
+                          format: int32
+                          type: integer
+                        minDomains:
+                          description: |-
+                            MinDomains indicates a minimum number of eligible domains.
+                            When the number of eligible domains with matching topology keys is less than minDomains,
+                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                            And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                            this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less than minDomains,
+                            scheduler won't schedule more than maxSkew Pods to those domains.
+                            If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                            Valid values are integers greater than 0.
+                            When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                            For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                            labelSelector spread as 2/2/2:
+                            | zone1 | zone2 | zone3 |
+                            |  P P  |  P P  |  P P  |
+                            The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                            In this situation, new pod with the same labelSelector cannot be scheduled,
+                            because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew.
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: |-
+                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                            when calculating pod topology spread skew. Options are:
+                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                            If this value is nil, the behavior is equivalent to the Honor policy.
+                          type: string
+                        nodeTaintsPolicy:
+                          description: |-
+                            NodeTaintsPolicy indicates how we will treat node taints when calculating
+                            pod topology spread skew. Options are:
+                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                            has a toleration, are included.
+                            - Ignore: node taints are ignored. All nodes are included.
+
+                            If this value is nil, the behavior is equivalent to the Ignore policy.
+                          type: string
+                        topologyKey:
+                          description: |-
+                            TopologyKey is the key of node labels. Nodes that have a label with this key
+                            and identical values are considered to be in the same topology.
+                            We consider each <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket.
+                            We define a domain as a particular instance of a topology.
+                            Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                            nodeAffinityPolicy and nodeTaintsPolicy.
+                            e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                            And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                            It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: |-
+                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                            the spread constraint.
+                            - DoNotSchedule (default) tells the scheduler not to schedule it.
+                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                              but giving higher precedence to topologies that would help reduce the
+                              skew.
+                            A constraint is considered "Unsatisfiable" for an incoming pod
+                            if and only if every possible node assignment for that pod would violate
+                            "MaxSkew" on some topology.
+                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                            labelSelector spread as 3/1/1:
+                            | zone1 | zone2 | zone3 |
+                            | P P P |   P   |   P   |
+                            If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                            to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                            MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                            won't make it *more* imbalanced.
+                            It's a required field.
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                required:
+                - initialCount
+                - storage
+                type: object
+              tls:
+                description: |-
+                  TLS 는 PostgreSQL server-side TLS 설정 (Pillar P7 §7).
+                  0.3.0-alpha.5+ Phase 1 facade — CRD field 만 정의. Phase 2 에서 cert-manager
+                  Certificate CR 통합 + Phase 3 에서 reconciler 의 server.crt/server.key emit
+                  만 의미 있음 — true 설정 시 webhook reject (NotImplemented Phase 1).
+                properties:
+                  certSecretName:
+                    description: |-
+                      CertSecretName 은 server cert 가 저장될 Secret 이름. 미설정 시
+                      "<cluster>-tls" default. Phase 2 에서 cert-manager Certificate.spec.secretName
+                      으로 사용됨.
+                    type: string
+                  enabled:
+                    default: false
+                    description: Enabled 는 server-side TLS 활성 여부. Phase 1 에서는 false
+                      만 동작.
+                    type: boolean
+                  issuerRef:
+                    description: |-
+                      IssuerRef 는 cert-manager Issuer 또는 ClusterIssuer 참조.
+                      Phase 2 부터 의미 있음. 미설정 시 self-signed 자체 발급 (Phase 3 default).
+                    properties:
+                      kind:
+                        default: Issuer
+                        description: Kind 는 Issuer 또는 ClusterIssuer.
+                        enum:
+                        - Issuer
+                        - ClusterIssuer
+                        type: string
+                      name:
+                        description: Name 은 Issuer 이름.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+            required:
+            - shards
+            type: object
+            x-kubernetes-validations:
+            - message: native sharding requires shards.initialCount >= 1
+              rule: self.shardingMode != 'native' || self.shards.initialCount >= 1
+            - message: router is only valid when shardingMode=native
+              rule: '!has(self.router) || self.shardingMode == ''native'''
+            - message: autoSplit requires shardingMode=native
+              rule: '!has(self.autoSplit) || self.autoSplit.enabled == false || self.shardingMode
+                == ''native'''
+            - message: postgresql.synchronous.number must be <= shards.replicas
+              rule: '!has(self.postgresql) || !has(self.postgresql.synchronous) ||
+                self.shards.replicas >= self.postgresql.synchronous.number'
+          status:
+            description: PostgresClusterStatus 는 PostgresCluster CR 의 관찰 상태 (RFC 0001
+              §3.2).
+            properties:
+              conditions:
+                description: |-
+                  Conditions 는 K8s 표준 condition 집합.
+                  권장 type: Ready / Progressing / BackupHealthy / AutoSplitEligible / RouterReady.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              managedRolesStatus:
+                description: ManagedRolesStatus 는 이 클러스터를 참조하는 PostgresUser CR 들의
+                  집계 상태다.
+                properties:
+                  byStatus:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: |-
+                      ByStatus 는 상태별 role 이름 목록이다.
+                      대표 상태: reserved, reconciled, pending-reconciliation.
+                    type: object
+                  cannotReconcile:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: CannotReconcile 은 operator 가 자동 복구할 수 없는 role 오류를
+                      role 별로 기록한다.
+                    type: object
+                  passwordStatus:
+                    additionalProperties:
+                      description: ManagedRolePasswordStatus 는 managed role password
+                        반영 상태다.
+                      properties:
+                        observedGeneration:
+                          description: ObservedGeneration 은 password 를 반영한 PostgresUser
+                            generation 이다.
+                          format: int64
+                          type: integer
+                        secretResourceVersion:
+                          description: SecretResourceVersion 은 마지막으로 성공 반영한 password
+                            Secret resourceVersion 이다.
+                          type: string
+                      type: object
+                    description: PasswordStatus 는 password Secret 이 성공 반영된 role 의
+                      Secret revision 을 기록한다.
+                    type: object
+                type: object
+              observedGeneration:
+                description: ObservedGeneration 은 reconciler 가 관측한 spec.metadata.generation.
+                format: int64
+                type: integer
+              phase:
+                description: Phase 는 cluster 의 상위 단계.
+                enum:
+                - Provisioning
+                - Ready
+                - Reconfiguring
+                - Degraded
+                - Hibernated
+                type: string
+              router:
+                description: Router 는 라우터 풀 관찰 상태 (shardingMode=native 시).
+                properties:
+                  endpoint:
+                    description: Endpoint 는 라우터 Service endpoint.
+                    type: string
+                  readyReplicas:
+                    description: ReadyReplicas 는 ready 상태 라우터 Pod 수.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: Replicas 는 desired 라우터 Pod 수.
+                    format: int32
+                    type: integer
+                type: object
+              shards:
+                description: Shards 는 샤드별 관찰 상태 배열 (ordinal 오름차순).
+                items:
+                  description: ShardStatus 는 단일 샤드의 관찰 상태.
+                  properties:
+                    lastSplit:
+                      description: LastSplit 은 마지막 분할 완료 시각. 분할 이력 없음 = nil.
+                      format: date-time
+                      type: string
+                    name:
+                      description: 'Name 은 샤드 식별자 (예: "shard-0").'
+                      type: string
+                    ordinal:
+                      description: Ordinal 은 샤드 순서 (0-based).
+                      format: int32
+                      type: integer
+                    primary:
+                      description: Primary 는 현재 primary endpoint.
+                      properties:
+                        endpoint:
+                          description: Endpoint 는 호스트:포트 형태의 접속 endpoint.
+                          type: string
+                        lagBytes:
+                          description: LagBytes 는 replica 의 WAL lag (bytes). primary
+                            는 0 또는 미설정.
+                          format: int64
+                          type: integer
+                        message:
+                          description: Message 는 endpoint 상태의 human-readable 상세 메시지다.
+                          type: string
+                        pod:
+                          description: Pod 는 K8s Pod 이름.
+                          type: string
+                        ready:
+                          description: Ready 는 readiness 통과 여부.
+                          type: boolean
+                        reason:
+                          description: Reason 은 endpoint 가 Ready=false 또는 degraded
+                            인 machine-readable 원인이다.
+                          type: string
+                      type: object
+                    replicas:
+                      description: Replicas 는 현재 replica endpoint 목록.
+                      items:
+                        description: ShardEndpoint 는 샤드 멤버 (primary 또는 replica) 1
+                          개의 관찰 상태.
+                        properties:
+                          endpoint:
+                            description: Endpoint 는 호스트:포트 형태의 접속 endpoint.
+                            type: string
+                          lagBytes:
+                            description: LagBytes 는 replica 의 WAL lag (bytes). primary
+                              는 0 또는 미설정.
+                            format: int64
+                            type: integer
+                          message:
+                            description: Message 는 endpoint 상태의 human-readable 상세
+                              메시지다.
+                            type: string
+                          pod:
+                            description: Pod 는 K8s Pod 이름.
+                            type: string
+                          ready:
+                            description: Ready 는 readiness 통과 여부.
+                            type: boolean
+                          reason:
+                            description: Reason 은 endpoint 가 Ready=false 또는 degraded
+                              인 machine-readable 원인이다.
+                            type: string
+                        type: object
+                      type: array
+                    sizeBytes:
+                      description: SizeBytes 는 샤드 데이터 크기 (bytes). 0 이면 미관측.
+                      format: int64
+                      type: integer
+                  required:
+                  - name
+                  - ordinal
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_postgresdatabases.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_postgresdatabases.yaml
@@ -1,0 +1,462 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  creationTimestamp: null
+  name: postgresdatabases.postgres.keiailab.io
+spec:
+  group: postgres.keiailab.io
+  names:
+    categories:
+    - postgres
+    - database
+    - all
+    kind: PostgresDatabase
+    listKind: PostgresDatabaseList
+    plural: postgresdatabases
+    shortNames:
+    - pgdb
+    singular: postgresdatabase
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .spec.name
+      name: Database
+      type: string
+    - jsonPath: .spec.owner
+      name: Owner
+      type: string
+    - jsonPath: .status.applied
+      name: Applied
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PostgresDatabaseSpec 은 CNPG Database CRD 의 핵심 운영 표면을 본 operator
+              모델로 이식한다.
+            properties:
+              cluster:
+                description: Cluster 는 database 를 생성할 PostgresCluster 이다.
+                properties:
+                  name:
+                    description: Name 은 PostgresCluster.metadata.name 이다.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              databaseReclaimPolicy:
+                default: retain
+                description: DatabaseReclaimPolicy 는 CR 삭제 시 database 처리 정책이다. 빈 값이면
+                  retain.
+                enum:
+                - retain
+                - delete
+                type: string
+              ensure:
+                default: present
+                description: Ensure 는 database 존재 상태다. 빈 값이면 present.
+                enum:
+                - present
+                - absent
+                type: string
+              extensions:
+                description: Extensions 는 target database 안에서 선언적으로 관리할 extension
+                  목록이다.
+                items:
+                  description: DatabaseExtensionSpec 은 target database 안에서 관리할 extension
+                    이다.
+                  properties:
+                    ensure:
+                      default: present
+                      description: Ensure 는 extension 존재 상태다. 빈 값이면 present.
+                      enum:
+                      - present
+                      - absent
+                      type: string
+                    name:
+                      description: Name 은 PostgreSQL extension 이름이다.
+                      minLength: 1
+                      type: string
+                    schema:
+                      description: Schema 는 extension 을 배치할 schema 다.
+                      type: string
+                    version:
+                      description: Version 은 설치 또는 업그레이드할 extension version 이다.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              fdws:
+                description: FDWs 는 target database 안에서 선언적으로 관리할 foreign data wrapper
+                  목록이다.
+                items:
+                  description: DatabaseFDWSpec 은 target database 안에서 관리할 foreign data
+                    wrapper 이다.
+                  properties:
+                    ensure:
+                      default: present
+                      description: Ensure 는 FDW 존재 상태다. 빈 값이면 present.
+                      enum:
+                      - present
+                      - absent
+                      type: string
+                    handler:
+                      description: Handler 는 FDW handler function 이름이다. "-" 는 NO HANDLER
+                        를 의미한다.
+                      type: string
+                    name:
+                      description: Name 은 foreign data wrapper 이름이다.
+                      minLength: 1
+                      type: string
+                    options:
+                      description: Options 는 FDW option 목록이다.
+                      items:
+                        description: DatabaseOptionSpec 은 FDW/server option 하나의 선언
+                          상태다.
+                        properties:
+                          ensure:
+                            default: present
+                            description: Ensure 는 option 존재 상태다. 빈 값이면 present.
+                            enum:
+                            - present
+                            - absent
+                            type: string
+                          name:
+                            description: Name 은 option 이름이다.
+                            minLength: 1
+                            type: string
+                          value:
+                            description: Value 는 option 값이다. ensure=absent 에서는 생략할
+                              수 있다.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    owner:
+                      description: Owner 는 FDW owner role 이다.
+                      type: string
+                    usage:
+                      description: Usage 는 FDW USAGE 권한 목록이다.
+                      items:
+                        description: DatabaseUsageSpec 은 FDW/server 에 대한 role USAGE
+                          권한 reconcile 항목이다.
+                        properties:
+                          name:
+                            description: Name 은 권한을 부여하거나 회수할 PostgreSQL role 이름이다.
+                            minLength: 1
+                            type: string
+                          type:
+                            default: grant
+                            description: Type 은 grant 또는 revoke 다. 빈 값이면 grant.
+                            enum:
+                            - grant
+                            - revoke
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    validator:
+                      description: Validator 는 FDW validator function 이름이다. "-" 는
+                        NO VALIDATOR 를 의미한다.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              name:
+                description: Name 은 PostgreSQL database 이름이다.
+                minLength: 1
+                type: string
+              owner:
+                description: Owner 는 database owner role 이다.
+                minLength: 1
+                type: string
+              privileges:
+                description: Privileges 는 database 객체 자체에 대한 role privilege grant/revoke
+                  목록이다.
+                items:
+                  description: DatabaseGrantSpec 은 database 또는 schema privilege grant/revoke
+                    항목이다.
+                  properties:
+                    privileges:
+                      description: |-
+                        Privileges 는 대상 객체에 적용할 PostgreSQL privilege 목록이다.
+                        database 대상: CONNECT, CREATE, TEMPORARY, TEMP, ALL PRIVILEGES
+                        schema 대상: USAGE, CREATE, ALL PRIVILEGES
+                      items:
+                        type: string
+                      minItems: 1
+                      type: array
+                    role:
+                      description: Role 은 권한을 부여하거나 회수할 PostgreSQL role 이름이다.
+                      minLength: 1
+                      type: string
+                    type:
+                      default: grant
+                      description: Type 은 grant 또는 revoke 다. 빈 값이면 grant.
+                      enum:
+                      - grant
+                      - revoke
+                      type: string
+                  required:
+                  - privileges
+                  - role
+                  type: object
+                type: array
+              schemas:
+                description: Schemas 는 target database 안에서 선언적으로 관리할 schema 목록이다.
+                items:
+                  description: DatabaseSchemaSpec 은 target database 안에서 관리할 schema
+                    이다.
+                  properties:
+                    ensure:
+                      default: present
+                      description: Ensure 는 schema 존재 상태다. 빈 값이면 present.
+                      enum:
+                      - present
+                      - absent
+                      type: string
+                    name:
+                      description: Name 은 PostgreSQL schema 이름이다.
+                      minLength: 1
+                      type: string
+                    owner:
+                      description: Owner 는 schema owner role 이다.
+                      type: string
+                    privileges:
+                      description: Privileges 는 이 schema 에 대한 role privilege grant/revoke
+                        목록이다.
+                      items:
+                        description: DatabaseGrantSpec 은 database 또는 schema privilege
+                          grant/revoke 항목이다.
+                        properties:
+                          privileges:
+                            description: |-
+                              Privileges 는 대상 객체에 적용할 PostgreSQL privilege 목록이다.
+                              database 대상: CONNECT, CREATE, TEMPORARY, TEMP, ALL PRIVILEGES
+                              schema 대상: USAGE, CREATE, ALL PRIVILEGES
+                            items:
+                              type: string
+                            minItems: 1
+                            type: array
+                          role:
+                            description: Role 은 권한을 부여하거나 회수할 PostgreSQL role 이름이다.
+                            minLength: 1
+                            type: string
+                          type:
+                            default: grant
+                            description: Type 은 grant 또는 revoke 다. 빈 값이면 grant.
+                            enum:
+                            - grant
+                            - revoke
+                            type: string
+                        required:
+                        - privileges
+                        - role
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  type: object
+                type: array
+              servers:
+                description: Servers 는 target database 안에서 선언적으로 관리할 foreign server
+                  목록이다.
+                items:
+                  description: DatabaseServerSpec 은 target database 안에서 관리할 foreign
+                    server 이다.
+                  properties:
+                    ensure:
+                      default: present
+                      description: Ensure 는 server 존재 상태다. 빈 값이면 present.
+                      enum:
+                      - present
+                      - absent
+                      type: string
+                    fdw:
+                      description: FDW 는 이 server 가 사용할 foreign data wrapper 이름이다.
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name 은 foreign server 이름이다.
+                      minLength: 1
+                      type: string
+                    options:
+                      description: Options 는 server option 목록이다.
+                      items:
+                        description: DatabaseOptionSpec 은 FDW/server option 하나의 선언
+                          상태다.
+                        properties:
+                          ensure:
+                            default: present
+                            description: Ensure 는 option 존재 상태다. 빈 값이면 present.
+                            enum:
+                            - present
+                            - absent
+                            type: string
+                          name:
+                            description: Name 은 option 이름이다.
+                            minLength: 1
+                            type: string
+                          value:
+                            description: Value 는 option 값이다. ensure=absent 에서는 생략할
+                              수 있다.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    usage:
+                      description: Usage 는 server USAGE 권한 목록이다.
+                      items:
+                        description: DatabaseUsageSpec 은 FDW/server 에 대한 role USAGE
+                          권한 reconcile 항목이다.
+                        properties:
+                          name:
+                            description: Name 은 권한을 부여하거나 회수할 PostgreSQL role 이름이다.
+                            minLength: 1
+                            type: string
+                          type:
+                            default: grant
+                            description: Type 은 grant 또는 revoke 다. 빈 값이면 grant.
+                            enum:
+                            - grant
+                            - revoke
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                  required:
+                  - fdw
+                  - name
+                  type: object
+                type: array
+              tablespace:
+                description: Tablespace 는 database 의 기본 tablespace 이다.
+                type: string
+            required:
+            - cluster
+            - name
+            - owner
+            type: object
+            x-kubernetes-validations:
+            - message: postgres, template0, template1 are reserved database names
+              rule: self.name != 'postgres' && self.name != 'template0' && self.name
+                != 'template1'
+          status:
+            description: PostgresDatabaseStatus 는 database reconcile 관찰 상태다.
+            properties:
+              applied:
+                description: Applied 는 마지막 observedGeneration 이 PostgreSQL 에 성공적으로
+                  반영됐는지 여부다.
+                type: boolean
+              conditions:
+                description: Conditions 는 K8s 표준 상태다.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              message:
+                description: Message 는 마지막 reconcile 요약 또는 실패 원인이다.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration 은 마지막 처리 generation 이다.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_postgresusers.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_postgresusers.yaml
@@ -1,0 +1,240 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  creationTimestamp: null
+  name: postgresusers.postgres.keiailab.io
+spec:
+  group: postgres.keiailab.io
+  names:
+    categories:
+    - postgres
+    - role
+    - all
+    kind: PostgresUser
+    listKind: PostgresUserList
+    plural: postgresusers
+    shortNames:
+    - pguser
+    singular: postgresuser
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .spec.name
+      name: Role
+      type: string
+    - jsonPath: .spec.login
+      name: Login
+      type: boolean
+    - jsonPath: .status.applied
+      name: Applied
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PostgresUserSpec 은 CNPG managed.roles 의 핵심 운영 표면을 별도 CRD
+              로 제공한다.
+            properties:
+              bypassrls:
+                description: BypassRLS 는 role 이 row-level security 를 우회할 수 있는지 여부다.
+                type: boolean
+              cluster:
+                description: Cluster 는 role 을 생성할 PostgresCluster 이다.
+                properties:
+                  name:
+                    description: Name 은 PostgresCluster.metadata.name 이다.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              connectionLimit:
+                description: ConnectionLimit 은 role connection limit 이다. nil 이면 변경하지
+                  않고, -1 은 제한 없음을 뜻한다.
+                format: int32
+                minimum: -1
+                type: integer
+              createdb:
+                description: CreateDB 는 role 이 CREATEDB 권한을 갖는지 여부다.
+                type: boolean
+              createrole:
+                description: CreateRole 은 role 이 CREATEROLE 권한을 갖는지 여부다.
+                type: boolean
+              disablePassword:
+                description: DisablePassword 는 password 를 NULL 로 설정해 password login
+                  을 비활성화한다.
+                type: boolean
+              ensure:
+                default: present
+                description: Ensure 는 role 존재 상태다. 빈 값이면 present.
+                enum:
+                - present
+                - absent
+                type: string
+              inRoles:
+                description: InRoles 는 이 role 이 member 로 들어갈 parent role 목록이다.
+                items:
+                  type: string
+                type: array
+              inherit:
+                description: Inherit 는 role privilege inheritance 여부다. nil 이면 PostgreSQL
+                  기본값인 true 로 reconcile 한다.
+                type: boolean
+              login:
+                description: Login 은 role 이 LOGIN 권한을 갖는지 여부다.
+                type: boolean
+              name:
+                description: Name 은 PostgreSQL role 이름이다.
+                minLength: 1
+                type: string
+              passwordSecretRef:
+                description: |-
+                  PasswordSecretRef 는 data.username/data.password 값을 PostgreSQL role password 로 반영할 Secret 이다.
+                  data.username 은 spec.name 과 일치해야 한다.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              replication:
+                description: Replication 은 role 이 REPLICATION 권한을 갖는지 여부다.
+                type: boolean
+              superuser:
+                description: Superuser 는 role 이 SUPERUSER 권한을 갖는지 여부다.
+                type: boolean
+              validUntil:
+                description: ValidUntil 은 role password 만료 시각이다. PostgreSQL 이 허용하는
+                  timestamp 또는 infinity 를 사용한다.
+                type: string
+            required:
+            - cluster
+            - name
+            type: object
+            x-kubernetes-validations:
+            - message: postgres and pg_* are reserved role names
+              rule: self.name != 'postgres' && !self.name.startsWith('pg_')
+            - message: passwordSecretRef and disablePassword cannot both be set
+              rule: '!(has(self.passwordSecretRef) && self.disablePassword)'
+          status:
+            description: PostgresUserStatus 는 role reconcile 관찰 상태다.
+            properties:
+              applied:
+                description: Applied 는 마지막 observedGeneration 이 PostgreSQL 에 성공적으로
+                  반영됐는지 여부다.
+                type: boolean
+              conditions:
+                description: Conditions 는 K8s 표준 상태다.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              message:
+                description: Message 는 마지막 reconcile 요약 또는 실패 원인이다.
+                type: string
+              observedGeneration:
+                description: ObservedGeneration 은 마지막 처리 generation 이다.
+                format: int64
+                type: integer
+              passwordSecretResourceVersion:
+                description: PasswordSecretResourceVersion 은 마지막으로 성공 반영한 password
+                  Secret resourceVersion 이다.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_scheduledbackups.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.18/manifests/postgres.keiailab.io_scheduledbackups.yaml
@@ -1,0 +1,9255 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  creationTimestamp: null
+  name: scheduledbackups.postgres.keiailab.io
+spec:
+  group: postgres.keiailab.io
+  names:
+    categories:
+    - postgres
+    - backup
+    - all
+    kind: ScheduledBackup
+    listKind: ScheduledBackupList
+    plural: scheduledbackups
+    shortNames:
+    - sb
+    singular: scheduledbackup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.cluster.name
+      name: Cluster
+      type: string
+    - jsonPath: .spec.schedule
+      name: Schedule
+      type: string
+    - jsonPath: .spec.suspend
+      name: Suspended
+      type: boolean
+    - jsonPath: .status.lastBackupJobName
+      name: LastBackup
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ScheduledBackup 은 cron schedule 에 따라 atomic BackupJob 을 생성한다.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ScheduledBackupSpec 은 cron 기반 정기 백업 정책이다.
+            properties:
+              backupOwnerReference:
+                default: self
+                description: BackupOwnerReference 는 생성된 BackupJob 의 ownerReference
+                  정책이다.
+                enum:
+                - none
+                - self
+                - cluster
+                type: string
+              cluster:
+                description: Cluster 는 백업 대상 PostgresCluster 참조 (같은 namespace).
+                properties:
+                  name:
+                    description: Name은 PostgresCluster.metadata.name.
+                    minLength: 1
+                    type: string
+                required:
+                - name
+                type: object
+              concurrencyPolicy:
+                default: Forbid
+                description: |-
+                  ConcurrencyPolicy 는 이전 BackupJob 이 Running/Pending 일 때 새 실행을 만들지
+                  결정한다.
+                enum:
+                - Allow
+                - Forbid
+                type: string
+              executionMode:
+                description: ExecutionMode 는 생성되는 BackupJob 에 복사되는 실행 모드다.
+                enum:
+                - sidecar
+                - job
+                - ""
+                type: string
+              immediate:
+                default: false
+                description: |-
+                  Immediate=true 이면 ScheduledBackup 생성 후 첫 reconcile 에서 즉시 BackupJob
+                  1건을 만든 뒤, 이후에는 Schedule 기준으로 동작한다.
+                type: boolean
+              jobTemplate:
+                description: |-
+                  JobTemplate 은 ExecutionMode="job"일 때 생성되는 BackupJob 에 복사할 runner
+                  batch/v1 Job 템플릿이다.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata of the jobs created from this template.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    type: object
+                  spec:
+                    description: |-
+                      Specification of the desired behavior of the job.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      activeDeadlineSeconds:
+                        description: |-
+                          Specifies the duration in seconds relative to the startTime that the job
+                          may be continuously active before the system tries to terminate it; value
+                          must be positive integer. If a Job is suspended (at creation or through an
+                          update), this timer will effectively be stopped and reset when the Job is
+                          resumed again.
+                        format: int64
+                        type: integer
+                      backoffLimit:
+                        description: |-
+                          Specifies the number of retries before marking this job failed.
+                          Defaults to 6, unless backoffLimitPerIndex (only Indexed Job) is specified.
+                          When backoffLimitPerIndex is specified, backoffLimit defaults to 2147483647.
+                        format: int32
+                        type: integer
+                      backoffLimitPerIndex:
+                        description: |-
+                          Specifies the limit for the number of retries within an
+                          index before marking this index as failed. When enabled the number of
+                          failures per index is kept in the pod's
+                          batch.kubernetes.io/job-index-failure-count annotation. It can only
+                          be set when Job's completionMode=Indexed, and the Pod's restart
+                          policy is Never. The field is immutable.
+                        format: int32
+                        type: integer
+                      completionMode:
+                        description: |-
+                          completionMode specifies how Pod completions are tracked. It can be
+                          `NonIndexed` (default) or `Indexed`.
+
+                          `NonIndexed` means that the Job is considered complete when there have
+                          been .spec.completions successfully completed Pods. Each Pod completion is
+                          homologous to each other.
+
+                          `Indexed` means that the Pods of a
+                          Job get an associated completion index from 0 to (.spec.completions - 1),
+                          available in the annotation batch.kubernetes.io/job-completion-index.
+                          The Job is considered complete when there is one successfully completed Pod
+                          for each index.
+                          When value is `Indexed`, .spec.completions must be specified and
+                          `.spec.parallelism` must be less than or equal to 10^5.
+                          In addition, The Pod name takes the form
+                          `$(job-name)-$(index)-$(random-string)`,
+                          the Pod hostname takes the form `$(job-name)-$(index)`.
+
+                          More completion modes can be added in the future.
+                          If the Job controller observes a mode that it doesn't recognize, which
+                          is possible during upgrades due to version skew, the controller
+                          skips updates for the Job.
+                        type: string
+                      completions:
+                        description: |-
+                          Specifies the desired number of successfully finished pods the
+                          job should be run with.  Setting to null means that the success of any
+                          pod signals the success of all pods, and allows parallelism to have any positive
+                          value.  Setting to 1 means that parallelism is limited to 1 and the success of that
+                          pod signals the success of the job.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                        format: int32
+                        type: integer
+                      managedBy:
+                        description: |-
+                          ManagedBy field indicates the controller that manages a Job. The k8s Job
+                          controller reconciles jobs which don't have this field at all or the field
+                          value is the reserved string `kubernetes.io/job-controller`, but skips
+                          reconciling Jobs with a custom value for this field.
+                          The value must be a valid domain-prefixed path (e.g. acme.io/foo) -
+                          all characters before the first "/" must be a valid subdomain as defined
+                          by RFC 1123. All characters trailing the first "/" must be valid HTTP Path
+                          characters as defined by RFC 3986. The value cannot exceed 63 characters.
+                          This field is immutable.
+                        type: string
+                      manualSelector:
+                        description: |-
+                          manualSelector controls generation of pod labels and pod selectors.
+                          Leave `manualSelector` unset unless you are certain what you are doing.
+                          When false or unset, the system pick labels unique to this job
+                          and appends those labels to the pod template.  When true,
+                          the user is responsible for picking unique labels and specifying
+                          the selector.  Failure to pick a unique label may cause this
+                          and other jobs to not function correctly.  However, You may see
+                          `manualSelector=true` in jobs that were created with the old `extensions/v1beta1`
+                          API.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector
+                        type: boolean
+                      maxFailedIndexes:
+                        description: |-
+                          Specifies the maximal number of failed indexes before marking the Job as
+                          failed, when backoffLimitPerIndex is set. Once the number of failed
+                          indexes exceeds this number the entire Job is marked as Failed and its
+                          execution is terminated. When left as null the job continues execution of
+                          all of its indexes and is marked with the `Complete` Job condition.
+                          It can only be specified when backoffLimitPerIndex is set.
+                          It can be null or up to completions. It is required and must be
+                          less than or equal to 10^4 when is completions greater than 10^5.
+                        format: int32
+                        type: integer
+                      parallelism:
+                        description: |-
+                          Specifies the maximum desired number of pods the job should
+                          run at any given time. The actual number of pods running in steady state will
+                          be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism),
+                          i.e. when the work left to do is less than max parallelism.
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                        format: int32
+                        type: integer
+                      podFailurePolicy:
+                        description: |-
+                          Specifies the policy of handling failed pods. In particular, it allows to
+                          specify the set of actions and conditions which need to be
+                          satisfied to take the associated action.
+                          If empty, the default behaviour applies - the counter of failed pods,
+                          represented by the jobs's .status.failed field, is incremented and it is
+                          checked against the backoffLimit. This field cannot be used in combination
+                          with restartPolicy=OnFailure.
+                        properties:
+                          rules:
+                            description: |-
+                              A list of pod failure policy rules. The rules are evaluated in order.
+                              Once a rule matches a Pod failure, the remaining of the rules are ignored.
+                              When no rule matches the Pod failure, the default handling applies - the
+                              counter of pod failures is incremented and it is checked against
+                              the backoffLimit. At most 20 elements are allowed.
+                            items:
+                              description: |-
+                                PodFailurePolicyRule describes how a pod failure is handled when the requirements are met.
+                                One of onExitCodes and onPodConditions, but not both, can be used in each rule.
+                              properties:
+                                action:
+                                  description: |-
+                                    Specifies the action taken on a pod failure when the requirements are satisfied.
+                                    Possible values are:
+
+                                    - FailJob: indicates that the pod's job is marked as Failed and all
+                                      running pods are terminated.
+                                    - FailIndex: indicates that the pod's index is marked as Failed and will
+                                      not be restarted.
+                                    - Ignore: indicates that the counter towards the .backoffLimit is not
+                                      incremented and a replacement pod is created.
+                                    - Count: indicates that the pod is handled in the default way - the
+                                      counter towards the .backoffLimit is incremented.
+                                    Additional values are considered to be added in the future. Clients should
+                                    react to an unknown action by skipping the rule.
+                                  type: string
+                                onExitCodes:
+                                  description: Represents the requirement on the container
+                                    exit codes.
+                                  properties:
+                                    containerName:
+                                      description: |-
+                                        Restricts the check for exit codes to the container with the
+                                        specified name. When null, the rule applies to all containers.
+                                        When specified, it should match one the container or initContainer
+                                        names in the pod template.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        Represents the relationship between the container exit code(s) and the
+                                        specified values. Containers completed with success (exit code 0) are
+                                        excluded from the requirement check. Possible values are:
+
+                                        - In: the requirement is satisfied if at least one container exit code
+                                          (might be multiple if there are multiple containers not restricted
+                                          by the 'containerName' field) is in the set of specified values.
+                                        - NotIn: the requirement is satisfied if at least one container exit code
+                                          (might be multiple if there are multiple containers not restricted
+                                          by the 'containerName' field) is not in the set of specified values.
+                                        Additional values are considered to be added in the future. Clients should
+                                        react to an unknown operator by assuming the requirement is not satisfied.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        Specifies the set of values. Each returned container exit code (might be
+                                        multiple in case of multiple containers) is checked against this set of
+                                        values with respect to the operator. The list of values must be ordered
+                                        and must not contain duplicates. Value '0' cannot be used for the In operator.
+                                        At least one element is required. At most 255 elements are allowed.
+                                      items:
+                                        format: int32
+                                        type: integer
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  required:
+                                  - operator
+                                  - values
+                                  type: object
+                                onPodConditions:
+                                  description: |-
+                                    Represents the requirement on the pod conditions. The requirement is represented
+                                    as a list of pod condition patterns. The requirement is satisfied if at
+                                    least one pattern matches an actual pod condition. At most 20 elements are allowed.
+                                  items:
+                                    description: |-
+                                      PodFailurePolicyOnPodConditionsPattern describes a pattern for matching
+                                      an actual pod condition type.
+                                    properties:
+                                      status:
+                                        description: |-
+                                          Specifies the required Pod condition status. To match a pod condition
+                                          it is required that the specified status equals the pod condition status.
+                                          Defaults to True.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          Specifies the required Pod condition type. To match a pod condition
+                                          it is required that specified type equals the pod condition type.
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - action
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - rules
+                        type: object
+                      podReplacementPolicy:
+                        description: |-
+                          podReplacementPolicy specifies when to create replacement Pods.
+                          Possible values are:
+                          - TerminatingOrFailed means that we recreate pods
+                            when they are terminating (has a metadata.deletionTimestamp) or failed.
+                          - Failed means to wait until a previously created Pod is fully terminated (has phase
+                            Failed or Succeeded) before creating a replacement Pod.
+
+                          When using podFailurePolicy, Failed is the the only allowed value.
+                          TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use.
+                        type: string
+                      selector:
+                        description: |-
+                          A label query over pods that should match the pod count.
+                          Normally, the system sets this field for you.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      successPolicy:
+                        description: |-
+                          successPolicy specifies the policy when the Job can be declared as succeeded.
+                          If empty, the default behavior applies - the Job is declared as succeeded
+                          only when the number of succeeded pods equals to the completions.
+                          When the field is specified, it must be immutable and works only for the Indexed Jobs.
+                          Once the Job meets the SuccessPolicy, the lingering pods are terminated.
+                        properties:
+                          rules:
+                            description: |-
+                              rules represents the list of alternative rules for the declaring the Jobs
+                              as successful before `.status.succeeded >= .spec.completions`. Once any of the rules are met,
+                              the "SuccessCriteriaMet" condition is added, and the lingering pods are removed.
+                              The terminal state for such a Job has the "Complete" condition.
+                              Additionally, these rules are evaluated in order; Once the Job meets one of the rules,
+                              other rules are ignored. At most 20 elements are allowed.
+                            items:
+                              description: |-
+                                SuccessPolicyRule describes rule for declaring a Job as succeeded.
+                                Each rule must have at least one of the "succeededIndexes" or "succeededCount" specified.
+                              properties:
+                                succeededCount:
+                                  description: |-
+                                    succeededCount specifies the minimal required size of the actual set of the succeeded indexes
+                                    for the Job. When succeededCount is used along with succeededIndexes, the check is
+                                    constrained only to the set of indexes specified by succeededIndexes.
+                                    For example, given that succeededIndexes is "1-4", succeededCount is "3",
+                                    and completed indexes are "1", "3", and "5", the Job isn't declared as succeeded
+                                    because only "1" and "3" indexes are considered in that rules.
+                                    When this field is null, this doesn't default to any value and
+                                    is never evaluated at any time.
+                                    When specified it needs to be a positive integer.
+                                  format: int32
+                                  type: integer
+                                succeededIndexes:
+                                  description: |-
+                                    succeededIndexes specifies the set of indexes
+                                    which need to be contained in the actual set of the succeeded indexes for the Job.
+                                    The list of indexes must be within 0 to ".spec.completions-1" and
+                                    must not contain duplicates. At least one element is required.
+                                    The indexes are represented as intervals separated by commas.
+                                    The intervals can be a decimal integer or a pair of decimal integers separated by a hyphen.
+                                    The number are listed in represented by the first and last element of the series,
+                                    separated by a hyphen.
+                                    For example, if the completed indexes are 1, 3, 4, 5 and 7, they are
+                                    represented as "1,3-5,7".
+                                    When this field is null, this field doesn't default to any value
+                                    and is never evaluated at any time.
+                                  type: string
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - rules
+                        type: object
+                      suspend:
+                        description: |-
+                          suspend specifies whether the Job controller should create Pods or not. If
+                          a Job is created with suspend set to true, no Pods are created by the Job
+                          controller. If a Job is suspended after creation (i.e. the flag goes from
+                          false to true), the Job controller will delete all active Pods associated
+                          with this Job. Users must design their workload to gracefully handle this.
+                          Suspending a Job will reset the StartTime field of the Job, effectively
+                          resetting the ActiveDeadlineSeconds timer too. Defaults to false.
+                        type: boolean
+                      template:
+                        description: |-
+                          Describes the pod that will be created when executing a job.
+                          The only allowed template.spec.restartPolicy values are "Never" or "OnFailure".
+                          More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                        properties:
+                          metadata:
+                            description: |-
+                              Standard object's metadata.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            type: object
+                          spec:
+                            description: |-
+                              Specification of the desired behavior of the pod.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                            properties:
+                              activeDeadlineSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod may be active on the node relative to
+                                  StartTime before the system will actively try to mark it failed and kill associated containers.
+                                  Value must be a positive integer.
+                                format: int64
+                                type: integer
+                              affinity:
+                                description: If specified, the pod's scheduling constraints
+                                properties:
+                                  nodeAffinity:
+                                    description: Describes node affinity scheduling
+                                      rules for the pod.
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and adding
+                                          "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                          node(s) with the highest sum are the most preferred.
+                                        items:
+                                          description: |-
+                                            An empty preferred scheduling term matches all objects with implicit weight 0
+                                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                          properties:
+                                            preference:
+                                              description: A node selector term, associated
+                                                with the corresponding weight.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            weight:
+                                              description: Weight associated with
+                                                matching the corresponding nodeSelectorTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - preference
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: |-
+                                          If the affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to an update), the system
+                                          may or may not try to eventually evict the pod from its node.
+                                        properties:
+                                          nodeSelectorTerms:
+                                            description: Required. A list of node
+                                              selector terms. The terms are ORed.
+                                            items:
+                                              description: |-
+                                                A null or empty node selector term matches no objects. The requirements of
+                                                them are ANDed.
+                                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                              properties:
+                                                matchExpressions:
+                                                  description: A list of node selector
+                                                    requirements by node's labels.
+                                                  items:
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchFields:
+                                                  description: A list of node selector
+                                                    requirements by node's fields.
+                                                  items:
+                                                    description: |-
+                                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                                      that relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: The label key
+                                                          that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          Represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          An array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                                          array must have a single element, which will be interpreted as an integer.
+                                                          This array is replaced during a strategic merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - nodeSelectorTerms
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  podAffinity:
+                                    description: Describes pod affinity scheduling
+                                      rules (e.g. co-locate this pod in the same node,
+                                      zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and adding
+                                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                          node(s) with the highest sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: |-
+                                                    A label query over a set of resources, in this case pods.
+                                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  description: |-
+                                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                                    be taken into consideration. The keys are used to lookup values from the
+                                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                    to select the group of existing pods which pods will be taken into consideration
+                                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                    pod labels will be ignored. The default value is empty.
+                                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  description: |-
+                                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                    be taken into consideration. The keys are used to lookup values from the
+                                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                    to select the group of existing pods which pods will be taken into consideration
+                                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                    pod labels will be ignored. The default value is empty.
+                                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  description: |-
+                                                    A label query over the set of namespaces that the term applies to.
+                                                    The term is applied to the union of the namespaces selected by this field
+                                                    and the ones listed in the namespaces field.
+                                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                                    An empty selector ({}) matches all namespaces.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  description: |-
+                                                    namespaces specifies a static list of namespace names that the term applies to.
+                                                    The term is applied to the union of the namespaces listed in this field
+                                                    and the ones selected by namespaceSelector.
+                                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  description: |-
+                                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                                    selected pods is running.
+                                                    Empty topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: |-
+                                                weight associated with matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: |-
+                                          If the affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to a pod label update), the
+                                          system may or may not try to eventually evict the pod from its node.
+                                          When there are multiple elements, the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                        items:
+                                          description: |-
+                                            Defines a set of pods (namely those matching the labelSelector
+                                            relative to the given namespace(s)) that this pod should be
+                                            co-located (affinity) or not co-located (anti-affinity) with,
+                                            where co-located is defined as running on a node whose value of
+                                            the label with key <topologyKey> matches that of any node on which
+                                            a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: |-
+                                                A label query over a set of resources, in this case pods.
+                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              description: |-
+                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              description: |-
+                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  podAntiAffinity:
+                                    description: Describes pod anti-affinity scheduling
+                                      rules (e.g. avoid putting this pod in the same
+                                      node, zone, etc. as some other pod(s)).
+                                    properties:
+                                      preferredDuringSchedulingIgnoredDuringExecution:
+                                        description: |-
+                                          The scheduler will prefer to schedule pods to nodes that satisfy
+                                          the anti-affinity expressions specified by this field, but it may choose
+                                          a node that violates one or more of the expressions. The node that is
+                                          most preferred is the one with the greatest sum of weights, i.e.
+                                          for each node that meets all of the scheduling requirements (resource
+                                          request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                          compute a sum by iterating through the elements of this field and subtracting
+                                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                          node(s) with the highest sum are the most preferred.
+                                        items:
+                                          description: The weights of all of the matched
+                                            WeightedPodAffinityTerm fields are added
+                                            per-node to find the most preferred node(s)
+                                          properties:
+                                            podAffinityTerm:
+                                              description: Required. A pod affinity
+                                                term, associated with the corresponding
+                                                weight.
+                                              properties:
+                                                labelSelector:
+                                                  description: |-
+                                                    A label query over a set of resources, in this case pods.
+                                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                matchLabelKeys:
+                                                  description: |-
+                                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                                    be taken into consideration. The keys are used to lookup values from the
+                                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                    to select the group of existing pods which pods will be taken into consideration
+                                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                    pod labels will be ignored. The default value is empty.
+                                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                mismatchLabelKeys:
+                                                  description: |-
+                                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                    be taken into consideration. The keys are used to lookup values from the
+                                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                    to select the group of existing pods which pods will be taken into consideration
+                                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                    pod labels will be ignored. The default value is empty.
+                                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                namespaceSelector:
+                                                  description: |-
+                                                    A label query over the set of namespaces that the term applies to.
+                                                    The term is applied to the union of the namespaces selected by this field
+                                                    and the ones listed in the namespaces field.
+                                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                                    An empty selector ({}) matches all namespaces.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                namespaces:
+                                                  description: |-
+                                                    namespaces specifies a static list of namespace names that the term applies to.
+                                                    The term is applied to the union of the namespaces listed in this field
+                                                    and the ones selected by namespaceSelector.
+                                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                topologyKey:
+                                                  description: |-
+                                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                                    selected pods is running.
+                                                    Empty topologyKey is not allowed.
+                                                  type: string
+                                              required:
+                                              - topologyKey
+                                              type: object
+                                            weight:
+                                              description: |-
+                                                weight associated with matching the corresponding podAffinityTerm,
+                                                in the range 1-100.
+                                              format: int32
+                                              type: integer
+                                          required:
+                                          - podAffinityTerm
+                                          - weight
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      requiredDuringSchedulingIgnoredDuringExecution:
+                                        description: |-
+                                          If the anti-affinity requirements specified by this field are not met at
+                                          scheduling time, the pod will not be scheduled onto the node.
+                                          If the anti-affinity requirements specified by this field cease to be met
+                                          at some point during pod execution (e.g. due to a pod label update), the
+                                          system may or may not try to eventually evict the pod from its node.
+                                          When there are multiple elements, the lists of nodes corresponding to each
+                                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                        items:
+                                          description: |-
+                                            Defines a set of pods (namely those matching the labelSelector
+                                            relative to the given namespace(s)) that this pod should be
+                                            co-located (affinity) or not co-located (anti-affinity) with,
+                                            where co-located is defined as running on a node whose value of
+                                            the label with key <topologyKey> matches that of any node on which
+                                            a pod of the set of pods is running
+                                          properties:
+                                            labelSelector:
+                                              description: |-
+                                                A label query over a set of resources, in this case pods.
+                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              description: |-
+                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              description: |-
+                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is
+                                                    a list of label selector requirements.
+                                                    The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label
+                                                          key that the selector applies
+                                                          to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                type: object
+                              automountServiceAccountToken:
+                                description: AutomountServiceAccountToken indicates
+                                  whether a service account token should be automatically
+                                  mounted.
+                                type: boolean
+                              containers:
+                                description: |-
+                                  List of containers belonging to the pod.
+                                  Containers cannot currently be added or removed.
+                                  There must be at least one container in a Pod.
+                                  Cannot be updated.
+                                items:
+                                  description: A single application container that
+                                    you want to run within a pod.
+                                  properties:
+                                    args:
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The container image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The container image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
+                                      items:
+                                        description: EnvFromSource represents the
+                                          source of a set of ConfigMaps or Secrets
+                                        properties:
+                                          configMapRef:
+                                            description: The ConfigMap to select from
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            description: |-
+                                              Optional text to prepend to the name of each environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          secretRef:
+                                            description: The Secret to select from
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      description: |-
+                                        Container image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level config management to default or override
+                                        container images in workload controllers like Deployments and StatefulSets.
+                                      type: string
+                                    imagePullPolicy:
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                      type: string
+                                    lifecycle:
+                                      description: |-
+                                        Actions that the management system should take in response to container lifecycle events.
+                                        Cannot be updated.
+                                      properties:
+                                        postStart:
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                          properties:
+                                            exec:
+                                              description: Exec specifies a command
+                                                to execute in the container.
+                                              properties:
+                                                command:
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
+                                              properties:
+                                                host:
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                          properties:
+                                            exec:
+                                              description: Exec specifies a command
+                                                to execute in the container.
+                                              properties:
+                                                command:
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
+                                              properties:
+                                                host:
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        stopSignal:
+                                          description: |-
+                                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                                            If not specified, the default is defined by the container runtime in use.
+                                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                          type: string
+                                      type: object
+                                    livenessProbe:
+                                      description: |-
+                                        Periodic probe of container liveness.
+                                        Container will be restarted if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      description: |-
+                                        Name of the container specified as a DNS_LABEL.
+                                        Each container in a pod must have a unique name (DNS_LABEL).
+                                        Cannot be updated.
+                                      type: string
+                                    ports:
+                                      description: |-
+                                        List of ports to expose from the container. Not specifying a port here
+                                        DOES NOT prevent that port from being exposed. Any port which is
+                                        listening on the default "0.0.0.0" address inside a container will be
+                                        accessible from the network.
+                                        Modifying this array with strategic merge patch may corrupt the data.
+                                        For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                        Cannot be updated.
+                                      items:
+                                        description: ContainerPort represents a network
+                                          port in a single container.
+                                        properties:
+                                          containerPort:
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            description: What host IP to bind the
+                                              external port to.
+                                            type: string
+                                          hostPort:
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      description: |-
+                                        Periodic probe of container service readiness.
+                                        Container will be removed from service endpoints if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      description: |-
+                                        Resources resize policy for the container.
+                                        This field cannot be set on ephemeral containers.
+                                      items:
+                                        description: ContainerResizePolicy represents
+                                          resource resize policy for the container.
+                                        properties:
+                                          resourceName:
+                                            description: |-
+                                              Name of the resource to which this resource resize policy applies.
+                                              Supported values: cpu, memory.
+                                            type: string
+                                          restartPolicy:
+                                            description: |-
+                                              Restart policy to apply when specified resource is resized.
+                                              If not specified, it defaults to NotRequired.
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      description: |-
+                                        Compute Resources required by this container.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      properties:
+                                        claims:
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+                                            This field depends on the
+                                            DynamicResourceAllocation feature gate.
+
+                                            This field is immutable. It can only be set for containers.
+                                          items:
+                                            description: ResourceClaim references
+                                              one entry in PodSpec.ResourceClaims.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                                  the Pod where this field is used. It makes that resource available
+                                                  inside a container.
+                                                type: string
+                                              request:
+                                                description: |-
+                                                  Request is the name chosen for a request in the referenced claim.
+                                                  If empty, everything from the claim is made available, otherwise
+                                                  only the result of this request.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      description: |-
+                                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                                        This overrides the pod-level restart policy. When this field is not specified,
+                                        the restart behavior is defined by the Pod's restart policy and the container type.
+                                        Additionally, setting the RestartPolicy as "Always" for the init container will
+                                        have the following effect:
+                                        this init container will be continually restarted on
+                                        exit until all regular containers have terminated. Once all regular
+                                        containers have completed, all init containers with restartPolicy "Always"
+                                        will be shut down. This lifecycle differs from normal init containers and
+                                        is often referred to as a "sidecar" container. Although this init
+                                        container still starts in the init container sequence, it does not wait
+                                        for the container to complete before proceeding to the next init
+                                        container. Instead, the next init container starts immediately after this
+                                        init container is started, or after any startupProbe has successfully
+                                        completed.
+                                      type: string
+                                    restartPolicyRules:
+                                      description: |-
+                                        Represents a list of rules to be checked to determine if the
+                                        container should be restarted on exit. The rules are evaluated in
+                                        order. Once a rule matches a container exit condition, the remaining
+                                        rules are ignored. If no rule matches the container exit condition,
+                                        the Container-level restart policy determines the whether the container
+                                        is restarted or not. Constraints on the rules:
+                                        - At most 20 rules are allowed.
+                                        - Rules can have the same action.
+                                        - Identical rules are not forbidden in validations.
+                                        When rules are specified, container MUST set RestartPolicy explicitly
+                                        even it if matches the Pod's RestartPolicy.
+                                      items:
+                                        description: ContainerRestartRule describes
+                                          how a container exit is handled.
+                                        properties:
+                                          action:
+                                            description: |-
+                                              Specifies the action taken on a container exit if the requirements
+                                              are satisfied. The only possible value is "Restart" to restart the
+                                              container.
+                                            type: string
+                                          exitCodes:
+                                            description: Represents the exit codes
+                                              to check on container exits.
+                                            properties:
+                                              operator:
+                                                description: |-
+                                                  Represents the relationship between the container exit code(s) and the
+                                                  specified values. Possible values are:
+                                                  - In: the requirement is satisfied if the container exit code is in the
+                                                    set of specified values.
+                                                  - NotIn: the requirement is satisfied if the container exit code is
+                                                    not in the set of specified values.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  Specifies the set of values to check for container exit codes.
+                                                  At most 255 elements are allowed.
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    securityContext:
+                                      description: |-
+                                        SecurityContext defines the security options the container should be run with.
+                                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        appArmorProfile:
+                                          description: |-
+                                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                            overrides the pod's appArmorProfile.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile loaded on the node that should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must match the loaded name of the profile.
+                                                Must be set if and only if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of AppArmor profile will be applied.
+                                                Valid options are:
+                                                  Localhost - a profile pre-loaded on the node.
+                                                  RuntimeDefault - the container runtime's default profile.
+                                                  Unconfined - no AppArmor enforcement.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        procMount:
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default value is Default which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      description: |-
+                                        StartupProbe indicates that the Pod has successfully initialized.
+                                        If specified, no other probes are executed until this completes successfully.
+                                        If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                        This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                        when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                        This cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
+                                      type: boolean
+                                    stdinOnce:
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
+                                      type: boolean
+                                    terminationMessagePath:
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
+                                      type: string
+                                    terminationMessagePolicy:
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
+                                      type: string
+                                    tty:
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
+                                      type: boolean
+                                    volumeDevices:
+                                      description: volumeDevices is the list of block
+                                        devices to be used by the container.
+                                      items:
+                                        description: volumeDevice describes a mapping
+                                          of a raw block device within a container.
+                                        properties:
+                                          devicePath:
+                                            description: devicePath is the path inside
+                                              of the container that the device will
+                                              be mapped to.
+                                            type: string
+                                          name:
+                                            description: name must match the name
+                                              of a persistentVolumeClaim in the pod
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem.
+                                        Cannot be updated.
+                                      items:
+                                        description: VolumeMount describes a mounting
+                                          of a Volume within a container.
+                                        properties:
+                                          mountPath:
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
+                                              not contain ':'.
+                                            type: string
+                                          mountPropagation:
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
+                                              to container and the other way around.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
+                                              When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                              (which defaults to None).
+                                            type: string
+                                          name:
+                                            description: This must match the Name
+                                              of a Volume.
+                                            type: string
+                                          readOnly:
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                                              Defaults to false.
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            description: |-
+                                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                                              recursively.
+
+                                              If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                              If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                              recursively read-only.  If this field is set to IfPossible, the mount is made
+                                              recursively read-only, if it is supported by the container runtime.  If this
+                                              field is set to Enabled, the mount is made recursively read-only if it is
+                                              supported by the container runtime, otherwise the pod will not be started and
+                                              an error will be generated to indicate the reason.
+
+                                              If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                              None (or be unspecified, which defaults to None).
+
+                                              If this field is not specified, it is treated as an equivalent of Disabled.
+                                            type: string
+                                          subPath:
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
+                                            type: string
+                                          subPathExpr:
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              dnsConfig:
+                                description: |-
+                                  Specifies the DNS parameters of a pod.
+                                  Parameters specified here will be merged to the generated DNS
+                                  configuration based on DNSPolicy.
+                                properties:
+                                  nameservers:
+                                    description: |-
+                                      A list of DNS name server IP addresses.
+                                      This will be appended to the base nameservers generated from DNSPolicy.
+                                      Duplicated nameservers will be removed.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  options:
+                                    description: |-
+                                      A list of DNS resolver options.
+                                      This will be merged with the base options generated from DNSPolicy.
+                                      Duplicated entries will be removed. Resolution options given in Options
+                                      will override those that appear in the base DNSPolicy.
+                                    items:
+                                      description: PodDNSConfigOption defines DNS
+                                        resolver options of a pod.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name is this DNS resolver option's name.
+                                            Required.
+                                          type: string
+                                        value:
+                                          description: Value is this DNS resolver
+                                            option's value.
+                                          type: string
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  searches:
+                                    description: |-
+                                      A list of DNS search domains for host-name lookup.
+                                      This will be appended to the base search paths generated from DNSPolicy.
+                                      Duplicated search paths will be removed.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              dnsPolicy:
+                                description: |-
+                                  Set DNS policy for the pod.
+                                  Defaults to "ClusterFirst".
+                                  Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                                  DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                                  To have DNS options set along with hostNetwork, you have to specify DNS policy
+                                  explicitly to 'ClusterFirstWithHostNet'.
+                                type: string
+                              enableServiceLinks:
+                                description: |-
+                                  EnableServiceLinks indicates whether information about services should be injected into pod's
+                                  environment variables, matching the syntax of Docker links.
+                                  Optional: Defaults to true.
+                                type: boolean
+                              ephemeralContainers:
+                                description: |-
+                                  List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                                  pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                                  creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                                  ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
+                                items:
+                                  description: |-
+                                    An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                    user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                    scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                    removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                    Pod to exceed its resource allocation.
+
+                                    To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+                                    Pod. Ephemeral containers may not be removed or restarted.
+                                  properties:
+                                    args:
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
+                                      items:
+                                        description: EnvFromSource represents the
+                                          source of a set of ConfigMaps or Secrets
+                                        properties:
+                                          configMapRef:
+                                            description: The ConfigMap to select from
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            description: |-
+                                              Optional text to prepend to the name of each environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          secretRef:
+                                            description: The Secret to select from
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      description: |-
+                                        Container image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                      type: string
+                                    imagePullPolicy:
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                      type: string
+                                    lifecycle:
+                                      description: Lifecycle is not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        postStart:
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                          properties:
+                                            exec:
+                                              description: Exec specifies a command
+                                                to execute in the container.
+                                              properties:
+                                                command:
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
+                                              properties:
+                                                host:
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                          properties:
+                                            exec:
+                                              description: Exec specifies a command
+                                                to execute in the container.
+                                              properties:
+                                                command:
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
+                                              properties:
+                                                host:
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        stopSignal:
+                                          description: |-
+                                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                                            If not specified, the default is defined by the container runtime in use.
+                                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                          type: string
+                                      type: object
+                                    livenessProbe:
+                                      description: Probes are not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      description: |-
+                                        Name of the ephemeral container specified as a DNS_LABEL.
+                                        This name must be unique among all containers, init containers and ephemeral containers.
+                                      type: string
+                                    ports:
+                                      description: Ports are not allowed for ephemeral
+                                        containers.
+                                      items:
+                                        description: ContainerPort represents a network
+                                          port in a single container.
+                                        properties:
+                                          containerPort:
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            description: What host IP to bind the
+                                              external port to.
+                                            type: string
+                                          hostPort:
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      description: Probes are not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      description: Resources resize policy for the
+                                        container.
+                                      items:
+                                        description: ContainerResizePolicy represents
+                                          resource resize policy for the container.
+                                        properties:
+                                          resourceName:
+                                            description: |-
+                                              Name of the resource to which this resource resize policy applies.
+                                              Supported values: cpu, memory.
+                                            type: string
+                                          restartPolicy:
+                                            description: |-
+                                              Restart policy to apply when specified resource is resized.
+                                              If not specified, it defaults to NotRequired.
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      description: |-
+                                        Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
+                                        already allocated to the pod.
+                                      properties:
+                                        claims:
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+                                            This field depends on the
+                                            DynamicResourceAllocation feature gate.
+
+                                            This field is immutable. It can only be set for containers.
+                                          items:
+                                            description: ResourceClaim references
+                                              one entry in PodSpec.ResourceClaims.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                                  the Pod where this field is used. It makes that resource available
+                                                  inside a container.
+                                                type: string
+                                              request:
+                                                description: |-
+                                                  Request is the name chosen for a request in the referenced claim.
+                                                  If empty, everything from the claim is made available, otherwise
+                                                  only the result of this request.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      description: |-
+                                        Restart policy for the container to manage the restart behavior of each
+                                        container within a pod.
+                                        You cannot set this field on ephemeral containers.
+                                      type: string
+                                    restartPolicyRules:
+                                      description: |-
+                                        Represents a list of rules to be checked to determine if the
+                                        container should be restarted on exit. You cannot set this field on
+                                        ephemeral containers.
+                                      items:
+                                        description: ContainerRestartRule describes
+                                          how a container exit is handled.
+                                        properties:
+                                          action:
+                                            description: |-
+                                              Specifies the action taken on a container exit if the requirements
+                                              are satisfied. The only possible value is "Restart" to restart the
+                                              container.
+                                            type: string
+                                          exitCodes:
+                                            description: Represents the exit codes
+                                              to check on container exits.
+                                            properties:
+                                              operator:
+                                                description: |-
+                                                  Represents the relationship between the container exit code(s) and the
+                                                  specified values. Possible values are:
+                                                  - In: the requirement is satisfied if the container exit code is in the
+                                                    set of specified values.
+                                                  - NotIn: the requirement is satisfied if the container exit code is
+                                                    not in the set of specified values.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  Specifies the set of values to check for container exit codes.
+                                                  At most 255 elements are allowed.
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    securityContext:
+                                      description: |-
+                                        Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        appArmorProfile:
+                                          description: |-
+                                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                            overrides the pod's appArmorProfile.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile loaded on the node that should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must match the loaded name of the profile.
+                                                Must be set if and only if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of AppArmor profile will be applied.
+                                                Valid options are:
+                                                  Localhost - a profile pre-loaded on the node.
+                                                  RuntimeDefault - the container runtime's default profile.
+                                                  Unconfined - no AppArmor enforcement.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        procMount:
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default value is Default which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      description: Probes are not allowed for ephemeral
+                                        containers.
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
+                                      type: boolean
+                                    stdinOnce:
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
+                                      type: boolean
+                                    targetContainerName:
+                                      description: |-
+                                        If set, the name of the container from PodSpec that this ephemeral container targets.
+                                        The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                        If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+                                        The container runtime must implement support for this feature. If the runtime does not
+                                        support namespace targeting then the result of setting this field is undefined.
+                                      type: string
+                                    terminationMessagePath:
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
+                                      type: string
+                                    terminationMessagePolicy:
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
+                                      type: string
+                                    tty:
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
+                                      type: boolean
+                                    volumeDevices:
+                                      description: volumeDevices is the list of block
+                                        devices to be used by the container.
+                                      items:
+                                        description: volumeDevice describes a mapping
+                                          of a raw block device within a container.
+                                        properties:
+                                          devicePath:
+                                            description: devicePath is the path inside
+                                              of the container that the device will
+                                              be mapped to.
+                                            type: string
+                                          name:
+                                            description: name must match the name
+                                              of a persistentVolumeClaim in the pod
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                        Cannot be updated.
+                                      items:
+                                        description: VolumeMount describes a mounting
+                                          of a Volume within a container.
+                                        properties:
+                                          mountPath:
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
+                                              not contain ':'.
+                                            type: string
+                                          mountPropagation:
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
+                                              to container and the other way around.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
+                                              When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                              (which defaults to None).
+                                            type: string
+                                          name:
+                                            description: This must match the Name
+                                              of a Volume.
+                                            type: string
+                                          readOnly:
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                                              Defaults to false.
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            description: |-
+                                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                                              recursively.
+
+                                              If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                              If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                              recursively read-only.  If this field is set to IfPossible, the mount is made
+                                              recursively read-only, if it is supported by the container runtime.  If this
+                                              field is set to Enabled, the mount is made recursively read-only if it is
+                                              supported by the container runtime, otherwise the pod will not be started and
+                                              an error will be generated to indicate the reason.
+
+                                              If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                              None (or be unspecified, which defaults to None).
+
+                                              If this field is not specified, it is treated as an equivalent of Disabled.
+                                            type: string
+                                          subPath:
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
+                                            type: string
+                                          subPathExpr:
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              hostAliases:
+                                description: |-
+                                  HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                  file if specified.
+                                items:
+                                  description: |-
+                                    HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                    pod's hosts file.
+                                  properties:
+                                    hostnames:
+                                      description: Hostnames for the above IP address.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    ip:
+                                      description: IP address of the host file entry.
+                                      type: string
+                                  required:
+                                  - ip
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - ip
+                                x-kubernetes-list-type: map
+                              hostIPC:
+                                description: |-
+                                  Use the host's ipc namespace.
+                                  Optional: Default to false.
+                                type: boolean
+                              hostNetwork:
+                                description: |-
+                                  Host networking requested for this pod. Use the host's network namespace.
+                                  When using HostNetwork you should specify ports so the scheduler is aware.
+                                  When `hostNetwork` is true, specified `hostPort` fields in port definitions must match `containerPort`,
+                                  and unspecified `hostPort` fields in port definitions are defaulted to match `containerPort`.
+                                  Default to false.
+                                type: boolean
+                              hostPID:
+                                description: |-
+                                  Use the host's pid namespace.
+                                  Optional: Default to false.
+                                type: boolean
+                              hostUsers:
+                                description: |-
+                                  Use the host's user namespace.
+                                  Optional: Default to true.
+                                  If set to true or not present, the pod will be run in the host user namespace, useful
+                                  for when the pod needs a feature only available to the host user namespace, such as
+                                  loading a kernel module with CAP_SYS_MODULE.
+                                  When set to false, a new userns is created for the pod. Setting false is useful for
+                                  mitigating container breakout vulnerabilities even allowing users to run their
+                                  containers as root without actually having root privileges on the host.
+                                  This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
+                                type: boolean
+                              hostname:
+                                description: |-
+                                  Specifies the hostname of the Pod
+                                  If not specified, the pod's hostname will be set to a system-defined value.
+                                type: string
+                              hostnameOverride:
+                                description: |-
+                                  HostnameOverride specifies an explicit override for the pod's hostname as perceived by the pod.
+                                  This field only specifies the pod's hostname and does not affect its DNS records.
+                                  When this field is set to a non-empty string:
+                                  - It takes precedence over the values set in `hostname` and `subdomain`.
+                                  - The Pod's hostname will be set to this value.
+                                  - `setHostnameAsFQDN` must be nil or set to false.
+                                  - `hostNetwork` must be set to false.
+
+                                  This field must be a valid DNS subdomain as defined in RFC 1123 and contain at most 64 characters.
+                                  Requires the HostnameOverride feature gate to be enabled.
+                                type: string
+                              imagePullSecrets:
+                                description: |-
+                                  ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                  If specified, these secrets will be passed to individual puller implementations for them to use.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                items:
+                                  description: |-
+                                    LocalObjectReference contains enough information to let you locate the
+                                    referenced object inside the same namespace.
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              initContainers:
+                                description: |-
+                                  List of initialization containers belonging to the pod.
+                                  Init containers are executed in order prior to containers being started. If any
+                                  init container fails, the pod is considered to have failed and is handled according
+                                  to its restartPolicy. The name for an init container or normal container must be
+                                  unique among all containers.
+                                  Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                                  The resourceRequirements of an init container are taken into account during scheduling
+                                  by finding the highest request/limit for each resource type, and then using the max of
+                                  that value or the sum of the normal containers. Limits are applied to init containers
+                                  in a similar fashion.
+                                  Init containers cannot currently be added or removed.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                                items:
+                                  description: A single application container that
+                                    you want to run within a pod.
+                                  properties:
+                                    args:
+                                      description: |-
+                                        Arguments to the entrypoint.
+                                        The container image's CMD is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    command:
+                                      description: |-
+                                        Entrypoint array. Not executed within a shell.
+                                        The container image's ENTRYPOINT is used if this is not provided.
+                                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                        of whether the variable exists or not. Cannot be updated.
+                                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    env:
+                                      description: |-
+                                        List of environment variables to set in the container.
+                                        Cannot be updated.
+                                      items:
+                                        description: EnvVar represents an environment
+                                          variable present in a Container.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          value:
+                                            description: |-
+                                              Variable references $(VAR_NAME) are expanded
+                                              using the previously defined environment variables in the container and
+                                              any service environment variables. If a variable cannot be resolved,
+                                              the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                              Escaped references will never be expanded, regardless of whether the variable
+                                              exists or not.
+                                              Defaults to "".
+                                            type: string
+                                          valueFrom:
+                                            description: Source for the environment
+                                              variable's value. Cannot be used if
+                                              value is not empty.
+                                            properties:
+                                              configMapKeyRef:
+                                                description: Selects a key of a ConfigMap.
+                                                properties:
+                                                  key:
+                                                    description: The key to select.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      ConfigMap or its key must be
+                                                      defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fieldRef:
+                                                description: |-
+                                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              fileKeyRef:
+                                                description: |-
+                                                  FileKeyRef selects a key of the env file.
+                                                  Requires the EnvFiles feature gate to be enabled.
+                                                properties:
+                                                  key:
+                                                    description: |-
+                                                      The key within the env file. An invalid key will prevent the pod from starting.
+                                                      The keys defined within a source may consist of any printable ASCII characters except '='.
+                                                      During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                                    type: string
+                                                  optional:
+                                                    default: false
+                                                    description: |-
+                                                      Specify whether the file or its key must be defined. If the file or key
+                                                      does not exist, then the env var is not published.
+                                                      If optional is set to true and the specified key does not exist,
+                                                      the environment variable will not be set in the Pod's containers.
+
+                                                      If optional is set to false and the specified key does not exist,
+                                                      an error will be returned during Pod creation.
+                                                    type: boolean
+                                                  path:
+                                                    description: |-
+                                                      The path within the volume from which to select the file.
+                                                      Must be relative and may not contain the '..' path or start with '..'.
+                                                    type: string
+                                                  volumeName:
+                                                    description: The name of the volume
+                                                      mount containing the env file.
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                - volumeName
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              secretKeyRef:
+                                                description: Selects a key of a secret
+                                                  in the pod's namespace
+                                                properties:
+                                                  key:
+                                                    description: The key of the secret
+                                                      to select from.  Must be a valid
+                                                      secret key.
+                                                    type: string
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: Specify whether the
+                                                      Secret or its key must be defined
+                                                    type: boolean
+                                                required:
+                                                - key
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    envFrom:
+                                      description: |-
+                                        List of sources to populate environment variables in the container.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        When a key exists in multiple
+                                        sources, the value associated with the last source will take precedence.
+                                        Values defined by an Env with a duplicate key will take precedence.
+                                        Cannot be updated.
+                                      items:
+                                        description: EnvFromSource represents the
+                                          source of a set of ConfigMaps or Secrets
+                                        properties:
+                                          configMapRef:
+                                            description: The ConfigMap to select from
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          prefix:
+                                            description: |-
+                                              Optional text to prepend to the name of each environment variable.
+                                              May consist of any printable ASCII characters except '='.
+                                            type: string
+                                          secretRef:
+                                            description: The Secret to select from
+                                            properties:
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret
+                                                  must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    image:
+                                      description: |-
+                                        Container image name.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level config management to default or override
+                                        container images in workload controllers like Deployments and StatefulSets.
+                                      type: string
+                                    imagePullPolicy:
+                                      description: |-
+                                        Image pull policy.
+                                        One of Always, Never, IfNotPresent.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                      type: string
+                                    lifecycle:
+                                      description: |-
+                                        Actions that the management system should take in response to container lifecycle events.
+                                        Cannot be updated.
+                                      properties:
+                                        postStart:
+                                          description: |-
+                                            PostStart is called immediately after a container is created. If the handler fails,
+                                            the container is terminated and restarted according to its restart policy.
+                                            Other management of the container blocks until the hook completes.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                          properties:
+                                            exec:
+                                              description: Exec specifies a command
+                                                to execute in the container.
+                                              properties:
+                                                command:
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
+                                              properties:
+                                                host:
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        preStop:
+                                          description: |-
+                                            PreStop is called immediately before a container is terminated due to an
+                                            API request or management event such as liveness/startup probe failure,
+                                            preemption, resource contention, etc. The handler is not called if the
+                                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                                            container will eventually terminate within the Pod's termination grace
+                                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                            or until the termination grace period is reached.
+                                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                          properties:
+                                            exec:
+                                              description: Exec specifies a command
+                                                to execute in the container.
+                                              properties:
+                                                command:
+                                                  description: |-
+                                                    Command is the command line to execute inside the container, the working directory for the
+                                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                    a shell, you need to explicitly call out to that shell.
+                                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            httpGet:
+                                              description: HTTPGet specifies an HTTP
+                                                GET request to perform.
+                                              properties:
+                                                host:
+                                                  description: |-
+                                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                                    "Host" in httpHeaders instead.
+                                                  type: string
+                                                httpHeaders:
+                                                  description: Custom headers to set
+                                                    in the request. HTTP allows repeated
+                                                    headers.
+                                                  items:
+                                                    description: HTTPHeader describes
+                                                      a custom header to be used in
+                                                      HTTP probes
+                                                    properties:
+                                                      name:
+                                                        description: |-
+                                                          The header field name.
+                                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                        type: string
+                                                      value:
+                                                        description: The header field
+                                                          value
+                                                        type: string
+                                                    required:
+                                                    - name
+                                                    - value
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                path:
+                                                  description: Path to access on the
+                                                    HTTP server.
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Name or number of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                                scheme:
+                                                  description: |-
+                                                    Scheme to use for connecting to the host.
+                                                    Defaults to HTTP.
+                                                  type: string
+                                              required:
+                                              - port
+                                              type: object
+                                            sleep:
+                                              description: Sleep represents a duration
+                                                that the container should sleep.
+                                              properties:
+                                                seconds:
+                                                  description: Seconds is the number
+                                                    of seconds to sleep.
+                                                  format: int64
+                                                  type: integer
+                                              required:
+                                              - seconds
+                                              type: object
+                                            tcpSocket:
+                                              description: |-
+                                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                for backward compatibility. There is no validation of this field and
+                                                lifecycle hooks will fail at runtime when it is specified.
+                                              properties:
+                                                host:
+                                                  description: 'Optional: Host name
+                                                    to connect to, defaults to the
+                                                    pod IP.'
+                                                  type: string
+                                                port:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: |-
+                                                    Number or name of the port to access on the container.
+                                                    Number must be in the range 1 to 65535.
+                                                    Name must be an IANA_SVC_NAME.
+                                                  x-kubernetes-int-or-string: true
+                                              required:
+                                              - port
+                                              type: object
+                                          type: object
+                                        stopSignal:
+                                          description: |-
+                                            StopSignal defines which signal will be sent to a container when it is being stopped.
+                                            If not specified, the default is defined by the container runtime in use.
+                                            StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                          type: string
+                                      type: object
+                                    livenessProbe:
+                                      description: |-
+                                        Periodic probe of container liveness.
+                                        Container will be restarted if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    name:
+                                      description: |-
+                                        Name of the container specified as a DNS_LABEL.
+                                        Each container in a pod must have a unique name (DNS_LABEL).
+                                        Cannot be updated.
+                                      type: string
+                                    ports:
+                                      description: |-
+                                        List of ports to expose from the container. Not specifying a port here
+                                        DOES NOT prevent that port from being exposed. Any port which is
+                                        listening on the default "0.0.0.0" address inside a container will be
+                                        accessible from the network.
+                                        Modifying this array with strategic merge patch may corrupt the data.
+                                        For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                        Cannot be updated.
+                                      items:
+                                        description: ContainerPort represents a network
+                                          port in a single container.
+                                        properties:
+                                          containerPort:
+                                            description: |-
+                                              Number of port to expose on the pod's IP address.
+                                              This must be a valid port number, 0 < x < 65536.
+                                            format: int32
+                                            type: integer
+                                          hostIP:
+                                            description: What host IP to bind the
+                                              external port to.
+                                            type: string
+                                          hostPort:
+                                            description: |-
+                                              Number of port to expose on the host.
+                                              If specified, this must be a valid port number, 0 < x < 65536.
+                                              If HostNetwork is specified, this must match ContainerPort.
+                                              Most containers do not need this.
+                                            format: int32
+                                            type: integer
+                                          name:
+                                            description: |-
+                                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                              named port in a pod must have a unique name. Name for the port that can be
+                                              referred to by services.
+                                            type: string
+                                          protocol:
+                                            default: TCP
+                                            description: |-
+                                              Protocol for port. Must be UDP, TCP, or SCTP.
+                                              Defaults to "TCP".
+                                            type: string
+                                        required:
+                                        - containerPort
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - containerPort
+                                      - protocol
+                                      x-kubernetes-list-type: map
+                                    readinessProbe:
+                                      description: |-
+                                        Periodic probe of container service readiness.
+                                        Container will be removed from service endpoints if the probe fails.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    resizePolicy:
+                                      description: |-
+                                        Resources resize policy for the container.
+                                        This field cannot be set on ephemeral containers.
+                                      items:
+                                        description: ContainerResizePolicy represents
+                                          resource resize policy for the container.
+                                        properties:
+                                          resourceName:
+                                            description: |-
+                                              Name of the resource to which this resource resize policy applies.
+                                              Supported values: cpu, memory.
+                                            type: string
+                                          restartPolicy:
+                                            description: |-
+                                              Restart policy to apply when specified resource is resized.
+                                              If not specified, it defaults to NotRequired.
+                                            type: string
+                                        required:
+                                        - resourceName
+                                        - restartPolicy
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    resources:
+                                      description: |-
+                                        Compute Resources required by this container.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      properties:
+                                        claims:
+                                          description: |-
+                                            Claims lists the names of resources, defined in spec.resourceClaims,
+                                            that are used by this container.
+
+                                            This field depends on the
+                                            DynamicResourceAllocation feature gate.
+
+                                            This field is immutable. It can only be set for containers.
+                                          items:
+                                            description: ResourceClaim references
+                                              one entry in PodSpec.ResourceClaims.
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                                  the Pod where this field is used. It makes that resource available
+                                                  inside a container.
+                                                type: string
+                                              request:
+                                                description: |-
+                                                  Request is the name chosen for a request in the referenced claim.
+                                                  If empty, everything from the claim is made available, otherwise
+                                                  only the result of this request.
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                          - name
+                                          x-kubernetes-list-type: map
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
+                                    restartPolicy:
+                                      description: |-
+                                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                                        This overrides the pod-level restart policy. When this field is not specified,
+                                        the restart behavior is defined by the Pod's restart policy and the container type.
+                                        Additionally, setting the RestartPolicy as "Always" for the init container will
+                                        have the following effect:
+                                        this init container will be continually restarted on
+                                        exit until all regular containers have terminated. Once all regular
+                                        containers have completed, all init containers with restartPolicy "Always"
+                                        will be shut down. This lifecycle differs from normal init containers and
+                                        is often referred to as a "sidecar" container. Although this init
+                                        container still starts in the init container sequence, it does not wait
+                                        for the container to complete before proceeding to the next init
+                                        container. Instead, the next init container starts immediately after this
+                                        init container is started, or after any startupProbe has successfully
+                                        completed.
+                                      type: string
+                                    restartPolicyRules:
+                                      description: |-
+                                        Represents a list of rules to be checked to determine if the
+                                        container should be restarted on exit. The rules are evaluated in
+                                        order. Once a rule matches a container exit condition, the remaining
+                                        rules are ignored. If no rule matches the container exit condition,
+                                        the Container-level restart policy determines the whether the container
+                                        is restarted or not. Constraints on the rules:
+                                        - At most 20 rules are allowed.
+                                        - Rules can have the same action.
+                                        - Identical rules are not forbidden in validations.
+                                        When rules are specified, container MUST set RestartPolicy explicitly
+                                        even it if matches the Pod's RestartPolicy.
+                                      items:
+                                        description: ContainerRestartRule describes
+                                          how a container exit is handled.
+                                        properties:
+                                          action:
+                                            description: |-
+                                              Specifies the action taken on a container exit if the requirements
+                                              are satisfied. The only possible value is "Restart" to restart the
+                                              container.
+                                            type: string
+                                          exitCodes:
+                                            description: Represents the exit codes
+                                              to check on container exits.
+                                            properties:
+                                              operator:
+                                                description: |-
+                                                  Represents the relationship between the container exit code(s) and the
+                                                  specified values. Possible values are:
+                                                  - In: the requirement is satisfied if the container exit code is in the
+                                                    set of specified values.
+                                                  - NotIn: the requirement is satisfied if the container exit code is
+                                                    not in the set of specified values.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  Specifies the set of values to check for container exit codes.
+                                                  At most 255 elements are allowed.
+                                                items:
+                                                  format: int32
+                                                  type: integer
+                                                type: array
+                                                x-kubernetes-list-type: set
+                                            required:
+                                            - operator
+                                            type: object
+                                        required:
+                                        - action
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    securityContext:
+                                      description: |-
+                                        SecurityContext defines the security options the container should be run with.
+                                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                      properties:
+                                        allowPrivilegeEscalation:
+                                          description: |-
+                                            AllowPrivilegeEscalation controls whether a process can gain more
+                                            privileges than its parent process. This bool directly controls if
+                                            the no_new_privs flag will be set on the container process.
+                                            AllowPrivilegeEscalation is true always when the container is:
+                                            1) run as Privileged
+                                            2) has CAP_SYS_ADMIN
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        appArmorProfile:
+                                          description: |-
+                                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                            overrides the pod's appArmorProfile.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile loaded on the node that should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must match the loaded name of the profile.
+                                                Must be set if and only if type is "Localhost".
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of AppArmor profile will be applied.
+                                                Valid options are:
+                                                  Localhost - a profile pre-loaded on the node.
+                                                  RuntimeDefault - the container runtime's default profile.
+                                                  Unconfined - no AppArmor enforcement.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        capabilities:
+                                          description: |-
+                                            The capabilities to add/drop when running containers.
+                                            Defaults to the default set of capabilities granted by the container runtime.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            add:
+                                              description: Added capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            drop:
+                                              description: Removed capabilities
+                                              items:
+                                                description: Capability represent
+                                                  POSIX capabilities type
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        privileged:
+                                          description: |-
+                                            Run container in privileged mode.
+                                            Processes in privileged containers are essentially equivalent to root on the host.
+                                            Defaults to false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        procMount:
+                                          description: |-
+                                            procMount denotes the type of proc mount to use for the containers.
+                                            The default value is Default which uses the container runtime defaults for
+                                            readonly paths and masked paths.
+                                            This requires the ProcMountType feature flag to be enabled.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        readOnlyRootFilesystem:
+                                          description: |-
+                                            Whether this container has a read-only root filesystem.
+                                            Default is false.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: boolean
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to the container.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level
+                                                label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role
+                                                label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type
+                                                label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user
+                                                label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by this container. If seccomp options are
+                                            provided at both the pod & container level, the container options
+                                            override the pod options.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        windowsOptions:
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options from the PodSecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName
+                                                is the name of the GMSA credential
+                                                spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    startupProbe:
+                                      description: |-
+                                        StartupProbe indicates that the Pod has successfully initialized.
+                                        If specified, no other probes are executed until this completes successfully.
+                                        If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                        This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                        when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                        This cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to
+                                            execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        failureThreshold:
+                                          description: |-
+                                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                            Defaults to 3. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        grpc:
+                                          description: GRPC specifies a GRPC HealthCheckRequest.
+                                          properties:
+                                            port:
+                                              description: Port number of the gRPC
+                                                service. Number must be in the range
+                                                1 to 65535.
+                                              format: int32
+                                              type: integer
+                                            service:
+                                              default: ""
+                                              description: |-
+                                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                                If this is not specified, the default behavior is defined by gRPC.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET
+                                            request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in
+                                                the request. HTTP allows repeated
+                                                headers.
+                                              items:
+                                                description: HTTPHeader describes
+                                                  a custom header to be used in HTTP
+                                                  probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field
+                                                      value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP
+                                                server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        initialDelaySeconds:
+                                          description: |-
+                                            Number of seconds after the container has started before liveness probes are initiated.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                        periodSeconds:
+                                          description: |-
+                                            How often (in seconds) to perform the probe.
+                                            Default to 10 seconds. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        successThreshold:
+                                          description: |-
+                                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                          format: int32
+                                          type: integer
+                                        tcpSocket:
+                                          description: TCPSocket specifies a connection
+                                            to a TCP port.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to
+                                                connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                        terminationGracePeriodSeconds:
+                                          description: |-
+                                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                            The grace period is the duration in seconds after the processes running in the pod are sent
+                                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                            Set this value longer than the expected cleanup time for your process.
+                                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                            value overrides the value provided by the pod spec.
+                                            Value must be non-negative integer. The value zero indicates stop immediately via
+                                            the kill signal (no opportunity to shut down).
+                                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                          format: int64
+                                          type: integer
+                                        timeoutSeconds:
+                                          description: |-
+                                            Number of seconds after which the probe times out.
+                                            Defaults to 1 second. Minimum value is 1.
+                                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                          format: int32
+                                          type: integer
+                                      type: object
+                                    stdin:
+                                      description: |-
+                                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                        is not set, reads from stdin in the container will always result in EOF.
+                                        Default is false.
+                                      type: boolean
+                                    stdinOnce:
+                                      description: |-
+                                        Whether the container runtime should close the stdin channel after it has been opened by
+                                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                        at which time stdin is closed and remains closed until the container is restarted. If this
+                                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                                        Default is false
+                                      type: boolean
+                                    terminationMessagePath:
+                                      description: |-
+                                        Optional: Path at which the file to which the container's termination message
+                                        will be written is mounted into the container's filesystem.
+                                        Message written is intended to be brief final status, such as an assertion failure message.
+                                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                        all containers will be limited to 12kb.
+                                        Defaults to /dev/termination-log.
+                                        Cannot be updated.
+                                      type: string
+                                    terminationMessagePolicy:
+                                      description: |-
+                                        Indicate how the termination message should be populated. File will use the contents of
+                                        terminationMessagePath to populate the container status message on both success and failure.
+                                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                        message file is empty and the container exited with an error.
+                                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                        Defaults to File.
+                                        Cannot be updated.
+                                      type: string
+                                    tty:
+                                      description: |-
+                                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                        Default is false.
+                                      type: boolean
+                                    volumeDevices:
+                                      description: volumeDevices is the list of block
+                                        devices to be used by the container.
+                                      items:
+                                        description: volumeDevice describes a mapping
+                                          of a raw block device within a container.
+                                        properties:
+                                          devicePath:
+                                            description: devicePath is the path inside
+                                              of the container that the device will
+                                              be mapped to.
+                                            type: string
+                                          name:
+                                            description: name must match the name
+                                              of a persistentVolumeClaim in the pod
+                                            type: string
+                                        required:
+                                        - devicePath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - devicePath
+                                      x-kubernetes-list-type: map
+                                    volumeMounts:
+                                      description: |-
+                                        Pod volumes to mount into the container's filesystem.
+                                        Cannot be updated.
+                                      items:
+                                        description: VolumeMount describes a mounting
+                                          of a Volume within a container.
+                                        properties:
+                                          mountPath:
+                                            description: |-
+                                              Path within the container at which the volume should be mounted.  Must
+                                              not contain ':'.
+                                            type: string
+                                          mountPropagation:
+                                            description: |-
+                                              mountPropagation determines how mounts are propagated from the host
+                                              to container and the other way around.
+                                              When not set, MountPropagationNone is used.
+                                              This field is beta in 1.10.
+                                              When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                              (which defaults to None).
+                                            type: string
+                                          name:
+                                            description: This must match the Name
+                                              of a Volume.
+                                            type: string
+                                          readOnly:
+                                            description: |-
+                                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                                              Defaults to false.
+                                            type: boolean
+                                          recursiveReadOnly:
+                                            description: |-
+                                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                                              recursively.
+
+                                              If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                              If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                              recursively read-only.  If this field is set to IfPossible, the mount is made
+                                              recursively read-only, if it is supported by the container runtime.  If this
+                                              field is set to Enabled, the mount is made recursively read-only if it is
+                                              supported by the container runtime, otherwise the pod will not be started and
+                                              an error will be generated to indicate the reason.
+
+                                              If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                              None (or be unspecified, which defaults to None).
+
+                                              If this field is not specified, it is treated as an equivalent of Disabled.
+                                            type: string
+                                          subPath:
+                                            description: |-
+                                              Path within the volume from which the container's volume should be mounted.
+                                              Defaults to "" (volume's root).
+                                            type: string
+                                          subPathExpr:
+                                            description: |-
+                                              Expanded path within the volume from which the container's volume should be mounted.
+                                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                              Defaults to "" (volume's root).
+                                              SubPathExpr and SubPath are mutually exclusive.
+                                            type: string
+                                        required:
+                                        - mountPath
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - mountPath
+                                      x-kubernetes-list-type: map
+                                    workingDir:
+                                      description: |-
+                                        Container's working directory.
+                                        If not specified, the container runtime's default will be used, which
+                                        might be configured in the container image.
+                                        Cannot be updated.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              nodeName:
+                                description: |-
+                                  NodeName indicates in which node this pod is scheduled.
+                                  If empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.
+                                  Once this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.
+                                  This field should not be used to express a desire for the pod to be scheduled on a specific node.
+                                  https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename
+                                type: string
+                              nodeSelector:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  NodeSelector is a selector which must be true for the pod to fit on a node.
+                                  Selector which must match a node's labels for the pod to be scheduled on that node.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              os:
+                                description: |-
+                                  Specifies the OS of the containers in the pod.
+                                  Some pod and container fields are restricted if this is set.
+
+                                  If the OS field is set to linux, the following fields must be unset:
+                                  -securityContext.windowsOptions
+
+                                  If the OS field is set to windows, following fields must be unset:
+                                  - spec.hostPID
+                                  - spec.hostIPC
+                                  - spec.hostUsers
+                                  - spec.resources
+                                  - spec.securityContext.appArmorProfile
+                                  - spec.securityContext.seLinuxOptions
+                                  - spec.securityContext.seccompProfile
+                                  - spec.securityContext.fsGroup
+                                  - spec.securityContext.fsGroupChangePolicy
+                                  - spec.securityContext.sysctls
+                                  - spec.shareProcessNamespace
+                                  - spec.securityContext.runAsUser
+                                  - spec.securityContext.runAsGroup
+                                  - spec.securityContext.supplementalGroups
+                                  - spec.securityContext.supplementalGroupsPolicy
+                                  - spec.containers[*].securityContext.appArmorProfile
+                                  - spec.containers[*].securityContext.seLinuxOptions
+                                  - spec.containers[*].securityContext.seccompProfile
+                                  - spec.containers[*].securityContext.capabilities
+                                  - spec.containers[*].securityContext.readOnlyRootFilesystem
+                                  - spec.containers[*].securityContext.privileged
+                                  - spec.containers[*].securityContext.allowPrivilegeEscalation
+                                  - spec.containers[*].securityContext.procMount
+                                  - spec.containers[*].securityContext.runAsUser
+                                  - spec.containers[*].securityContext.runAsGroup
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name is the name of the operating system. The currently supported values are linux and windows.
+                                      Additional value may be defined in future and can be one of:
+                                      https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                      Clients should expect to handle additional values and treat unrecognized values in this field as os: null
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              overhead:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                                  This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                                  the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                                  The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                                  set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                                  defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                                  More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+                                type: object
+                              preemptionPolicy:
+                                description: |-
+                                  PreemptionPolicy is the Policy for preempting pods with lower priority.
+                                  One of Never, PreemptLowerPriority.
+                                  Defaults to PreemptLowerPriority if unset.
+                                type: string
+                              priority:
+                                description: |-
+                                  The priority value. Various system components use this field to find the
+                                  priority of the pod. When Priority Admission Controller is enabled, it
+                                  prevents users from setting this field. The admission controller populates
+                                  this field from PriorityClassName.
+                                  The higher the value, the higher the priority.
+                                format: int32
+                                type: integer
+                              priorityClassName:
+                                description: |-
+                                  If specified, indicates the pod's priority. "system-node-critical" and
+                                  "system-cluster-critical" are two special keywords which indicate the
+                                  highest priorities with the former being the highest priority. Any other
+                                  name must be defined by creating a PriorityClass object with that name.
+                                  If not specified, the pod priority will be default or zero if there is no
+                                  default.
+                                type: string
+                              readinessGates:
+                                description: |-
+                                  If specified, all readiness gates will be evaluated for pod readiness.
+                                  A pod is ready when all its containers are ready AND
+                                  all conditions specified in the readiness gates have status equal to "True"
+                                  More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
+                                items:
+                                  description: PodReadinessGate contains the reference
+                                    to a pod condition
+                                  properties:
+                                    conditionType:
+                                      description: ConditionType refers to a condition
+                                        in the pod's condition list with matching
+                                        type.
+                                      type: string
+                                  required:
+                                  - conditionType
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              resourceClaims:
+                                description: |-
+                                  ResourceClaims defines which ResourceClaims must be allocated
+                                  and reserved before the Pod is allowed to start. The resources
+                                  will be made available to those containers which consume them
+                                  by name.
+
+                                  This is a stable field but requires that the
+                                  DynamicResourceAllocation feature gate is enabled.
+
+                                  This field is immutable.
+                                items:
+                                  description: |-
+                                    PodResourceClaim references exactly one ResourceClaim, either directly
+                                    or by naming a ResourceClaimTemplate which is then turned into a ResourceClaim
+                                    for the pod.
+
+                                    It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                                    Containers that need access to the ResourceClaim reference it with this name.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name uniquely identifies this resource claim inside the pod.
+                                        This must be a DNS_LABEL.
+                                      type: string
+                                    resourceClaimName:
+                                      description: |-
+                                        ResourceClaimName is the name of a ResourceClaim object in the same
+                                        namespace as this pod.
+
+                                        Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                        be set.
+                                      type: string
+                                    resourceClaimTemplateName:
+                                      description: |-
+                                        ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                        object in the same namespace as this pod.
+
+                                        The template will be used to create a new ResourceClaim, which will
+                                        be bound to this pod. When this pod is deleted, the ResourceClaim
+                                        will also be deleted. The pod name and resource name, along with a
+                                        generated component, will be used to form a unique name for the
+                                        ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+                                        This field is immutable and no changes will be made to the
+                                        corresponding ResourceClaim by the control plane after creating the
+                                        ResourceClaim.
+
+                                        Exactly one of ResourceClaimName and ResourceClaimTemplateName must
+                                        be set.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              resources:
+                                description: |-
+                                  Resources is the total amount of CPU and Memory resources required by all
+                                  containers in the pod. It supports specifying Requests and Limits for
+                                  "cpu", "memory" and "hugepages-" resource names only. ResourceClaims are not supported.
+
+                                  This field enables fine-grained control over resource allocation for the
+                                  entire pod, allowing resource sharing among containers in a pod.
+
+                                  This is an alpha field and requires enabling the PodLevelResources feature
+                                  gate.
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+                                      This field depends on the
+                                      DynamicResourceAllocation feature gate.
+
+                                      This field is immutable. It can only be set for containers.
+                                    items:
+                                      description: ResourceClaim references one entry
+                                        in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                type: object
+                              restartPolicy:
+                                description: |-
+                                  Restart policy for all containers within the pod.
+                                  One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                                  Default to Always.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+                                type: string
+                              runtimeClassName:
+                                description: |-
+                                  RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                                  to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                                  If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                                  empty definition that uses the default runtime handler.
+                                  More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+                                type: string
+                              schedulerName:
+                                description: |-
+                                  If specified, the pod will be dispatched by specified scheduler.
+                                  If not specified, the pod will be dispatched by default scheduler.
+                                type: string
+                              schedulingGates:
+                                description: |-
+                                  SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                                  If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                                  scheduler will not attempt to schedule the pod.
+
+                                  SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+                                items:
+                                  description: PodSchedulingGate is associated to
+                                    a Pod to guard its scheduling.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name of the scheduling gate.
+                                        Each scheduling gate must have a unique name field.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              securityContext:
+                                description: |-
+                                  SecurityContext holds pod-level security attributes and common container settings.
+                                  Optional: Defaults to empty.  See type description for default values of each field.
+                                properties:
+                                  appArmorProfile:
+                                    description: |-
+                                      appArmorProfile is the AppArmor options to use by the containers in this pod.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile loaded on the node that should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must match the loaded name of the profile.
+                                          Must be set if and only if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of AppArmor profile will be applied.
+                                          Valid options are:
+                                            Localhost - a profile pre-loaded on the node.
+                                            RuntimeDefault - the container runtime's default profile.
+                                            Unconfined - no AppArmor enforcement.
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  fsGroup:
+                                    description: |-
+                                      A special supplemental group that applies to all containers in a pod.
+                                      Some volume types allow the Kubelet to change the ownership of that volume
+                                      to be owned by the pod:
+
+                                      1. The owning GID will be the FSGroup
+                                      2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                      3. The permission bits are OR'd with rw-rw----
+
+                                      If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  fsGroupChangePolicy:
+                                    description: |-
+                                      fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                      before being exposed inside Pod. This field will only apply to
+                                      volume types which support fsGroup based ownership(and permissions).
+                                      It will have no effect on ephemeral volume types such as: secret, configmaps
+                                      and emptydir.
+                                      Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
+                                  runAsGroup:
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence
+                                      for that container.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in SecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence
+                                      for that container.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  seLinuxChangePolicy:
+                                    description: |-
+                                      seLinuxChangePolicy defines how the container's SELinux label is applied to all volumes used by the Pod.
+                                      It has no effect on nodes that do not support SELinux or to volumes does not support SELinux.
+                                      Valid values are "MountOption" and "Recursive".
+
+                                      "Recursive" means relabeling of all files on all Pod volumes by the container runtime.
+                                      This may be slow for large volumes, but allows mixing privileged and unprivileged Pods sharing the same volume on the same node.
+
+                                      "MountOption" mounts all eligible Pod volumes with `-o context` mount option.
+                                      This requires all Pods that share the same volume to use the same SELinux label.
+                                      It is not possible to share the same volume among privileged and unprivileged Pods.
+                                      Eligible volumes are in-tree FibreChannel and iSCSI volumes, and all CSI volumes
+                                      whose CSI driver announces SELinux support by setting spec.seLinuxMount: true in their
+                                      CSIDriver instance. Other volumes are always re-labelled recursively.
+                                      "MountOption" value is allowed only when SELinuxMount feature gate is enabled.
+
+                                      If not specified and SELinuxMount feature gate is enabled, "MountOption" is used.
+                                      If not specified and SELinuxMount feature gate is disabled, "MountOption" is used for ReadWriteOncePod volumes
+                                      and "Recursive" for all other volumes.
+
+                                      This field affects only Pods that have SELinux label set, either in PodSecurityContext or in SecurityContext of all containers.
+
+                                      All Pods that use the same volume should use the same seLinuxChangePolicy, otherwise some pods can get stuck in ContainerCreating state.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
+                                  seLinuxOptions:
+                                    description: |-
+                                      The SELinux context to be applied to all containers.
+                                      If unspecified, the container runtime will allocate a random SELinux context for each
+                                      container.  May also be set in SecurityContext.  If set in
+                                      both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                      takes precedence for that container.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label
+                                          that applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label
+                                          that applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label
+                                          that applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label
+                                          that applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: |-
+                                      The seccomp options to use by the containers in this pod.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
+                                        type: string
+                                    required:
+                                    - type
+                                    type: object
+                                  supplementalGroups:
+                                    description: |-
+                                      A list of groups applied to the first process run in each container, in
+                                      addition to the container's primary GID and fsGroup (if specified).  If
+                                      the SupplementalGroupsPolicy feature is enabled, the
+                                      supplementalGroupsPolicy field determines whether these are in addition
+                                      to or instead of any group memberships defined in the container image.
+                                      If unspecified, no additional groups are added, though group memberships
+                                      defined in the container image may still be used, depending on the
+                                      supplementalGroupsPolicy field.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    items:
+                                      format: int64
+                                      type: integer
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  supplementalGroupsPolicy:
+                                    description: |-
+                                      Defines how supplemental groups of the first container processes are calculated.
+                                      Valid values are "Merge" and "Strict". If not specified, "Merge" is used.
+                                      (Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled
+                                      and the container runtime must implement support for this feature.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
+                                  sysctls:
+                                    description: |-
+                                      Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                      sysctls (by the container runtime) might fail to launch.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    items:
+                                      description: Sysctl defines a kernel parameter
+                                        to be set
+                                      properties:
+                                        name:
+                                          description: Name of a property to set
+                                          type: string
+                                        value:
+                                          description: Value of a property to set
+                                          type: string
+                                      required:
+                                      - name
+                                      - value
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  windowsOptions:
+                                    description: |-
+                                      The Windows specific settings applied to all containers.
+                                      If unspecified, the options within a container's SecurityContext will be used.
+                                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is linux.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: |-
+                                          GMSACredentialSpec is where the GMSA admission webhook
+                                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                          GMSA credential spec named by the GMSACredentialSpecName field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the
+                                          name of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: |-
+                                          HostProcess determines if a container should be run as a 'Host Process' container.
+                                          All of a Pod's containers must have the same effective HostProcess value
+                                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: |-
+                                          The UserName in Windows to run the entrypoint of the container process.
+                                          Defaults to the user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              serviceAccount:
+                                description: |-
+                                  DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.
+                                  Deprecated: Use serviceAccountName instead.
+                                type: string
+                              serviceAccountName:
+                                description: |-
+                                  ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                                type: string
+                              setHostnameAsFQDN:
+                                description: |-
+                                  If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                                  In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                                  In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                                  If a pod does not have FQDN, this has no effect.
+                                  Default to false.
+                                type: boolean
+                              shareProcessNamespace:
+                                description: |-
+                                  Share a single process namespace between all of the containers in a pod.
+                                  When this is set containers will be able to view and signal processes from other containers
+                                  in the same pod, and the first process in each container will not be assigned PID 1.
+                                  HostPID and ShareProcessNamespace cannot both be set.
+                                  Optional: Default to false.
+                                type: boolean
+                              subdomain:
+                                description: |-
+                                  If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                                  If not specified, the pod will not have a domainname at all.
+                                type: string
+                              terminationGracePeriodSeconds:
+                                description: |-
+                                  Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                  the kill signal (no opportunity to shut down).
+                                  If this value is nil, the default grace period will be used instead.
+                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                  Set this value longer than the expected cleanup time for your process.
+                                  Defaults to 30 seconds.
+                                format: int64
+                                type: integer
+                              tolerations:
+                                description: If specified, the pod's tolerations.
+                                items:
+                                  description: |-
+                                    The pod this Toleration is attached to tolerates any taint that matches
+                                    the triple <key,value,effect> using the matching operator <operator>.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: |-
+                                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        Operator represents a key's relationship to the value.
+                                        Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                                        Exists is equivalent to wildcard for value, so that a pod can
+                                        tolerate all taints of a particular category.
+                                        Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                                      type: string
+                                    tolerationSeconds:
+                                      description: |-
+                                        TolerationSeconds represents the period of time the toleration (which must be
+                                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                        negative values will be treated as 0 (evict immediately) by the system.
+                                      format: int64
+                                      type: integer
+                                    value:
+                                      description: |-
+                                        Value is the taint value the toleration matches to.
+                                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                      type: string
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              topologySpreadConstraints:
+                                description: |-
+                                  TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                  domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                  All topologySpreadConstraints are ANDed.
+                                items:
+                                  description: TopologySpreadConstraint specifies
+                                    how to spread matching pods among the given topology.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        LabelSelector is used to find matching pods.
+                                        Pods that match this label selector are counted to determine the number of pods
+                                        in their corresponding topology domain.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select the pods over which
+                                        spreading will be calculated. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are ANDed with labelSelector
+                                        to select the group of existing pods over which spreading will be calculated
+                                        for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        Keys that don't exist in the incoming pod labels will
+                                        be ignored. A null or empty list means only match against labelSelector.
+
+                                        This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    maxSkew:
+                                      description: |-
+                                        MaxSkew describes the degree to which pods may be unevenly distributed.
+                                        When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                        between the number of matching pods in the target topology and the global minimum.
+                                        The global minimum is the minimum number of matching pods in an eligible domain
+                                        or zero if the number of eligible domains is less than MinDomains.
+                                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                        labelSelector spread as 2/2/1:
+                                        In this case, the global minimum is 1.
+                                        | zone1 | zone2 | zone3 |
+                                        |  P P  |  P P  |   P   |
+                                        - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                        scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                        violate MaxSkew(1).
+                                        - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                        When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                        to topologies that satisfy it.
+                                        It's a required field. Default value is 1 and 0 is not allowed.
+                                      format: int32
+                                      type: integer
+                                    minDomains:
+                                      description: |-
+                                        MinDomains indicates a minimum number of eligible domains.
+                                        When the number of eligible domains with matching topology keys is less than minDomains,
+                                        Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                        And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                        this value has no effect on scheduling.
+                                        As a result, when the number of eligible domains is less than minDomains,
+                                        scheduler won't schedule more than maxSkew Pods to those domains.
+                                        If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                        Valid values are integers greater than 0.
+                                        When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                        For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                        labelSelector spread as 2/2/2:
+                                        | zone1 | zone2 | zone3 |
+                                        |  P P  |  P P  |  P P  |
+                                        The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                        In this situation, new pod with the same labelSelector cannot be scheduled,
+                                        because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                        it will violate MaxSkew.
+                                      format: int32
+                                      type: integer
+                                    nodeAffinityPolicy:
+                                      description: |-
+                                        NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                        when calculating pod topology spread skew. Options are:
+                                        - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                        - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                        If this value is nil, the behavior is equivalent to the Honor policy.
+                                      type: string
+                                    nodeTaintsPolicy:
+                                      description: |-
+                                        NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                        pod topology spread skew. Options are:
+                                        - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                        has a toleration, are included.
+                                        - Ignore: node taints are ignored. All nodes are included.
+
+                                        If this value is nil, the behavior is equivalent to the Ignore policy.
+                                      type: string
+                                    topologyKey:
+                                      description: |-
+                                        TopologyKey is the key of node labels. Nodes that have a label with this key
+                                        and identical values are considered to be in the same topology.
+                                        We consider each <key, value> as a "bucket", and try to put balanced number
+                                        of pods into each bucket.
+                                        We define a domain as a particular instance of a topology.
+                                        Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                        nodeAffinityPolicy and nodeTaintsPolicy.
+                                        e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                        And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                        It's a required field.
+                                      type: string
+                                    whenUnsatisfiable:
+                                      description: |-
+                                        WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                        the spread constraint.
+                                        - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                        - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                          but giving higher precedence to topologies that would help reduce the
+                                          skew.
+                                        A constraint is considered "Unsatisfiable" for an incoming pod
+                                        if and only if every possible node assignment for that pod would violate
+                                        "MaxSkew" on some topology.
+                                        For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                        labelSelector spread as 3/1/1:
+                                        | zone1 | zone2 | zone3 |
+                                        | P P P |   P   |   P   |
+                                        If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                        to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                        MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                        won't make it *more* imbalanced.
+                                        It's a required field.
+                                      type: string
+                                  required:
+                                  - maxSkew
+                                  - topologyKey
+                                  - whenUnsatisfiable
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - topologyKey
+                                - whenUnsatisfiable
+                                x-kubernetes-list-type: map
+                              volumes:
+                                description: |-
+                                  List of volumes that can be mounted by containers belonging to the pod.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes
+                                items:
+                                  description: Volume represents a named volume in
+                                    a pod that may be accessed by any container in
+                                    the pod.
+                                  properties:
+                                    awsElasticBlockStore:
+                                      description: |-
+                                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                        awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          type: string
+                                        partition:
+                                          description: |-
+                                            partition is the partition in the volume that you want to mount.
+                                            If omitted, the default is to mount by volume name.
+                                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: |-
+                                            readOnly value true will force the readOnly setting in VolumeMounts.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          type: boolean
+                                        volumeID:
+                                          description: |-
+                                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    azureDisk:
+                                      description: |-
+                                        azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                        Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                        are redirected to the disk.csi.azure.com CSI driver.
+                                      properties:
+                                        cachingMode:
+                                          description: 'cachingMode is the Host Caching
+                                            mode: None, Read Only, Read Write.'
+                                          type: string
+                                        diskName:
+                                          description: diskName is the Name of the
+                                            data disk in the blob storage
+                                          type: string
+                                        diskURI:
+                                          description: diskURI is the URI of data
+                                            disk in the blob storage
+                                          type: string
+                                        fsType:
+                                          default: ext4
+                                          description: |-
+                                            fsType is Filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        kind:
+                                          description: 'kind expected values are Shared:
+                                            multiple blob disks per storage account  Dedicated:
+                                            single blob disk per storage account  Managed:
+                                            azure managed data disk (only in managed
+                                            availability set). defaults to shared'
+                                          type: string
+                                        readOnly:
+                                          default: false
+                                          description: |-
+                                            readOnly Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                      required:
+                                      - diskName
+                                      - diskURI
+                                      type: object
+                                    azureFile:
+                                      description: |-
+                                        azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                        Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                        are redirected to the file.csi.azure.com CSI driver.
+                                      properties:
+                                        readOnly:
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretName:
+                                          description: secretName is the  name of
+                                            secret that contains Azure Storage Account
+                                            Name and Key
+                                          type: string
+                                        shareName:
+                                          description: shareName is the azure share
+                                            Name
+                                          type: string
+                                      required:
+                                      - secretName
+                                      - shareName
+                                      type: object
+                                    cephfs:
+                                      description: |-
+                                        cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                        Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                                      properties:
+                                        monitors:
+                                          description: |-
+                                            monitors is Required: Monitors is a collection of Ceph monitors
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: 'path is Optional: Used as
+                                            the mounted root, rather than the full
+                                            Ceph tree, default is /'
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                          type: boolean
+                                        secretFile:
+                                          description: |-
+                                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                          type: string
+                                        secretRef:
+                                          description: |-
+                                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          description: |-
+                                            user is optional: User is the rados user name, default is admin
+                                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                          type: string
+                                      required:
+                                      - monitors
+                                      type: object
+                                    cinder:
+                                      description: |-
+                                        cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                        Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                        are redirected to the cinder.csi.openstack.org CSI driver.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                          type: boolean
+                                        secretRef:
+                                          description: |-
+                                            secretRef is optional: points to a secret object containing parameters used to connect
+                                            to OpenStack.
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeID:
+                                          description: |-
+                                            volumeID used to identify the volume in cinder.
+                                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    configMap:
+                                      description: configMap represents a configMap
+                                        that should populate this volume
+                                      properties:
+                                        defaultMode:
+                                          description: |-
+                                            defaultMode is optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: |-
+                                            items if unspecified, each key-value pair in the Data field of the referenced
+                                            ConfigMap will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the ConfigMap,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: |-
+                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: |-
+                                                  path is the relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the
+                                            ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    csi:
+                                      description: csi (Container Storage Interface)
+                                        represents ephemeral storage that is handled
+                                        by certain external CSI drivers.
+                                      properties:
+                                        driver:
+                                          description: |-
+                                            driver is the name of the CSI driver that handles this volume.
+                                            Consult with your admin for the correct name as registered in the cluster.
+                                          type: string
+                                        fsType:
+                                          description: |-
+                                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                            If not provided, the empty value is passed to the associated CSI driver
+                                            which will determine the default filesystem to apply.
+                                          type: string
+                                        nodePublishSecretRef:
+                                          description: |-
+                                            nodePublishSecretRef is a reference to the secret object containing
+                                            sensitive information to pass to the CSI driver to complete the CSI
+                                            NodePublishVolume and NodeUnpublishVolume calls.
+                                            This field is optional, and  may be empty if no secret is required. If the
+                                            secret object contains more than one secret, all secret references are passed.
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        readOnly:
+                                          description: |-
+                                            readOnly specifies a read-only configuration for the volume.
+                                            Defaults to false (read/write).
+                                          type: boolean
+                                        volumeAttributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            volumeAttributes stores driver-specific properties that are passed to the CSI
+                                            driver. Consult your driver's documentation for supported values.
+                                          type: object
+                                      required:
+                                      - driver
+                                      type: object
+                                    downwardAPI:
+                                      description: downwardAPI represents downward
+                                        API about the pod that should populate this
+                                        volume
+                                      properties:
+                                        defaultMode:
+                                          description: |-
+                                            Optional: mode bits to use on created files by default. Must be a
+                                            Optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: Items is a list of downward
+                                            API volume file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents
+                                              information to create the file containing
+                                              the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a
+                                                  field of the pod: only annotations,
+                                                  labels, name, namespace and uid
+                                                  are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema
+                                                      the FieldPath is written in
+                                                      terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field
+                                                      to select in the specified API
+                                                      version.
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              mode:
+                                                description: |-
+                                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                                  between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the
+                                                  relative path name of the file to
+                                                  be created. Must not be absolute
+                                                  or contain the ''..'' path. Must
+                                                  be utf-8 encoded. The first item
+                                                  of the relative path must not start
+                                                  with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: |-
+                                                  Selects a resource of the container: only resources limits and requests
+                                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name:
+                                                      required for volumes, optional
+                                                      for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: Specifies the output
+                                                      format of the exposed resources,
+                                                      defaults to "1"
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    description: 'Required: resource
+                                                      to select'
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    emptyDir:
+                                      description: |-
+                                        emptyDir represents a temporary directory that shares a pod's lifetime.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                      properties:
+                                        medium:
+                                          description: |-
+                                            medium represents what type of storage medium should back this directory.
+                                            The default is "" which means to use the node's default medium.
+                                            Must be an empty string (default) or Memory.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                          type: string
+                                        sizeLimit:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                            The size limit is also applicable for memory medium.
+                                            The maximum usage on memory medium EmptyDir would be the minimum value between
+                                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                            The default is nil which means that the limit is undefined.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    ephemeral:
+                                      description: |-
+                                        ephemeral represents a volume that is handled by a cluster storage driver.
+                                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                        and deleted when the pod is removed.
+
+                                        Use this if:
+                                        a) the volume is only needed while the pod runs,
+                                        b) features of normal volumes like restoring from snapshot or capacity
+                                           tracking are needed,
+                                        c) the storage driver is specified through a storage class, and
+                                        d) the storage driver supports dynamic volume provisioning through
+                                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                           information on the connection between this volume type
+                                           and PersistentVolumeClaim).
+
+                                        Use PersistentVolumeClaim or one of the vendor-specific
+                                        APIs for volumes that persist for longer than the lifecycle
+                                        of an individual pod.
+
+                                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                        be used that way - see the documentation of the driver for
+                                        more information.
+
+                                        A pod can use both types of ephemeral volumes and
+                                        persistent volumes at the same time.
+                                      properties:
+                                        volumeClaimTemplate:
+                                          description: |-
+                                            Will be used to create a stand-alone PVC to provision the volume.
+                                            The pod in which this EphemeralVolumeSource is embedded will be the
+                                            owner of the PVC, i.e. the PVC will be deleted together with the
+                                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                            `<volume name>` is the name from the `PodSpec.Volumes` array
+                                            entry. Pod validation will reject the pod if the concatenated name
+                                            is not valid for a PVC (for example, too long).
+
+                                            An existing PVC with that name that is not owned by the pod
+                                            will *not* be used for the pod to avoid using an unrelated
+                                            volume by mistake. Starting the pod is then blocked until
+                                            the unrelated PVC is removed. If such a pre-created PVC is
+                                            meant to be used by the pod, the PVC has to updated with an
+                                            owner reference to the pod once the pod exists. Normally
+                                            this should not be necessary, but it may be useful when
+                                            manually reconstructing a broken cluster.
+
+                                            This field is read-only and no changes will be made by Kubernetes
+                                            to the PVC after it has been created.
+
+                                            Required, must not be nil.
+                                          properties:
+                                            metadata:
+                                              description: |-
+                                                May contain labels and annotations that will be copied into the PVC
+                                                when creating it. No other fields are allowed and will be rejected during
+                                                validation.
+                                              type: object
+                                            spec:
+                                              description: |-
+                                                The specification for the PersistentVolumeClaim. The entire content is
+                                                copied unchanged into the PVC that gets created from this
+                                                template. The same fields as in a PersistentVolumeClaim
+                                                are also valid here.
+                                              properties:
+                                                accessModes:
+                                                  description: |-
+                                                    accessModes contains the desired access modes the volume should have.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                dataSource:
+                                                  description: |-
+                                                    dataSource field can be used to specify either:
+                                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                    * An existing PVC (PersistentVolumeClaim)
+                                                    If the provisioner or an external controller can support the specified data source,
+                                                    it will create a new volume based on the contents of the specified data source.
+                                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                                  properties:
+                                                    apiGroup:
+                                                      description: |-
+                                                        APIGroup is the group for the resource being referenced.
+                                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                        For any other third-party types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type
+                                                        of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name
+                                                        of resource being referenced
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                dataSourceRef:
+                                                  description: |-
+                                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                    volume is desired. This may be any object from a non-empty API group (non
+                                                    core object) or a PersistentVolumeClaim object.
+                                                    When this field is specified, volume binding will only succeed if the type of
+                                                    the specified object matches some installed volume populator or dynamic
+                                                    provisioner.
+                                                    This field will replace the functionality of the dataSource field and as such
+                                                    if both fields are non-empty, they must have the same value. For backwards
+                                                    compatibility, when namespace isn't specified in dataSourceRef,
+                                                    both fields (dataSource and dataSourceRef) will be set to the same
+                                                    value automatically if one of them is empty and the other is non-empty.
+                                                    When namespace is specified in dataSourceRef,
+                                                    dataSource isn't set to the same value and must be empty.
+                                                    There are three important differences between dataSource and dataSourceRef:
+                                                    * While dataSource only allows two specific types of objects, dataSourceRef
+                                                      allows any non-core object, as well as PersistentVolumeClaim objects.
+                                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                                      preserves all values, and generates an error if a disallowed value is
+                                                      specified.
+                                                    * While dataSource only allows local objects, dataSourceRef allows objects
+                                                      in any namespaces.
+                                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                  properties:
+                                                    apiGroup:
+                                                      description: |-
+                                                        APIGroup is the group for the resource being referenced.
+                                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                        For any other third-party types, APIGroup is required.
+                                                      type: string
+                                                    kind:
+                                                      description: Kind is the type
+                                                        of resource being referenced
+                                                      type: string
+                                                    name:
+                                                      description: Name is the name
+                                                        of resource being referenced
+                                                      type: string
+                                                    namespace:
+                                                      description: |-
+                                                        Namespace is the namespace of resource being referenced
+                                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                      type: string
+                                                  required:
+                                                  - kind
+                                                  - name
+                                                  type: object
+                                                resources:
+                                                  description: |-
+                                                    resources represents the minimum resources the volume should have.
+                                                    Users are allowed to specify resource requirements
+                                                    that are lower than previous value but must still be higher than capacity recorded in the
+                                                    status field of the claim.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                                  properties:
+                                                    limits:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: |-
+                                                        Limits describes the maximum amount of compute resources allowed.
+                                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                      type: object
+                                                    requests:
+                                                      additionalProperties:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      description: |-
+                                                        Requests describes the minimum amount of compute resources required.
+                                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                      type: object
+                                                  type: object
+                                                selector:
+                                                  description: selector is a label
+                                                    query over volumes to consider
+                                                    for binding.
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                storageClassName:
+                                                  description: |-
+                                                    storageClassName is the name of the StorageClass required by the claim.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                                  type: string
+                                                volumeAttributesClassName:
+                                                  description: |-
+                                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                                    If specified, the CSI driver will create or update the volume with the attributes defined
+                                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                                    it can be changed after the claim is created. An empty string or nil value indicates that no
+                                                    VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state,
+                                                    this field can be reset to its previous value (including nil) to cancel the modification.
+                                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                                    exists.
+                                                    More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                                  type: string
+                                                volumeMode:
+                                                  description: |-
+                                                    volumeMode defines what type of volume is required by the claim.
+                                                    Value of Filesystem is implied when not included in claim spec.
+                                                  type: string
+                                                volumeName:
+                                                  description: volumeName is the binding
+                                                    reference to the PersistentVolume
+                                                    backing this claim.
+                                                  type: string
+                                              type: object
+                                          required:
+                                          - spec
+                                          type: object
+                                      type: object
+                                    fc:
+                                      description: fc represents a Fibre Channel resource
+                                        that is attached to a kubelet's host machine
+                                        and then exposed to the pod.
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        lun:
+                                          description: 'lun is Optional: FC target
+                                            lun number'
+                                          format: int32
+                                          type: integer
+                                        readOnly:
+                                          description: |-
+                                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        targetWWNs:
+                                          description: 'targetWWNs is Optional: FC
+                                            target worldwide names (WWNs)'
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        wwids:
+                                          description: |-
+                                            wwids Optional: FC volume world wide identifiers (wwids)
+                                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    flexVolume:
+                                      description: |-
+                                        flexVolume represents a generic volume resource that is
+                                        provisioned/attached using an exec based plugin.
+                                        Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                                      properties:
+                                        driver:
+                                          description: driver is the name of the driver
+                                            to use for this volume.
+                                          type: string
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                          type: string
+                                        options:
+                                          additionalProperties:
+                                            type: string
+                                          description: 'options is Optional: this
+                                            field holds extra command options if any.'
+                                          type: object
+                                        readOnly:
+                                          description: |-
+                                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: |-
+                                            secretRef is Optional: secretRef is reference to the secret object containing
+                                            sensitive information to pass to the plugin scripts. This may be
+                                            empty if no secret object is specified. If the secret object
+                                            contains more than one secret, all secrets are passed to the plugin
+                                            scripts.
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - driver
+                                      type: object
+                                    flocker:
+                                      description: |-
+                                        flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                        Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                                      properties:
+                                        datasetName:
+                                          description: |-
+                                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                            should be considered as deprecated
+                                          type: string
+                                        datasetUUID:
+                                          description: datasetUUID is the UUID of
+                                            the dataset. This is unique identifier
+                                            of a Flocker dataset
+                                          type: string
+                                      type: object
+                                    gcePersistentDisk:
+                                      description: |-
+                                        gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                        gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          type: string
+                                        partition:
+                                          description: |-
+                                            partition is the partition in the volume that you want to mount.
+                                            If omitted, the default is to mount by volume name.
+                                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          format: int32
+                                          type: integer
+                                        pdName:
+                                          description: |-
+                                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          type: boolean
+                                      required:
+                                      - pdName
+                                      type: object
+                                    gitRepo:
+                                      description: |-
+                                        gitRepo represents a git repository at a particular revision.
+                                        Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                        into the Pod's container.
+                                      properties:
+                                        directory:
+                                          description: |-
+                                            directory is the target directory name.
+                                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                            git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                            the subdirectory with the given name.
+                                          type: string
+                                        repository:
+                                          description: repository is the URL
+                                          type: string
+                                        revision:
+                                          description: revision is the commit hash
+                                            for the specified revision.
+                                          type: string
+                                      required:
+                                      - repository
+                                      type: object
+                                    glusterfs:
+                                      description: |-
+                                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                        Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                                      properties:
+                                        endpoints:
+                                          description: endpoints is the endpoint name
+                                            that details Glusterfs topology.
+                                          type: string
+                                        path:
+                                          description: |-
+                                            path is the Glusterfs volume path.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                            Defaults to false.
+                                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                          type: boolean
+                                      required:
+                                      - endpoints
+                                      - path
+                                      type: object
+                                    hostPath:
+                                      description: |-
+                                        hostPath represents a pre-existing file or directory on the host
+                                        machine that is directly exposed to the container. This is generally
+                                        used for system agents or other privileged things that are allowed
+                                        to see the host machine. Most containers will NOT need this.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                      properties:
+                                        path:
+                                          description: |-
+                                            path of the directory on the host.
+                                            If the path is a symlink, it will follow the link to the real path.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type for HostPath Volume
+                                            Defaults to ""
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                    image:
+                                      description: |-
+                                        image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                                        The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                                        - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                        - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                        - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                                        The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                                        A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                                        The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                                        The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                                        The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                                      properties:
+                                        pullPolicy:
+                                          description: |-
+                                            Policy for pulling OCI objects. Possible values are:
+                                            Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                            Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                            IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                            Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                          type: string
+                                        reference:
+                                          description: |-
+                                            Required: Image or artifact reference to be used.
+                                            Behaves in the same way as pod.spec.containers[*].image.
+                                            Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                            More info: https://kubernetes.io/docs/concepts/containers/images
+                                            This field is optional to allow higher level config management to default or override
+                                            container images in workload controllers like Deployments and StatefulSets.
+                                          type: string
+                                      type: object
+                                    iscsi:
+                                      description: |-
+                                        iscsi represents an ISCSI Disk resource that is attached to a
+                                        kubelet's host machine and then exposed to the pod.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi
+                                      properties:
+                                        chapAuthDiscovery:
+                                          description: chapAuthDiscovery defines whether
+                                            support iSCSI Discovery CHAP authentication
+                                          type: boolean
+                                        chapAuthSession:
+                                          description: chapAuthSession defines whether
+                                            support iSCSI Session CHAP authentication
+                                          type: boolean
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          type: string
+                                        initiatorName:
+                                          description: |-
+                                            initiatorName is the custom iSCSI Initiator Name.
+                                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                            <target portal>:<volume name> will be created for the connection.
+                                          type: string
+                                        iqn:
+                                          description: iqn is the target iSCSI Qualified
+                                            Name.
+                                          type: string
+                                        iscsiInterface:
+                                          default: default
+                                          description: |-
+                                            iscsiInterface is the interface Name that uses an iSCSI transport.
+                                            Defaults to 'default' (tcp).
+                                          type: string
+                                        lun:
+                                          description: lun represents iSCSI Target
+                                            Lun number.
+                                          format: int32
+                                          type: integer
+                                        portals:
+                                          description: |-
+                                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                            is other than default (typically TCP ports 860 and 3260).
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        readOnly:
+                                          description: |-
+                                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
+                                          type: boolean
+                                        secretRef:
+                                          description: secretRef is the CHAP Secret
+                                            for iSCSI target and initiator authentication
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        targetPortal:
+                                          description: |-
+                                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                            is other than default (typically TCP ports 860 and 3260).
+                                          type: string
+                                      required:
+                                      - iqn
+                                      - lun
+                                      - targetPortal
+                                      type: object
+                                    name:
+                                      description: |-
+                                        name of the volume.
+                                        Must be a DNS_LABEL and unique within the pod.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    nfs:
+                                      description: |-
+                                        nfs represents an NFS mount on the host that shares a pod's lifetime
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                      properties:
+                                        path:
+                                          description: |-
+                                            path that is exported by the NFS server.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly here will force the NFS export to be mounted with read-only permissions.
+                                            Defaults to false.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                          type: boolean
+                                        server:
+                                          description: |-
+                                            server is the hostname or IP address of the NFS server.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                          type: string
+                                      required:
+                                      - path
+                                      - server
+                                      type: object
+                                    persistentVolumeClaim:
+                                      description: |-
+                                        persistentVolumeClaimVolumeSource represents a reference to a
+                                        PersistentVolumeClaim in the same namespace.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                      properties:
+                                        claimName:
+                                          description: |-
+                                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                                            Default false.
+                                          type: boolean
+                                      required:
+                                      - claimName
+                                      type: object
+                                    photonPersistentDisk:
+                                      description: |-
+                                        photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                        Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        pdID:
+                                          description: pdID is the ID that identifies
+                                            Photon Controller persistent disk
+                                          type: string
+                                      required:
+                                      - pdID
+                                      type: object
+                                    portworxVolume:
+                                      description: |-
+                                        portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                        Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                        are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                                        is on.
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fSType represents the filesystem type to mount
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        volumeID:
+                                          description: volumeID uniquely identifies
+                                            a Portworx volume
+                                          type: string
+                                      required:
+                                      - volumeID
+                                      type: object
+                                    projected:
+                                      description: projected items for all in one
+                                        resources secrets, configmaps, and downward
+                                        API
+                                      properties:
+                                        defaultMode:
+                                          description: |-
+                                            defaultMode are the mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        sources:
+                                          description: |-
+                                            sources is the list of volume projections. Each entry in this list
+                                            handles one source.
+                                          items:
+                                            description: |-
+                                              Projection that may be projected along with other supported volume types.
+                                              Exactly one of these fields must be set.
+                                            properties:
+                                              clusterTrustBundle:
+                                                description: |-
+                                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                                  of ClusterTrustBundle objects in an auto-updating file.
+
+                                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                                  ClusterTrustBundle objects can either be selected by name, or by the
+                                                  combination of signer name and a label selector.
+
+                                                  Kubelet performs aggressive normalization of the PEM contents written
+                                                  into the pod filesystem.  Esoteric PEM features such as inter-block
+                                                  comments and block headers are stripped.  Certificates are deduplicated.
+                                                  The ordering of certificates within the file is arbitrary, and Kubelet
+                                                  may change the order over time.
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      Select all ClusterTrustBundles that match this label selector.  Only has
+                                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                                      interpreted as "match nothing".  If set but empty, interpreted as "match
+                                                      everything".
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions
+                                                          is a list of label selector
+                                                          requirements. The requirements
+                                                          are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is
+                                                                the label key that
+                                                                the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                              x-kubernetes-list-type: atomic
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  name:
+                                                    description: |-
+                                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                                      with signerName and labelSelector.
+                                                    type: string
+                                                  optional:
+                                                    description: |-
+                                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                                      aren't available.  If using name, then the named ClusterTrustBundle is
+                                                      allowed not to exist.  If using signerName, then the combination of
+                                                      signerName and labelSelector is allowed to match zero
+                                                      ClusterTrustBundles.
+                                                    type: boolean
+                                                  path:
+                                                    description: Relative path from
+                                                      the volume root to write the
+                                                      bundle.
+                                                    type: string
+                                                  signerName:
+                                                    description: |-
+                                                      Select all ClusterTrustBundles that match this signer name.
+                                                      Mutually-exclusive with name.  The contents of all selected
+                                                      ClusterTrustBundles will be unified and deduplicated.
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                              configMap:
+                                                description: configMap information
+                                                  about the configMap data to project
+                                                properties:
+                                                  items:
+                                                    description: |-
+                                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                                      ConfigMap will be projected into the volume as a file whose name is the
+                                                      key and content is the value. If specified, the listed keys will be
+                                                      projected into the specified paths, and unlisted keys will not be
+                                                      present. If a key is specified which is not present in the ConfigMap,
+                                                      the volume setup will error unless it is marked optional. Paths must be
+                                                      relative and may not contain the '..' path or start with '..'.
+                                                    items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: |-
+                                                            mode is Optional: mode bits used to set permissions on this file.
+                                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                            If not specified, the volume defaultMode will be used.
+                                                            This might be in conflict with other options that affect the file
+                                                            mode, like fsGroup, and the result can be other mode bits set.
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: |-
+                                                            path is the relative path of the file to map the key to.
+                                                            May not be an absolute path.
+                                                            May not contain the path element '..'.
+                                                            May not start with the string '..'.
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: optional specify
+                                                      whether the ConfigMap or its
+                                                      keys must be defined
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              downwardAPI:
+                                                description: downwardAPI information
+                                                  about the downwardAPI data to project
+                                                properties:
+                                                  items:
+                                                    description: Items is a list of
+                                                      DownwardAPIVolume file
+                                                    items:
+                                                      description: DownwardAPIVolumeFile
+                                                        represents information to
+                                                        create the file containing
+                                                        the pod field
+                                                      properties:
+                                                        fieldRef:
+                                                          description: 'Required:
+                                                            Selects a field of the
+                                                            pod: only annotations,
+                                                            labels, name, namespace
+                                                            and uid are supported.'
+                                                          properties:
+                                                            apiVersion:
+                                                              description: Version
+                                                                of the schema the
+                                                                FieldPath is written
+                                                                in terms of, defaults
+                                                                to "v1".
+                                                              type: string
+                                                            fieldPath:
+                                                              description: Path of
+                                                                the field to select
+                                                                in the specified API
+                                                                version.
+                                                              type: string
+                                                          required:
+                                                          - fieldPath
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        mode:
+                                                          description: |-
+                                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                                            between 0000 and 0777 or a decimal value between 0 and 511.
+                                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                            If not specified, the volume defaultMode will be used.
+                                                            This might be in conflict with other options that affect the file
+                                                            mode, like fsGroup, and the result can be other mode bits set.
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: 'Required:
+                                                            Path is  the relative
+                                                            path name of the file
+                                                            to be created. Must not
+                                                            be absolute or contain
+                                                            the ''..'' path. Must
+                                                            be utf-8 encoded. The
+                                                            first item of the relative
+                                                            path must not start with
+                                                            ''..'''
+                                                          type: string
+                                                        resourceFieldRef:
+                                                          description: |-
+                                                            Selects a resource of the container: only resources limits and requests
+                                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                          properties:
+                                                            containerName:
+                                                              description: 'Container
+                                                                name: required for
+                                                                volumes, optional
+                                                                for env vars'
+                                                              type: string
+                                                            divisor:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              description: Specifies
+                                                                the output format
+                                                                of the exposed resources,
+                                                                defaults to "1"
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            resource:
+                                                              description: 'Required:
+                                                                resource to select'
+                                                              type: string
+                                                          required:
+                                                          - resource
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                type: object
+                                              podCertificate:
+                                                description: |-
+                                                  Projects an auto-rotating credential bundle (private key and certificate
+                                                  chain) that the pod can use either as a TLS client or server.
+
+                                                  Kubelet generates a private key and uses it to send a
+                                                  PodCertificateRequest to the named signer.  Once the signer approves the
+                                                  request and issues a certificate chain, Kubelet writes the key and
+                                                  certificate chain to the pod filesystem.  The pod does not start until
+                                                  certificates have been issued for each podCertificate projected volume
+                                                  source in its spec.
+
+                                                  Kubelet will begin trying to rotate the certificate at the time indicated
+                                                  by the signer using the PodCertificateRequest.Status.BeginRefreshAt
+                                                  timestamp.
+
+                                                  Kubelet can write a single file, indicated by the credentialBundlePath
+                                                  field, or separate files, indicated by the keyPath and
+                                                  certificateChainPath fields.
+
+                                                  The credential bundle is a single file in PEM format.  The first PEM
+                                                  entry is the private key (in PKCS#8 format), and the remaining PEM
+                                                  entries are the certificate chain issued by the signer (typically,
+                                                  signers will return their certificate chain in leaf-to-root order).
+
+                                                  Prefer using the credential bundle format, since your application code
+                                                  can read it atomically.  If you use keyPath and certificateChainPath,
+                                                  your application must make two separate file reads. If these coincide
+                                                  with a certificate rotation, it is possible that the private key and leaf
+                                                  certificate you read may not correspond to each other.  Your application
+                                                  will need to check for this condition, and re-read until they are
+                                                  consistent.
+
+                                                  The named signer controls chooses the format of the certificate it
+                                                  issues; consult the signer implementation's documentation to learn how to
+                                                  use the certificates it issues.
+                                                properties:
+                                                  certificateChainPath:
+                                                    description: |-
+                                                      Write the certificate chain at this path in the projected volume.
+
+                                                      Most applications should use credentialBundlePath.  When using keyPath
+                                                      and certificateChainPath, your application needs to check that the key
+                                                      and leaf certificate are consistent, because it is possible to read the
+                                                      files mid-rotation.
+                                                    type: string
+                                                  credentialBundlePath:
+                                                    description: |-
+                                                      Write the credential bundle at this path in the projected volume.
+
+                                                      The credential bundle is a single file that contains multiple PEM blocks.
+                                                      The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private
+                                                      key.
+
+                                                      The remaining blocks are CERTIFICATE blocks, containing the issued
+                                                      certificate chain from the signer (leaf and any intermediates).
+
+                                                      Using credentialBundlePath lets your Pod's application code make a single
+                                                      atomic read that retrieves a consistent key and certificate chain.  If you
+                                                      project them to separate files, your application code will need to
+                                                      additionally check that the leaf certificate was issued to the key.
+                                                    type: string
+                                                  keyPath:
+                                                    description: |-
+                                                      Write the key at this path in the projected volume.
+
+                                                      Most applications should use credentialBundlePath.  When using keyPath
+                                                      and certificateChainPath, your application needs to check that the key
+                                                      and leaf certificate are consistent, because it is possible to read the
+                                                      files mid-rotation.
+                                                    type: string
+                                                  keyType:
+                                                    description: |-
+                                                      The type of keypair Kubelet will generate for the pod.
+
+                                                      Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384",
+                                                      "ECDSAP521", and "ED25519".
+                                                    type: string
+                                                  maxExpirationSeconds:
+                                                    description: |-
+                                                      maxExpirationSeconds is the maximum lifetime permitted for the
+                                                      certificate.
+
+                                                      Kubelet copies this value verbatim into the PodCertificateRequests it
+                                                      generates for this projection.
+
+                                                      If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver
+                                                      will reject values shorter than 3600 (1 hour).  The maximum allowable
+                                                      value is 7862400 (91 days).
+
+                                                      The signer implementation is then free to issue a certificate with any
+                                                      lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600
+                                                      seconds (1 hour).  This constraint is enforced by kube-apiserver.
+                                                      `kubernetes.io` signers will never issue certificates with a lifetime
+                                                      longer than 24 hours.
+                                                    format: int32
+                                                    type: integer
+                                                  signerName:
+                                                    description: Kubelet's generated
+                                                      CSRs will be addressed to this
+                                                      signer.
+                                                    type: string
+                                                  userAnnotations:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      userAnnotations allow pod authors to pass additional information to
+                                                      the signer implementation.  Kubernetes does not restrict or validate this
+                                                      metadata in any way.
+
+                                                      These values are copied verbatim into the `spec.unverifiedUserAnnotations` field of
+                                                      the PodCertificateRequest objects that Kubelet creates.
+
+                                                      Entries are subject to the same validation as object metadata annotations,
+                                                      with the addition that all keys must be domain-prefixed. No restrictions
+                                                      are placed on values, except an overall size limitation on the entire field.
+
+                                                      Signers should document the keys and values they support. Signers should
+                                                      deny requests that contain keys they do not recognize.
+                                                    type: object
+                                                required:
+                                                - keyType
+                                                - signerName
+                                                type: object
+                                              secret:
+                                                description: secret information about
+                                                  the secret data to project
+                                                properties:
+                                                  items:
+                                                    description: |-
+                                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                                      Secret will be projected into the volume as a file whose name is the
+                                                      key and content is the value. If specified, the listed keys will be
+                                                      projected into the specified paths, and unlisted keys will not be
+                                                      present. If a key is specified which is not present in the Secret,
+                                                      the volume setup will error unless it is marked optional. Paths must be
+                                                      relative and may not contain the '..' path or start with '..'.
+                                                    items:
+                                                      description: Maps a string key
+                                                        to a path within a volume.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            key to project.
+                                                          type: string
+                                                        mode:
+                                                          description: |-
+                                                            mode is Optional: mode bits used to set permissions on this file.
+                                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                            If not specified, the volume defaultMode will be used.
+                                                            This might be in conflict with other options that affect the file
+                                                            mode, like fsGroup, and the result can be other mode bits set.
+                                                          format: int32
+                                                          type: integer
+                                                        path:
+                                                          description: |-
+                                                            path is the relative path of the file to map the key to.
+                                                            May not be an absolute path.
+                                                            May not contain the path element '..'.
+                                                            May not start with the string '..'.
+                                                          type: string
+                                                      required:
+                                                      - key
+                                                      - path
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  name:
+                                                    default: ""
+                                                    description: |-
+                                                      Name of the referent.
+                                                      This field is effectively required, but due to backwards compatibility is
+                                                      allowed to be empty. Instances of this type with an empty value here are
+                                                      almost certainly wrong.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    type: string
+                                                  optional:
+                                                    description: optional field specify
+                                                      whether the Secret or its key
+                                                      must be defined
+                                                    type: boolean
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              serviceAccountToken:
+                                                description: serviceAccountToken is
+                                                  information about the serviceAccountToken
+                                                  data to project
+                                                properties:
+                                                  audience:
+                                                    description: |-
+                                                      audience is the intended audience of the token. A recipient of a token
+                                                      must identify itself with an identifier specified in the audience of the
+                                                      token, and otherwise should reject the token. The audience defaults to the
+                                                      identifier of the apiserver.
+                                                    type: string
+                                                  expirationSeconds:
+                                                    description: |-
+                                                      expirationSeconds is the requested duration of validity of the service
+                                                      account token. As the token approaches expiration, the kubelet volume
+                                                      plugin will proactively rotate the service account token. The kubelet will
+                                                      start trying to rotate the token if the token is older than 80 percent of
+                                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                      and must be at least 10 minutes.
+                                                    format: int64
+                                                    type: integer
+                                                  path:
+                                                    description: |-
+                                                      path is the path relative to the mount point of the file to project the
+                                                      token into.
+                                                    type: string
+                                                required:
+                                                - path
+                                                type: object
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    quobyte:
+                                      description: |-
+                                        quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                        Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                                      properties:
+                                        group:
+                                          description: |-
+                                            group to map volume access to
+                                            Default is no group
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                            Defaults to false.
+                                          type: boolean
+                                        registry:
+                                          description: |-
+                                            registry represents a single or multiple Quobyte Registry services
+                                            specified as a string as host:port pair (multiple entries are separated with commas)
+                                            which acts as the central registry for volumes
+                                          type: string
+                                        tenant:
+                                          description: |-
+                                            tenant owning the given Quobyte volume in the Backend
+                                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                          type: string
+                                        user:
+                                          description: |-
+                                            user to map volume access to
+                                            Defaults to serivceaccount user
+                                          type: string
+                                        volume:
+                                          description: volume is a string that references
+                                            an already created Quobyte volume by name.
+                                          type: string
+                                      required:
+                                      - registry
+                                      - volume
+                                      type: object
+                                    rbd:
+                                      description: |-
+                                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                        Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type of the volume that you want to mount.
+                                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          type: string
+                                        image:
+                                          description: |-
+                                            image is the rados image name.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          type: string
+                                        keyring:
+                                          default: /etc/ceph/keyring
+                                          description: |-
+                                            keyring is the path to key ring for RBDUser.
+                                            Default is /etc/ceph/keyring.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          type: string
+                                        monitors:
+                                          description: |-
+                                            monitors is a collection of Ceph monitors.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        pool:
+                                          default: rbd
+                                          description: |-
+                                            pool is the rados pool name.
+                                            Default is rbd.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                                            Defaults to false.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          type: boolean
+                                        secretRef:
+                                          description: |-
+                                            secretRef is name of the authentication secret for RBDUser. If provided
+                                            overrides keyring.
+                                            Default is nil.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        user:
+                                          default: admin
+                                          description: |-
+                                            user is the rados user name.
+                                            Default is admin.
+                                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                          type: string
+                                      required:
+                                      - image
+                                      - monitors
+                                      type: object
+                                    scaleIO:
+                                      description: |-
+                                        scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                        Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                                      properties:
+                                        fsType:
+                                          default: xfs
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs".
+                                            Default is "xfs".
+                                          type: string
+                                        gateway:
+                                          description: gateway is the host address
+                                            of the ScaleIO API Gateway.
+                                          type: string
+                                        protectionDomain:
+                                          description: protectionDomain is the name
+                                            of the ScaleIO Protection Domain for the
+                                            configured storage.
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly Defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: |-
+                                            secretRef references to the secret for ScaleIO user and other
+                                            sensitive information. If this is not provided, Login operation will fail.
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        sslEnabled:
+                                          description: sslEnabled Flag enable/disable
+                                            SSL communication with Gateway, default
+                                            false
+                                          type: boolean
+                                        storageMode:
+                                          default: ThinProvisioned
+                                          description: |-
+                                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                            Default is ThinProvisioned.
+                                          type: string
+                                        storagePool:
+                                          description: storagePool is the ScaleIO
+                                            Storage Pool associated with the protection
+                                            domain.
+                                          type: string
+                                        system:
+                                          description: system is the name of the storage
+                                            system as configured in ScaleIO.
+                                          type: string
+                                        volumeName:
+                                          description: |-
+                                            volumeName is the name of a volume already created in the ScaleIO system
+                                            that is associated with this volume source.
+                                          type: string
+                                      required:
+                                      - gateway
+                                      - secretRef
+                                      - system
+                                      type: object
+                                    secret:
+                                      description: |-
+                                        secret represents a secret that should populate this volume.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                      properties:
+                                        defaultMode:
+                                          description: |-
+                                            defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values
+                                            for mode bits. Defaults to 0644.
+                                            Directories within the path are not affected by this setting.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        items:
+                                          description: |-
+                                            items If unspecified, each key-value pair in the Data field of the referenced
+                                            Secret will be projected into the volume as a file whose name is the
+                                            key and content is the value. If specified, the listed keys will be
+                                            projected into the specified paths, and unlisted keys will not be
+                                            present. If a key is specified which is not present in the Secret,
+                                            the volume setup will error unless it is marked optional. Paths must be
+                                            relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path
+                                              within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: |-
+                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  If not specified, the volume defaultMode will be used.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: |-
+                                                  path is the relative path of the file to map the key to.
+                                                  May not be an absolute path.
+                                                  May not contain the path element '..'.
+                                                  May not start with the string '..'.
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        optional:
+                                          description: optional field specify whether
+                                            the Secret or its keys must be defined
+                                          type: boolean
+                                        secretName:
+                                          description: |-
+                                            secretName is the name of the secret in the pod's namespace to use.
+                                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                          type: string
+                                      type: object
+                                    storageos:
+                                      description: |-
+                                        storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                        Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is the filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            readOnly defaults to false (read/write). ReadOnly here will force
+                                            the ReadOnly setting in VolumeMounts.
+                                          type: boolean
+                                        secretRef:
+                                          description: |-
+                                            secretRef specifies the secret to use for obtaining the StorageOS API
+                                            credentials.  If not specified, default values will be attempted.
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        volumeName:
+                                          description: |-
+                                            volumeName is the human-readable name of the StorageOS volume.  Volume
+                                            names are only unique within a namespace.
+                                          type: string
+                                        volumeNamespace:
+                                          description: |-
+                                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                            namespace is specified then the Pod's namespace will be used.  This allows the
+                                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                            Set VolumeName to any name to override the default behaviour.
+                                            Set to "default" if you are not using namespaces within StorageOS.
+                                            Namespaces that do not pre-exist within StorageOS will be created.
+                                          type: string
+                                      type: object
+                                    vsphereVolume:
+                                      description: |-
+                                        vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                        Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                        are redirected to the csi.vsphere.vmware.com CSI driver.
+                                      properties:
+                                        fsType:
+                                          description: |-
+                                            fsType is filesystem type to mount.
+                                            Must be a filesystem type supported by the host operating system.
+                                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          type: string
+                                        storagePolicyID:
+                                          description: storagePolicyID is the storage
+                                            Policy Based Management (SPBM) profile
+                                            ID associated with the StoragePolicyName.
+                                          type: string
+                                        storagePolicyName:
+                                          description: storagePolicyName is the storage
+                                            Policy Based Management (SPBM) profile
+                                            name.
+                                          type: string
+                                        volumePath:
+                                          description: volumePath is the path that
+                                            identifies vSphere volume vmdk
+                                          type: string
+                                      required:
+                                      - volumePath
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              workloadRef:
+                                description: |-
+                                  WorkloadRef provides a reference to the Workload object that this Pod belongs to.
+                                  This field is used by the scheduler to identify the PodGroup and apply the
+                                  correct group scheduling policies. The Workload object referenced
+                                  by this field may not exist at the time the Pod is created.
+                                  This field is immutable, but a Workload object with the same name
+                                  may be recreated with different policies. Doing this during pod scheduling
+                                  may result in the placement not conforming to the expected policies.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name defines the name of the Workload object this Pod belongs to.
+                                      Workload must be in the same namespace as the Pod.
+                                      If it doesn't match any existing Workload, the Pod will remain unschedulable
+                                      until a Workload object is created and observed by the kube-scheduler.
+                                      It must be a DNS subdomain.
+                                    type: string
+                                  podGroup:
+                                    description: |-
+                                      PodGroup is the name of the PodGroup within the Workload that this Pod
+                                      belongs to. If it doesn't match any existing PodGroup within the Workload,
+                                      the Pod will remain unschedulable until the Workload object is recreated
+                                      and observed by the kube-scheduler. It must be a DNS label.
+                                    type: string
+                                  podGroupReplicaKey:
+                                    description: |-
+                                      PodGroupReplicaKey specifies the replica key of the PodGroup to which this
+                                      Pod belongs. It is used to distinguish pods belonging to different replicas
+                                      of the same pod group. The pod group policy is applied separately to each replica.
+                                      When set, it must be a DNS label.
+                                    type: string
+                                required:
+                                - name
+                                - podGroup
+                                type: object
+                            required:
+                            - containers
+                            type: object
+                        type: object
+                      ttlSecondsAfterFinished:
+                        description: |-
+                          ttlSecondsAfterFinished limits the lifetime of a Job that has finished
+                          execution (either Complete or Failed). If this field is set,
+                          ttlSecondsAfterFinished after the Job finishes, it is eligible to be
+                          automatically deleted. When the Job is being deleted, its lifecycle
+                          guarantees (e.g. finalizers) will be honored. If this field is unset,
+                          the Job won't be automatically deleted. If this field is set to zero,
+                          the Job becomes eligible to be deleted immediately after it finishes.
+                        format: int32
+                        type: integer
+                    required:
+                    - template
+                    type: object
+                type: object
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels 는 생성되는 BackupJob 의 spec.labels 에 복사된다.
+                type: object
+              repo:
+                description: Repo 는 다중 저장소 환경에서 어느 repo 를 쓸지 식별한다.
+                minLength: 1
+                type: string
+              retention:
+                description: Retention 은 생성되는 BackupJob 에 복사되는 보존 정책이다.
+                properties:
+                  keepFull:
+                    description: KeepFull은 보존할 full 백업 개수. 0이면 무제한 (plugin 기본).
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  keepIncremental:
+                    description: KeepIncremental은 보존할 incremental/differential 백업
+                      개수.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
+              schedule:
+                description: |-
+                  Schedule 은 초 필드를 포함한 6-field cron expression 이다.
+                  형식: "second minute hour day-of-month month day-of-week".
+                  예: "0 0 2 * * *" = 매일 02:00:00.
+                minLength: 1
+                type: string
+              suspend:
+                default: false
+                description: Suspend=true 이면 새 BackupJob 생성을 중단한다. 기존 BackupJob 은
+                  건드리지 않는다.
+                type: boolean
+              tool:
+                description: Tool 은 사용할 백업 도구 이름. BackupPlugin.Name() 과 일치해야 한다.
+                minLength: 1
+                type: string
+              type:
+                default: full
+                description: Type 은 정기 백업 종류다. restore 는 atomic BackupJob 에서만 허용한다.
+                enum:
+                - full
+                - incremental
+                - differential
+                type: string
+            required:
+            - cluster
+            - repo
+            - schedule
+            - tool
+            type: object
+          status:
+            description: ScheduledBackupStatus 는 정기 백업 컨트롤러의 관찰 상태다.
+            properties:
+              conditions:
+                description: Conditions 는 K8s 표준 상태다.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastBackupJobName:
+                description: LastBackupJobName 은 마지막으로 생성한 BackupJob 이름이다.
+                type: string
+              lastScheduleTime:
+                description: LastScheduleTime 은 마지막으로 BackupJob 생성을 시도한 스케줄 시각이다.
+                format: date-time
+                type: string
+              nextScheduleTime:
+                description: NextScheduleTime 은 다음 생성 예정 시각이다.
+                format: date-time
+                type: string
+              observedGeneration:
+                description: ObservedGeneration 은 reconciler 가 마지막 처리한 spec generation
+                  이다.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.18/metadata/annotations.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.18/metadata/annotations.yaml
@@ -1,0 +1,15 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: keiailab-postgres-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.2
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/keiailab-postgres-operator/0.3.0-alpha.18/tests/scorecard/config.yaml
+++ b/operators/keiailab-postgres-operator/0.3.0-alpha.18/tests/scorecard/config.yaml
@@ -1,0 +1,67 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.2
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}

--- a/operators/keiailab-postgres-operator/ci.yaml
+++ b/operators/keiailab-postgres-operator/ci.yaml
@@ -1,0 +1,6 @@
+---
+# Use `replaces-mode` or `semver-mode`. Once you switch to `semver-mode`, there is no easy way back.
+updateGraph: replaces-mode
+
+reviewers:
+  - eightynine01


### PR DESCRIPTION
## Summary

Initial submission of the keiailab-postgres-operator OLM bundle to the community-operators channel.

- Apache-2.0 Kubernetes operator for vanilla PostgreSQL 18+ on Kubernetes.
- 8 owned CRDs: PostgresCluster, BackupJob, ScheduledBackup, Pooler, PostgresDatabase, PostgresUser, ImageCatalog, ClusterImageCatalog.
- Built-in PgBouncer auth + password rotation + cert-manager AutoTLS integration (Pooler reconciler).
- CNPG-compatible surface for ImageCatalog / hibernation / externalClusters / standalone replica cluster.
- 4-layer local gate (lefthook + Makefile validate/audit/gate + PR evidence); GitHub Actions intentionally unused per RFC-0002.
- 0 known HIGH/CRITICAL vulnerabilities; spdystream v0.5.1 (CVE-2026-35469 fix) included.

Source: https://github.com/keiailab/postgres-operator
Release: 0.3.0-alpha.18 (2026-05-12)
Bundle validate (default + operatorframework suite): PASS via \`operator-sdk bundle validate\`.

## Why \`keiailab-postgres-operator\` and not \`postgres-operator\`?

The directory \`operators/postgres-operator/\` is occupied by zalando (postgresqls.acid.zalan.do). This bundle uses the package name \`keiailab-postgres-operator\` matching the helm chart's Artifact Hub alternativeName.

## Test plan

- [x] \`operator-sdk bundle validate ./bundle\` (default + operatorframework suite) PASS
- [x] \`make validate\` (8 CRDs + 18 monitoring grep + Chart version drift + .github/workflows absence + kube-linter) PASS
- [x] Pooler Service psql round-trip live verified on kind (2026-05-12, PG18)
- [ ] Bundle image push to \`ghcr.io/keiailab/postgres-operator-bundle:0.3.0-alpha.18\` (requires maintainer PAT with \`write:packages\` scope; will be completed before CI runs)
- [ ] community-operators CI green

This PR is opened as a **Draft** until the bundle image push completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)