### PR TITLE
operator trustee-operator (0.19.0)

### DIFF
--- a/operators/trustee-operator/0.19.0/manifests/confidentialcontainers.org_kbsconfigs.yaml
+++ b/operators/trustee-operator/0.19.0/manifests/confidentialcontainers.org_kbsconfigs.yaml
@@ -1,0 +1,195 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  creationTimestamp: null
+  name: kbsconfigs.confidentialcontainers.org
+spec:
+  group: confidentialcontainers.org
+  names:
+    kind: KbsConfig
+    listKind: KbsConfigList
+    plural: kbsconfigs
+    singular: kbsconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KbsConfig is the Schema for the kbsconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KbsConfigSpec defines the desired state of KbsConfig
+            properties:
+              KbsDeploymentSpec:
+                description: KbsDeploymentSpec is the struct for trustee deployment
+                  options
+                properties:
+                  replicas:
+                    description: |-
+                      Number of desired trustee pods. This is a pointer to distinguish between explicit
+                      zero and not specified. Defaults to 1.
+                    format: int32
+                    type: integer
+                type: object
+              KbsEnvVars:
+                additionalProperties:
+                  type: string
+                description: |-
+                  KbsEnvVars injects environment variables in the trustee pods
+                  For example, RUST_LOG=debug enables logging with DEBUG severity
+                type: object
+              ibmSEConfigSpec:
+                description: IbmSEConfigSpec is the struct that hosts the IBMSE specific
+                  configuration
+                properties:
+                  certStorePvc:
+                    description: certStorePvc is the name of the PeristentVolumeClaim
+                      where certificates/keys are mounted
+                    type: string
+                type: object
+              kbsAsConfigMapName:
+                description: |-
+                  KbsAsConfigMapName is the name of the configmap that contains the KBS AS configuration
+                  Required only when MicroservicesDeployment is set
+                type: string
+              kbsAttestationCertSecretName:
+                description: KbsAttestationCertSecretName is the name of the secret
+                  that contains the attestation token certificate
+                type: string
+              kbsAttestationKeySecretName:
+                description: KbsAttestationKeySecretName is the name of the secret
+                  that contains the attestation token private key
+                type: string
+              kbsAttestationPolicyConfigMapName:
+                description: KbsAttestationPolicyConfigMapName is the name of the
+                  configmap that contains the Attestation Policy
+                type: string
+              kbsAuthSecretName:
+                description: KbsAuthSecretName is the name of the secret that contains
+                  the KBS auth secret
+                type: string
+              kbsConfigMapName:
+                description: KbsConfigMapName is the name of the configmap that contains
+                  the KBS configuration
+                type: string
+              kbsDeploymentType:
+                description: |-
+                  KbsDeploymentType is the type of KBS deployment
+                  It can assume one of the following values:
+                     AllInOneDeployment: all the KBS components will be deployed in the same container
+                     MicroservicesDeployment: all the KBS components will be deployed in separate containers
+                  Default value is AllInOneDeployment
+                enum:
+                - AllInOneDeployment
+                - MicroservicesDeployment
+                type: string
+              kbsGpuAttestationPolicyConfigMapName:
+                description: KbsGpuAttestationPolicyConfigMapName is the name of the
+                  configmap that contains the GPU Attestation Policy
+                type: string
+              kbsHttpsCertSecretName:
+                description: KbsHttpsCertSecretName is the name of the secret that
+                  contains the KBS https certificate
+                type: string
+              kbsHttpsKeySecretName:
+                description: KbsHttpsKeySecretName is the name of the secret that
+                  contains the KBS https private key
+                type: string
+              kbsLocalCertCacheSpec:
+                description: KbsLocalCertCacheSpec is the struct for mounting local
+                  certificates into trustee file system
+                properties:
+                  secrets:
+                    description: Secrets is a list of certificate cache entries, each
+                      containing a secret name and mount path
+                    items:
+                      description: KbsLocalCertCacheEntry defines a single certificate
+                        cache entry with secret and mount path
+                      properties:
+                        mountPath:
+                          description: |-
+                            MountPath is the destination path in the trustee file system
+                            The default path is "/opt/confidential-containers/attestation-service/kds-store/vcek" if not specified by the user
+                          type: string
+                        secretName:
+                          description: SecretName is the name of the secret that maps
+                            to a local directory containing the certificates
+                          type: string
+                      required:
+                      - secretName
+                      type: object
+                    type: array
+                type: object
+              kbsResourcePolicyConfigMapName:
+                description: KbsResourcePolicyConfigMapName is the name of the configmap
+                  that contains the Resource Policy
+                type: string
+              kbsRvpsConfigMapName:
+                description: |-
+                  KbsRvpsConfigMapName is the name of the configmap that contains the KBS RVPS configuration
+                  Required only when MicroservicesDeployment is set
+                type: string
+              kbsRvpsRefValuesConfigMapName:
+                description: kbsRvpsRefValuesConfigMapName is the name of the configmap
+                  that contains the RVPS reference values
+                type: string
+              kbsSecretResources:
+                description: KbsSecretResources is an array of secret names that contain
+                  the keys required by clients
+                items:
+                  type: string
+                type: array
+              kbsServiceType:
+                description: |-
+                  KbsServiceType is the type of service to create for KBS
+                  Default value is ClusterIP
+                type: string
+              tdxConfigSpec:
+                description: TdxConfigSpec is the struct that hosts the TDX specific
+                  configuration
+                properties:
+                  kbsTdxConfigMapName:
+                    description: kbsTdxConfigMapName is the name of the configmap
+                      containing sgx_default_qcnl.conf file
+                    type: string
+                type: object
+            type: object
+          status:
+            description: KbsConfigStatus defines the observed state of KbsConfig
+            properties:
+              isReady:
+                description: IsReady is true when the KBS configuration is ready
+                type: boolean
+            required:
+            - isReady
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/trustee-operator/0.19.0/manifests/confidentialcontainers.org_trusteeconfigs.yaml
+++ b/operators/trustee-operator/0.19.0/manifests/confidentialcontainers.org_trusteeconfigs.yaml
@@ -1,0 +1,137 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  creationTimestamp: null
+  name: trusteeconfigs.confidentialcontainers.org
+spec:
+  group: confidentialcontainers.org
+  names:
+    kind: TrusteeConfig
+    listKind: TrusteeConfigList
+    plural: trusteeconfigs
+    singular: trusteeconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TrusteeConfig is the Schema for the trusteeconfigs API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TrusteeConfigSpec defines the desired state of TrusteeConfig
+            properties:
+              attestationTokenVerificationSpec:
+                description: AttestationTokenVerificationSpec token validation using
+                  trusted certificate authorities
+                properties:
+                  tlsSecretName:
+                    description: |-
+                      TlsSecretName is the name of the Kubernetes TLS secret (type: kubernetes.io/tls)
+                      that contains the TLS certificate for attestation token verification
+                    type: string
+                type: object
+              httpsSpec:
+                description: HttpsSpec is the struct that hosts the HTTPS configuration
+                properties:
+                  tlsSecretName:
+                    description: |-
+                      TlsSecretName is the name of the Kubernetes TLS secret (type: kubernetes.io/tls)
+                      that contains the TLS certificate and private key
+                    type: string
+                type: object
+              kbsServiceType:
+                description: |-
+                  KbsServiceType is the type of service to create for KBS
+                  Default value is ClusterIP
+                type: string
+              profileType:
+                description: ProfileType determines how to configure trustee, e.g.
+                  in permissive/restricted mode etc.
+                type: string
+            type: object
+          status:
+            description: TrusteeConfigStatus defines the observed state of TrusteeConfig
+            properties:
+              isReady:
+                description: IsReady is true when the TrusteeConfig configuration
+                  is ready
+                type: boolean
+              kbsConfigRef:
+                description: KbsConfigRef is a reference to the associated KbsConfig
+                  object
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              statusDescription:
+                description: StatusDescription provides a human-readable description
+                  of the current status
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/trustee-operator/0.19.0/manifests/trustee-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/trustee-operator/0.19.0/manifests/trustee-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: trustee-operator
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: trustee-operator
+    control-plane: controller-manager
+  name: trustee-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/trustee-operator/0.19.0/manifests/trustee-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/trustee-operator/0.19.0/manifests/trustee-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: trustee-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/trustee-operator/0.19.0/manifests/trustee-operator-trusteeconfig-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/trustee-operator/0.19.0/manifests/trustee-operator-trusteeconfig-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,31 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: trustee-operator
+    app.kubernetes.io/instance: trusteeconfig-editor-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: trustee-operator
+  name: trustee-operator-trusteeconfig-editor-role
+rules:
+- apiGroups:
+  - confidentialcontainers.org
+  resources:
+  - trusteeconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - confidentialcontainers.org
+  resources:
+  - trusteeconfigs/status
+  verbs:
+  - get

--- a/operators/trustee-operator/0.19.0/manifests/trustee-operator-trusteeconfig-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/trustee-operator/0.19.0/manifests/trustee-operator-trusteeconfig-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: trustee-operator
+    app.kubernetes.io/instance: trusteeconfig-viewer-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: trustee-operator
+  name: trustee-operator-trusteeconfig-viewer-role
+rules:
+- apiGroups:
+  - confidentialcontainers.org
+  resources:
+  - trusteeconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - confidentialcontainers.org
+  resources:
+  - trusteeconfigs/status
+  verbs:
+  - get

--- a/operators/trustee-operator/0.19.0/manifests/trustee-operator.clusterserviceversion.yaml
+++ b/operators/trustee-operator/0.19.0/manifests/trustee-operator.clusterserviceversion.yaml
@@ -1,0 +1,266 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[]'
+    capabilities: Basic Install
+    categories: Security
+    containerImage: quay.io/confidential-containers/trustee-operator:v0.19.0
+    createdAt: "2026-05-21T15:49:55Z"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/suggested-namespace: trustee-operator-system
+    operators.operatorframework.io/builder: operator-sdk-v1.42.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    support: Confidential Containers Community
+  name: trustee-operator.v0.19.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: KbsConfig is the Schema for the kbsconfigs API
+      displayName: Kbs Config
+      kind: KbsConfig
+      name: kbsconfigs.confidentialcontainers.org
+      version: v1alpha1
+    - kind: TrusteeConfig
+      name: trusteeconfigs.confidentialcontainers.org
+      version: v1alpha1
+  description: Operator to manage the lifecycle of Trustee
+  displayName: Trustee Operator
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTguNTEgMjU4LjUxIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2QxZDFkMTt9LmNscy0ye2ZpbGw6IzhkOGQ4Zjt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkFzc2V0IDQ8L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTI5LjI1LDIwQTEwOS4xLDEwOS4xLDAsMCwxLDIwNi40LDIwNi40LDEwOS4xLDEwOS4xLDAsMSwxLDUyLjExLDUyLjExLDEwOC40NSwxMDguNDUsMCwwLDEsMTI5LjI1LDIwbTAtMjBoMEM1OC4xNiwwLDAsNTguMTYsMCwxMjkuMjVIMGMwLDcxLjA5LDU4LjE2LDEyOS4yNiwxMjkuMjUsMTI5LjI2aDBjNzEuMDksMCwxMjkuMjYtNTguMTcsMTI5LjI2LTEyOS4yNmgwQzI1OC41MSw1OC4xNiwyMDAuMzQsMCwxMjkuMjUsMFoiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0xNzcuNTQsMTAzLjQxSDE0MS42NkwxNTQuOSw2NS43NmMxLjI1LTQuNC0yLjMzLTguNzYtNy4yMS04Ljc2SDEwMi45M2E3LjMyLDcuMzIsMCwwLDAtNy40LDZsLTEwLDY5LjYxYy0uNTksNC4xNywyLjg5LDcuODksNy40LDcuODloMzYuOUwxMTUuNTUsMTk3Yy0xLjEyLDQuNDEsMi40OCw4LjU1LDcuMjQsOC41NWE3LjU4LDcuNTgsMCwwLDAsNi40Ny0zLjQ4TDE4NCwxMTMuODVDMTg2Ljg2LDEwOS4yNCwxODMuMjksMTAzLjQxLDE3Ny41NCwxMDMuNDFaIi8+PC9nPjwvZz48L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - confidentialcontainers.org
+          resources:
+          - kbsconfigs
+          - trusteeconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - confidentialcontainers.org
+          resources:
+          - kbsconfigs/finalizers
+          - trusteeconfigs/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - confidentialcontainers.org
+          resources:
+          - kbsconfigs/status
+          - trusteeconfigs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - proxies
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: trustee-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/component: manager
+          app.kubernetes.io/created-by: trustee-operator
+          app.kubernetes.io/instance: controller-manager
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: deployment
+          app.kubernetes.io/part-of: trustee-operator
+          control-plane: controller-manager
+        name: trustee-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                command:
+                - /manager
+                env:
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OPERATOR_IMAGE_NAME
+                  value: quay.io/confidential-containers/trustee-operator:v0.19.0
+                - name: KBS_IMAGE_NAME
+                  value: ghcr.io/confidential-containers/key-broker-service:built-in-as-v0.19.0-trustee-operator
+                - name: KBS_IMAGE_NAME_MICROSERVICES
+                  value: ghcr.io/confidential-containers/key-broker-service:v0.19.0
+                - name: AS_IMAGE_NAME
+                  value: ghcr.io/confidential-containers/staged-images/coco-as-grpc:latest
+                - name: RVPS_IMAGE_NAME
+                  value: ghcr.io/confidential-containers/staged-images/rvps:latest
+                image: quay.io/confidential-containers/trustee-operator:v0.19.0
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                  requests:
+                    cpu: 10m
+                    memory: 256Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: trustee-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: trustee-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - trustee
+  - trustee-operator
+  - attestation-service
+  - rvps
+  links:
+  - name: Trustee Operator
+    url: https://github.com/confidential-containers/trustee-operator
+  maintainers:
+  - email: cncf-ccontainers-maintainers@lists.cncf.io
+    name: Pradipta Banerjee
+  - email: cncf-ccontainers-maintainers@lists.cncf.io
+    name: Jens Freimann
+  - email: lmilleri@redhat.com
+    name: Leonardo Milleri
+  maturity: alpha
+  provider:
+    name: Confidential Containers Community
+    url: https://github.com/confidential-containers
+  replaces: trustee-operator.v0.18.0
+  version: 0.19.0

--- a/operators/trustee-operator/0.19.0/metadata/annotations.yaml
+++ b/operators/trustee-operator/0.19.0/metadata/annotations.yaml
@@ -1,0 +1,14 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: trustee-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/trustee-operator/0.19.0/tests/scorecard/config.yaml
+++ b/operators/trustee-operator/0.19.0/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.28.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.28.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.28.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.28.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.28.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.28.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
# New Operator Submission

## Operator Information
- **Operator Name**: trustee-operator
- **Version**: 0.19.0
- **Catalog**: community

## Description
Trustee Operator manages the deployment and lifecycle of Trustee components for Confidential Containers.

## Testing
- Bundle validation: `operator-sdk bundle validate operators/trustee-operator/0.19.0`
- Scorecard tests included in bundle

## Checklist
- [x] Bundle files follow community-operators guidelines
- [x] Operator metadata is complete
- [x] Version follows semantic versioning
- [x] ClusterServiceVersion replaces field points to previous version

🤖 Generated with automated release scripts