### PR TITLE
operator [CI] attune (0.1.7)

### DIFF
--- a/operators/attune/0.1.7/manifests/attune-operator.clusterserviceversion.yaml
+++ b/operators/attune/0.1.7/manifests/attune-operator.clusterserviceversion.yaml
@@ -1,0 +1,393 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: attune-operator.v0.1.7
+  namespace: placeholder
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "attune.io/v1alpha1",
+          "kind": "AttunePolicy",
+          "metadata": {
+            "name": "my-app-policy",
+            "namespace": "default"
+          },
+          "spec": {
+            "targetRef": {
+              "kind": "Deployment",
+              "name": "my-app"
+            },
+            "updateStrategy": {
+              "type": "InPlace"
+            }
+          }
+        },
+        {
+          "apiVersion": "attune.io/v1alpha1",
+          "kind": "AttuneDefaults",
+          "metadata": {
+            "name": "cluster-defaults"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "attune.io/v1alpha1",
+          "kind": "AttuneNamespaceDefaults",
+          "metadata": {
+            "name": "namespace-defaults",
+            "namespace": "default"
+          },
+          "spec": {}
+        }
+      ]
+    categories: "Application Runtime,Monitoring"
+    capabilities: Auto Pilot
+    containerImage: ghcr.io/attune-io/attune:v0.1.7
+    createdAt: "2026-05-29T00:00:00Z"
+    support: attune-io
+    repository: https://github.com/attune-io/attune
+    description: Safe, in-place Kubernetes pod resource right-sizing using real Prometheus metrics. A modern VPA replacement.
+    operators.operatorframework.io/builder: operator-sdk-v1.39.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+spec:
+  displayName: Attune
+  description: |
+    ## Attune
+
+    Attune is a Kubernetes operator for safe, in-place pod resource right-sizing
+    using real Prometheus metrics. It is a modern replacement for the Vertical Pod
+    Autoscaler (VPA) that leverages the Kubernetes 1.32+ In-Place Pod Resize feature
+    to adjust CPU and memory requests without restarting pods.
+
+    ### Features
+
+    * **In-Place Resizing** - Adjusts container resources without pod restarts using the Kubernetes In-Place Pod Resize API (requires Kubernetes 1.32+)
+    * **Prometheus-Driven** - Uses real Prometheus metrics for accurate, data-driven resource recommendations
+    * **Safety Guardrails** - Configurable bounds, cooldown periods, and disruption budgets prevent unsafe changes
+    * **Auto-Rollback** - Post-resize safety observation with automatic rollback on OOMKill or degraded performance
+    * **Cluster & Namespace Defaults** - AttuneDefaults and AttuneNamespaceDefaults CRDs let you set organization-wide policies
+    * **HPA-Aware** - Automatically detects and avoids conflicts with Horizontal Pod Autoscalers
+    * **Cost Optimization** - Right-sizes resources to actual usage, reducing cloud spend without sacrificing reliability
+    * **Multi-Source Metrics** - Works with Prometheus, Thanos, VictoriaMetrics, and Grafana Mimir
+
+    ### Capability Level: Auto Pilot
+
+    Attune operates at the highest operator capability level:
+
+    * **Deep Insights** - Exposes 22+ Prometheus metrics, ships a Grafana dashboard, and emits Kubernetes Events for every resize action
+    * **Auto Pilot** - Continuously analyzes workload metrics and automatically adjusts CPU and memory resources based on real usage patterns, with configurable safety bounds and automatic rollback
+
+    ### How It Works
+
+    1. Create an `AttunePolicy` targeting a Deployment, StatefulSet, DaemonSet, or other workload
+    2. Attune queries Prometheus for real resource usage metrics
+    3. The operator calculates optimal resource requests based on actual usage patterns
+    4. Resources are adjusted in-place (no pod restart) or via controlled rollout
+
+    ### Prerequisites
+
+    * Kubernetes 1.32+ (In-Place Pod Resize feature gate enabled; beta and enabled by default in 1.33+)
+    * Prometheus instance accessible from the operator
+
+    ### Getting Started
+
+    After installing the operator, create an AttunePolicy to start right-sizing a workload:
+
+    ```yaml
+    apiVersion: attune.io/v1alpha1
+    kind: AttunePolicy
+    metadata:
+      name: my-app-policy
+    spec:
+      targetRef:
+        kind: Deployment
+        name: my-app
+      updateStrategy:
+        type: InPlace
+    ```
+
+  maturity: alpha
+  version: 0.1.7
+  minKubeVersion: "1.32.0"
+
+  keywords:
+    - kubernetes
+    - autoscaling
+    - vpa
+    - right-sizing
+    - resources
+    - in-place
+    - cost-optimization
+    - finops
+    - prometheus
+    - vertical-pod-autoscaler
+    - resource-optimization
+
+  maintainers:
+    - name: attune-io
+      email: maintainers@attune.io
+
+  provider:
+    name: attune-io
+
+  links:
+    - name: Documentation
+      url: https://attune-io.github.io/attune/
+    - name: GitHub
+      url: https://github.com/attune-io/attune
+
+  icon:
+    - base64data: iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAAIGNIUk0AAHomAACAhAAA+gAAAIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGYktHRAD/AP8A/6C9p5MAAAAHdElNRQfqBRwRBQ23BrSsAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDI2LTA1LTI2VDIwOjIzOjIxKzAwOjAwcS2CTQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAyNi0wNS0yNlQyMDoyMzoyMSswMDowMABwOvEAAAAodEVYdGRhdGU6dGltZXN0YW1wADIwMjYtMDUtMjhUMTc6MDU6MTMrMDA6MDA6lxFKAAA4UElEQVR42q19eZhlVXXvb5071NTV1d3V1U1PQHdDM3Q3k8xGEFEgggKOEY1JlGAkJn4vyXt+iTFiNOa9SNT4zDP5VEA0asIgyidBAQkoMw3dzFNDNz2PNVfdusNZ749z9t5rT+feanL4mqq695y9115r7TX89tr7EDq8/s+3H8H/uvJ0/MFf/Qw3/P1tuOpv3rd8296JCyamG5dP11pvma6lAwwCEUCUP8QMgLPfiQAk+ces25W/k35QfwuAPFqY2dzLqp/8TzLtqLaJASSc30cAJaZPNs3AedaiTf1K0AOU32dfUdYGG1qQ88QbL3M+vPwZMs0rtrHko2iEAHRVMdnbnTzS31O5demi3ju+88Vvvvb+T38cf/HRM/DApl34s4+d3ZFcqd0N3/3ps7jl9g1YuKAPN/7kafzRFaet2rZn8iP7R2rvna6nx7ZSVDkfTDYWAhLKhMSCc4RCBfCF7xBqMTWgBGCjL64CmN6yBhIKti3bl/RZws+F7I7DpZ+EAMnWAD0nMvkr4RKseQOGbp3NGIxSZM+WEjS7q3hlbl/llhWL+75/3bc3vvh7HzsR2/eM4UPvOhlXvvfEQr6WCoV/+/P42LuOw/d/9hyWLOzun7+g/w9f2zX2jYOjjffVGryYmUrIha5442oqKNEDtD7Xv5MvfDbDJyIhIDazjERr5LSaf6nb1opCHo1WEy5x8nsSM1y17/x0HjH6QuR3RpwZIv1drgTSFCiNDtBHeePMnNQbvHByunnOgZHaO9etX1ReMtT7/L6Reu3CNx+No097P/7rjuuiMk5iX/zJl36J7dsOgI7+W/TP6TrhiRdHvr/rQO2fJqbTY1ppPihBOxPAbiO23LVw1YwlcNgEaTkFviU1IwONE6zZ7T2eUODDnCxiMHHwO6VETD5NlEkxU9Q2VkwKUDMNJNyYdDsh5hmlVo9w3kYrBSZneNWugzPXbnjxwI/nz+06/Z0fux5otXDNN+6PkhNUgE//3S/BzPj81b+FS3/7uPe/vmfy1vHp9NKUqZQNFMEBy7+NkILsBmlNMCbWatMEEmBipGCtZBxs0fGT1szPWafdrzTduRkWLUs9cMfoxgaegIiz9pLIPbqrLCYxMQGAVMUpgceUcjvGJFcb7f1aDBqfTC/cunvqpovffvxHP/WBk0rDYxP43b+4Kdiu5wI+84/3IWXGB3/7uPJOPvPqnXunv1qrt5YqfpLw5SDKmRdQBvU/8bnx9wA40QEQR01pqlsj7UbI6SQsKOtvx4RK022MWG6CmeJ628FlkxFyb2wE6rouhHkZ5o3HbTMuJGimGJiupxfc8ZvN9XNOXPDYazvH07VnXI5nH7nVetJSgC9992G0mil+/90nlj7ztXv+bO/B2pfrTe7XgifDKCkANXPtGVzIpoBvlAOV8zxmCn1rzixjhIifdwIzYh3B6AAWHZlzKzK0OjLKj8g9MAxVV+LzhVyLhkDmYfEeICpl9DOhlaI602ids3n7aOOc9XMf2jea8tlv/z08fv+PfAX4j7tfQ5o28JcfvwCv1I6/ct9w/X/PNLmX2I5U/WhE+SF4RLtEdna5Rt5mlBIy5RrgMonBAWskZ7qIqF2BRKxIPNoXlsQTFuloXt2pk9qgPlBQ4EV89chHggRGTkSMFqNcb6Rn7xlpjt36zQ898uhTO/Chj/8Zfn7Tv5gR/PzBLbj47CNx+Hlfx6knLL9oy86JG2t1HiI1ADK9UC5sLqBHB7CWDAUznbzWlr+fztlfs8esYp8cEKKTUnbynJuuFs1IQ1cKnXoWCJCEVnDOA9cxtLu04bXyxIyRDKBa5uHlC3s/fv+GbT8ZfuTPseHlKZy6pi/r58rP346R0Rl0VWjlKzsmbhufTE/wcldNo5w/ZN1iiHAEk7sOSZs3U0X0G5rFnQj2jdzXybNSCdopALMJLJWFtMfkzhDxl7Yc7SebR7Oy0qwUIMloIUZ/T+nl41bNe8/I2PQzXVXgx9d+EMldG/Zg8dAcXPL2ldWteyb+amKydQK5NkqnfIwsMPOZSVIvYIIczm2fAlRkxO9dwmTqj1SkLH7K7ywhvIHgLXil8Yg/+DkzmFMnlUsiz+TWVEX/KZtJa0vUDvypOOVkcDhOQILJGh/92o6Jvz7thMU9S4YG8IPbX0bpiR0r8Mq2CezZX3vX3gMz17RSqlhRstdZIBr3pSiURtiM3IKE/KDy00H0DBljDGYSyiycOKHTmKNgKEVNhNsXsVKb5yRSaOgQoI/4O9RnW8tn/089hEazdfToSO2l+x/f+vR1f/cR0F985W7095bn3v3I9tsOjDbOs4gsYDRLX23xgGEFAQIh0kCcdAeKYDY5bZzB/12XIDxPBbXv9SBcZWXCfPDHHpmZBbBxqE0L6SxoyxoTm2dUkGzRZlzBo+tXDlzcbPH+UmvoPOwbnr7wwGjjf6RMZRWQzA7Vkp+pGSAXgSS/wxZAYt9+Cuf7XCIKBmZEOvZpIxc74ibAwvwNDWTxQ1lEZtOJJ6xAemoPJ8xb3+KqOII6iGHYzPhYoJo322ylS5IkeeVXj219IvnEe07qmppOP9psoVtnw87MP5QAyrKtZDNRLuhYQlZPWJ9HhuvEAjJuYYLjS+17ZXpmjVFlUDGXUChERsideHGK1bPHqXCPaXj1NNhKoeyymKSVUjIyUf/IVe87cV6pe/lFp+8ZnvlMM0Wf5+/Z76LzS8YKcdNoI3bh3+VsD7Etm8EijRLExtK32AKO/i0kSC9XLzbVsbEaVFMORYBRss2Am41b5w4lxECLecH0TPOh8vBo7d31ZrrImkHyN73US7Pqw+pNomYqBYwNhFQOTPqpkNa7jFdtdnLFI2g5btU6GecklCBME4mG2E70PMVzMgL9qcl0iMRdAQV0ehc/IzECsrQQRGimmDs903pXMjWTnp+mshEyHQaZM0sGMwCmPAZhZ3IVmTNFBsdvcYo33Ds79b1RA6xX6cJjtP7lwyGNm/mWptD3axrM+keR55Uptd2WGE7QBWQ/mIGpWuu88kwzXZvfi5ByEgicyAZmGw8QPNHEUigVcRe1Jk1l5F5FZWymhvu2x2atCGpkUoAzTqqpMDc5VsqtWGcBtbIy/gKtX9hip5AK91FWJywln4ZaI11Tnp5Je21b49PkcbaDSzPfecZlHFGmjmx10j7Ple14y9DEWu2IfCDGy8Gzb/1xW67adcbkB5P57LViiRh/RKsKqWv3jBSCFdt4dGjm2hQ7456pc7msGKkJEU1kN6fQeWURWWK2zabky2YrhRnrzjZFc0BJWGIQ2p3ZfA1Bq1Z6GQGjAqCH+CYe5cfGbV2pSl1C4EqsT1Et1UaBYu4iMYyU//KOmDPCOFvxi7rjosiaqPB7M/st52UPcpYrY3ZApLppt2ZQ3KKOYSL3czgHtFI4SUuYns6snzdMj38B+ims+OVYhC3hbI2SBWdEHCcIzdIiv8wy+paQqegvoy2eF4cKR5hsnKCYn7afn91F9sxWf6Rs+Ci/Viub4nYXcZTj9oQEiXm0RxdD9JZjXxCZxKpAr4qZaeE8LlMFkqZ9kz9QW2uleYwv0oTqAdpfBFAKtLnXtB/OMEihdh1kUZoneffM8XtcnhRVMrcZJUDGmifxlaWkw0KOuG9nXfOn8AQWs0y4mwDE4AMuDCB1ZgbbEK5LwaxRTH+/gKY2kFK1dRvK7BIOwY11mD3o+2yliy5Z68KezFolQf/MfgcxZQjTaGPZLJeR2W8/CFtEkT8VyQtTTyE1nN2iEnVoJ7ynIusUMVQzRpNbDVxEd7CINsyEaH8KiEuCkXTu1/WKH8KBS2Fwp9kqx8/y047ZbCyqDVKRrPP3lLT9DA1wxLY8EXfTSYoKcE7WbIgIzI62/biDEH9F+1Zy4EwBQkCD6EVkCanVcJwRgSnuOSpfCaJImYV65eYrEtUafRBrBWp+B62YS4dUKns4nVYpFc/w4mf/Oy/XXdoBe/bTygLMyngqTCysByTBSnnsJdKQSCDsloGD2ZFg5/7azG7ziJZSPlBJeXFkL5E0DYqRbdIPJSMIfhpJlTspYmEVQxlochZIJ0O6FvVcWRLFAfNjZJToCDI0mOjiiKuEnWi6wKXDt3MkYmb9eJAJRUsPZuXJoj9crNFBAOem0d4Q7eJWV8liCtEOJurkkv2UQ1UozKQ3a1gDeiM9s9FalwjVtpdD56khR32wrSQGQQzj9RHCYPAF/9vZFZXmM43jszzWVuw72b9dpDKby2i4235ZNswycIrNIsQFGRtU9oeK1sOaJBFNLohow0/Jv32GHZoJj7OyaJwa/6DcSjk7jcyu6c7ihEOqZg7qYJihiXWDirYFFk/5iJhS8VgoJw+ZRhE8qnVS9gelsXfhxovjikA3gTw49NOmF8GofzZbszz63Lp8ytJfy7zH0jWYgHdWQWGEnz7tYqx5P+VYY5kbTq1AjYuoj9Jmp34KxWIKLPIQMtBIFI4UXeTZbbL3J0Sg63iD/texVUc5No/5RcUiEf6ITxAF10LwrkjVQ4+RjKXYaZ0sBYjj620ZV8AQymFHC8SNCghgUitcqbop2JepUCJxbwAVtBTJFWBnq5w+jabLIB8gM6oOMQ9legtYHazStrKgoIMyDZIDi1PAAnDOVGkYsyt6lEAR+3LCO7tbBnfkcML4tVBgl4hBGsQwWA3j/F1Qya1pmm2O3n4nbwh8k/yyBd1J/yHxh9YsnMG5h6W4+toO7DZ+N3S0SnzZM48Lgrtr8v+52tqWJgENB+/r3IIV1vDb/ws+L2/2eRCxCiLuAbVpV9NlADG/lDzEMxMgMzM4ZZRnh5dGGKd+hkxw4GYWROqIWG3KkG0qK6//p55LijuI2lEZ38RGEbYIThabxUbEdulYoSmxYxrbjRfPcgKyJWX3bCPDGH8Y0tGzWtm1FZGB2HKwT3BokBaArGK3dlbHElAYlVO1dHZ/bCN2kWKPMAyb9yaLWsjrCYTs3B6FuFlNkdBBMf72Sq9S7FQAYTb9hcJXJXP54KXQs3I3x2q57sNnl0VaXAGiErTC7BjM5XyQQs1aVdBBCvmJrJRZW7QE3xW6yIFndG8MMCcAp6gkLfR21dHfVcPcnkn0d0+jr9pAd7mOSikFEaOVJphuVDEx043xWjfGZ3oxVuvGZL0LzVYJDEKSGKTRjDNcTC8I0+IXG4neIO7vxgnxGUeFEzG7PAUgInsnSqwBa5lApnruM34LiYbbcz8m7pPKqluz1g7YMFaUk6X57O4q1zE0ZwwrF+zDsYt3YtXQPiyfP4zB3gnM6Z5GV7mBctJCAkaSmHGkaYJGq4SZZgVTjW7sn+zD9uF52LxvMV7auwSv7l+MfRMDmGlWALCjtyI9EymPtcqiXcihCz+MsxzCZUPBzoS1aticNMk1JRZgVBScmd/M9g12pzaUW2CNkQvkkV2Nz/xayoSeSh0rB/fjlBVbccqKV7HmsB1Y1DeCruoMkvx5dZqWg9mZHKfUQrlUR2/XFBbQKFbMZ5y8PNvbP9nsxuvjA3h57xI8uXUlnnr9SGw9sAi1ehcoyV1zQDZZsS0jGOx6gqTibw9hWZkjVtaS8LrLr2d9gIGD3FpidL5z0Tv9XdFGCmHW5Xk+0ft1xGCmE5MqsUsx1DeCM498Fecf+wLWL9uGwb5xJEkTzClSdpiaZxUpi2oEQXzAheqrzkCNMxfQ4jJGpvrx7M4j8F/Pr8Xjr63CgcmBrLiCWFgAAZXLzZlBQUpQoTjdttDRJOepsMAmwFZ+0rhrD4FlgNZdfgMD4mTPgPAlr1gsc4UCoNA28kPJo11aiJGZeWKsmHcAFx63CRcctxGrFu5FV6WJNE1EpJv9CyGBqQr2xPfuhlH3uemUMCOj/QRIEqDequLVvYtw7/Prcf8L67F9eBBICZRwvhYg4LeYdmnlUDclWlf0LBZ80VTqWIwDnkAG2NlBFKE0HQBo7WU3sPRdQRyZ87wdyoS/8dTRJlbyJwnekjJhcf9BvHPtU7j0pA04cnA3SpTmgje0ukWbzCJ4s4pEXAhZFr6otrJ2JlNC0w22chYkCYNRwo7hRbjz6ZPxnxtPxJ6xeaCEdYwjhalnsMiySEOYMsBTs9jeXWSAPzGmdsUmCOiI+m7tZTeoEeeBlp9SmcOOgNBZu0CHuaxu35h+uZ2K8o2L0sylnKCnUsP5xzyNK057EMcdtj0TvHUyGUyooH2vZJQdtMlUKptNwlzrjTCZ22kCmEpJq789IHH6WMJIUcJLu5fg5kfPwn3Pr8VUowelxLpdK5usu9cCUmzRxKoqZZna2XS80ZVOowAqNA+YcE2MTnxJcN03+8GO8uxCYwuWmbe1n4j0sTmrB3fjyrPvw/nHbkJ3pa59eKQTu4qrYCNHyIpZB1nm39dTYEopFaeiPQo0x0goRa3ehfteWofvP3AuXtu3BIlSAiGnFKwBb02vABpUCVvoiqOrIWxEVk/5k7SsBszBTlwkRKVqxryFfW2EPt2XfUqIVdwJIAWhRE1csOZp/NFb7sHqoV1oAWhJ4evSLzJ/2gOwBCXhC2ZpESSjzAG26uumoBN5VO/GPbKiKuUE1UodF6x7Escs2YXrf30e7nt+HZpp2eEmudwVrFKmPwzE2cf0GNdNsaodZXQDciotPu7SaxQ57cQYZbZ1T9waqDN5s28S0xAx1Bn+jARzuyZw5Zm/wh+f80ssHjigzb05Xsb4SO1lpYlnWbwqkESvxMsOlsQgtDLUWR1pbSeQ4fN81N8JmIGBvnGctupVdFcaeGXXEsw0q8LM+4K3JkTwhvhlTwz/m5DMiAjltsthoiFzqHKxqY8dBilBYBL/V34wRYLlAwfwp+fegbcf+xSSJEXKSQ6qZCqqXL8K/aRNAlRMYYRv19lJGUtY1WcaM9ACoaXu1QCUH1JxQIcAgFuE3soUPnzWfRgcGMU37rkQU+MDeawSqAxitxHWMU3sspuwMwZTnu7Aw8KKJIykUKD27hoCxP1hJF+JIUBqCnBqABkpnDQlHL1gN75wyS24cO1GJEmOAOT5e4L8IFTO0xoF7oiJov+RL1R9PrmYXfqEcVLfZ6kk5zFOC7oQ3oAqIMgt57p9FYwzIYuZs/uJGQ0Aw0v3Yc6ZT6I8cNBKuW1G+QhsR/UK+p+dxbmbeUKxgwUF++lkcU1OIIyKir+ooRSEo3k//rx6L07p32LCI1H+DCEA/TlljM72MUIsFuUiz/1ikk/aZppBvTOtMhqtMlppAlCCUsKolproKjVQzaFigDPcAWRvLg3EAQSYY+6sCiJGAyX8dPQw3DG6EOXF+zDvrCcw+siJaB5cEIEQXeb+d6bcjjwoV4BYVGktwBxKB5p+RqisODP7wGrej08nv8HqncMYvnM+Bi4aRnl+I6vY0QIQ8KZIG7PmDQLGzEgoE0Kt2Y094wPYcmAIm/cNYevBQewZ68fodA+mG11ophUQCKWkhZ7KDOZ2T2GofwyHLziIVUP7sGRwPwb7R9BdrUMFnLofK+Zgo31K+GA0qYQ7xhbj9tHFaCIBMaM6tB8DZzyJ0YdPQXNkAZCk0KeCUCJGJzIjhAPCoN6ozIrDpt9iPji2Gpj5cMqJOiTZ6yxGBFoqT88HlRKwLB3Bp5IHcCx2gSlB47U+jP4CmHvhCCrzmzaqKUZooFzSbSZg1NMyXh0ewiNbjsYjW1bj5d2LcWByDmYaFaR55VBmOEhnJNmRsErlCQml6Co3MX/OOI5atAtvWvka3rRyKw5fsBeV8gzS1DFo2jiYdKqFBHeOLcIto0tQRwmgNEv9mFBZdBADZ2zEyIOnIh2fGwxDrDLy2GpfAQbQyWZUZokDyE8ZgKoCpsTU9bVZd/fVwPHDbPw6iDDA0/hT+g3OwSvZwo7yzSmjsmoK8y4aQWleAyoY0rZWDowJCQHTjS48tWMF7nhmHR58dQ32jA+glZYyayCBIMu0ipXIQB0kg5CmQClpYWH/GE5d9QouWLcJ65dtRXdlJncROkIQ4yzhrvFB/NvIUkyjAgIjTVOrCpkoxfTrSzH28JvAtV7tw+Wah25PJEudXPE1HVsmRAQ6/rIbfOg/ZdOKA886m1i9w59D+//l5+q+LqT4A3oUl+Gp3ISSeSzvp7J6EgMX5krAOWBEBkZNiJGmZWzasRI/evx0PLh5DUane7NwznllSyfbruz7xJqH9u9Af/cUTl/1Ei47ZQNOWLEFpVJdnOuVcfy+iYX43sFlmEjLAKUoUQmLeoZwoHYATW6Ko3eAqReOxsSGE8BpJeru37gCSJmILfBEKA0de+k1QQRAI362CzAgYLtTNwI4AJTZBd6BF/Eh2oAKt5z5Yx5vHaygebCE6vIGkh5ld7O7E2LsGV+A6x88F9+490I8teMINFrl3P87TclIGYHv4EbMzmJK/mhCQL1Zwea9h+GhzWswMtWHFYMHMLd7GspEPTg1iBuHl2E8LYPRQl+5D+9ZfSkuXn0Rnti7EdOtaUhzVJ4/jtZ0F5oHFphUNgAydpSoswzAXRzBFz4AlIaOvfwaB0cRaUVxtx1Vq8qoOE+xjuG9+CQ9gPk0rc1+TIcyJSijsryBUk9LD/DhLcfh7++8DL947iRMN7qQJGHBWwKO0B4eh0wsbdYkBNQaVTyzYwWe2nYEFvZPYdn8YTxWG8D1I8sx0qqAOcXK/pW4+uRP4C0rzsYPX/gxNo9uFkWfeSRUaqEyfxyN/fPRmuwDiCNK2YECGC0AiM32Pg0WuGMmlIaOu+waS1HcRoNAmR0LFJcxkwVD9mMGV/FDOI72hGe+YU0W4yeEdLiM5nAZ1eV1NKsl3PzkGbj2rkvw6r7DslU38umx82Oz0KX8cNEYYsK3OZ2Nc9/YADa8ugq7W134VaWK/WkJXVTB21a8FZ9+09U4ZvBofOfpG/Cr7fdlbxIz2aSO8UvdDVR6G6jvWAxulS1+ha4Y2moCY4OR+usbOXfzOKzcBtiDPrhJzhjDOUtb/ePbpAZmXuV8fgWn0TYLxPH7NEih6qe5uRt77zwMN89bix88dRZmGl1IkhaKLg/f8+DfAqbmlVGyLhHiSTXOUsIYmZqDW399Dnp2v4bjzj6AD62/BO848nx0lav44fM34Zdb7xEZUB4I63FmPrGydDd6jt6CiWfXFAuk3YA5MQG8NT7L8+jYoKx8l6UHDl7uvcEm1ya/QlgwSwVtUHkscDiP4N30LKpooQVnUSOgBKY9Ro268IPNp+BWrEOTyk6Bpg/PBoWqsgn1FEO/388qYIF9j6x0JqkUuRIwMapJGecsPBdXn3E8jlm6FADhri334Mcv3IwGN0xKbCHkouGkid5jXkFt5xCaBwfBSfwsxKjL0gGf7evlfgd3DpTjpkbltIkbIASJsEWQ/aVMOQCUmHEJPY8VOAg2EI5WEDAjJesTPaYGlfHv6Yn4Ca1Di8pZNi8F6QQ6s1ofb/NCJ/9gE9u6pcxYtKAHv3/p8Xj/BcdgTm8XAODp/c/ihmf/DZOtSTu4dNIyPfEYKPVPoO/YLRh7eB7AibC+If6Hl3xDBSJF7iQABGWplkHYELFIKip3amsY5pk85E+JsAZ7cS5tBrFY4NCamDEiUbNNWZjc+vycj8PNvB7NpCRmIOlVO/eKHbYQ3PIohm2/rIrDZk2l62k2m9580mH45AdPxinHL9bKvmXHKL7287uwe2A/kpJ6aRNgZibHSED34dtR27wc9T2LNA1mcUvc660hUORP8voMK0CstCjmp1k1ytImmmekmeEUF9DLWMgTaKnq3JRDim3VAhIYj/IR+CFOxgxVNfvMJOzcV4ZqHs36ga0swbELhrZSYP7cCj7022vw4YvXYv7cHi3kkfEavnrj43j48W7MP3sZeo/c5rHJspf6syRT6O5pdB+1FTP7FgBp6N3eYUEWnvNkrcMq1mUTouyaJ85XsdxDGsJAj9MFOyaTGSkRjuQDODPZmq8EGh5wmi+xupE5Z+tyO2kevsen4CD1otSJrBVaE6ukEb5bj0VmCAEUzmZy1smJxwzij3/nJJx90jIklGjfWm808e2bn8K9j24DtboxvukYVOePoTwwkq9rBAQhTmNR7/zrWrYblfkjaOwfNHG0HlY43smuNJeba1dseUlrEl4MckqEfDOrNnaSNvVR+TDjLNqKIZ7wd1TnZtWDlJhRpzJu5nV4iYZCJYgR4efuSJtc2aQw73KV09pmLUy800ArBfp6yrjsbavwscvXY8nCfmvjJzNw810v4sd3vIA0L+VrjQxg/Jk1mHfmk6BS087LVfcub5lQ7plGzxG70DgwaIkkNr9VqG433j6NBFCwGKSjMM0Rq2pW5ZPehBOEMoB5PIUz8DqIU4upal9AiMyEgI1YhnuxBkQJyNmEKcnUOUr+e8hfBpXAohJaGZUwVTsMgNMUq1cM4I8+cCIuOPtIVMolyxISJbh/w+v41r9vwnQ9NTE4EWpbl6K2fBd6jtwmRutiDHJ8Ge+7l+/C5Aur0Jruc4TPQfptu8DaZIQKY2Q2ZJ8SFsDxNXPd78Rssi+DdDEDx2AvjsSwQPxs/2eRld8yjm7chnUYoy6UwAUYOOsf9qsaii4zNltZTMClKn9SZnRVElxw1kp84gMnYtXy+TnzpDlN8OKW/bj2hsdwYGQGidqsoTpoVjHxwmpUD9uPUve0JXh72YGgS++ZUBoYR9fiA5h6bQ7MMfKuEuefWxbbBy58zpiswbIAWcNpnoJAd2hfidbIYCm43vFDKFOKU7EDvagLBfCj8+zTjMwSGI9jOTZhCRI2p4QEq1y14sgAKGImrSBZhsm2YqqV91aaYumiPvzhe9fj0vOOQk9XxeMFEWHvwUl85bpH8fLWUZTyGnB58DUz0Ng3iNq2Jeg7ekvWuwyFvEMsstlLpRa6l+1F7fXlWVlccFCG/th+DY4+mH1TDgqRTG4ezpyMl4zNOmZgPmpYT7uDN3k4Qo6STVEVd2MNZlAxdX/elibbnJmfceGzrigWa3f+4gHSNFtoeuupy3D175yE9UcPBWkgAqZnGvjnHz2BBzftRkLKHZJ9ExhIS5h+9XD0Hr4LVK2Z7qXZDzCwsmg/kt4ppBP9+mabb0n8+ehlH4kX3R5eCKZwmgVcInVzI+cWAyt4GEtoDAYOMplFqP0EjJcwhOewGH6BdoxZoe+lmXXMZeQ+IJv1C+ZW8eGLj8UVFx+PgTnd0UmQpowbf/YMbvvVqznlDoIoMw5iNPbPx8zeeehevkvDvzb9MrbKfHTSO4ny/BE0x/uFZw3M8tnI30FDHSSQ2zbmD9THD9TWp6OwFz08E0hNAu0yo0UJHuHDMUZd1g45V74SjrXFYhipoQgZ5Ys0SmULMv087fghfPJ3TsLp65fkMzrCDCLc8evNuO4nz6LRZC9CFxGG/oCbZdS2L0H30j0afm6n4FRqorJwGLXXlyGzj2RcrCll6UDm8eC4LCNfm5FGwNbLltTwLEtE+TsB1DxjVLiJNbQfCTjfkOkHm3adPjBCvdiEpcWDoXaDVuXrSY46sv2gwjpyWlppioE5Vbz/gqPx0Xcdj4Xz+/Rm0RAWT0R4/Lld+PqNGzA20UBSkoC3URAlTPn4zN6FaNV6UOqbAti1SKZ9c6WozBsBlVpAWslqI0W6GvN6Hs0iqdO/sI4BImx01suzRQ/VAXSa4cUQubbNQR3LMRqmEL42JmC8zvOwE3M7y/uddvzZmmpQC8gCRRKndyrkbt1RC3D1B0/CW960HKXEXkcICf/1XaO49vrHsWPvFJLEnHqi3xRi7rYtIwGtiT40huehNGdKzKBAViAeKvdPIumaQTpd8Xdit+GT/bod1SIJKN07JzDeojUbHJPnw6eEQZ7GIE16LsVexJErVcCLtBCTqHa+GBq80adFcUNZrxan6O2u4NK3rcLH37MeyxbN9cfhjR8Ym5zB17+/AZteOoCklNhdUlxx9FibFdT3L0D38l0BfrtTOpNe0l1DqXc6KxZJhDUrYouwQFbcINMnOwh0AR4psA7P3LW2KxMGaRK9XBeQMgeUQfngFA2U8AoGkRKhhKJLpIOuwIPcUGk05YdLMFavGMAnPnAiLnzzkahaoE5c+I1Wiut+8jTuenhbdl6QkpEFhxRPIjCheWAe0KwgSRpInSkt4d4sjiJQuYGkbxLYu9ABeqALWaLH9AtwCzApp8zeypAfaf9im1X7uFd1q//mTCDfZ0SERZhGFS3NwOwGf7uz6n0KVezEQPvZr+XPuq3wlnb5QPZZQsA73nw4PnXFyVitQZ12HWbXbfe8hB/c/jzSVMwwCo0EGkqUwWGa/9qYmIO0XgF114NCcyA4oMQoz5mOm3u1bU2tygpY3t1KzkJ+6pey6VrGz2EzxlrMca5xHqAswDRKOYPlYWyxawzdGEZvoQLYHtbA0K4rcR9SINM7f+tIfPaqMzFvTrdppSAtzfhJeHDjdvzzjzZiqtZCMpsAJcSdWhWt6SqSnvEMm/CANBitIoASRtJbk2mMB2qpiR5OtBRmI2RA0OslZX1wsyr8iKTfnW1AyAlkxlxM594gsSNxlyV5hDqCHkyiGmabE1xZObY1TPt+s10LWLa4F1e974Rc+Iyd+ybx8KYdSIhw1klLsXiwz1MeIsLm7cO49obHsPfgTOfCDyyOaWvQLINnug3Y5onKnmCMrGYwO7/QKLzkn7Lc4Tpt2+K6J42UXebFpmC799RZKR0YvdTQeXgnbBunbtSpHL238zMIXCkCaZri1LWLsXr5PACMHXvH8Zdf/zWefH4/EgJOXz+EL/3pW7B4cI4IZQgHx6bx1e89hhdeG9ERf2i8kj86JqAAQEYApwnSmapXoGJO0/dnH1UaAKUAl7TQ5SQo2jlk88d/xU+icy41VXz+SdVzIEzoJVGzjSlL6bryU3WA/O2zltlS/0hXAE1ROVoiHirmNKXmQvZ5WybdNRXCq5YP5EIkPLhxB554bh/UcVGPPr0XTzy3B8bEEmYaTfzLv2/EfY/vdIQfKdVW7wbItlBZymDzCUib5Zzi1BpThpikALfAnOb/GCilIBLH9IC9+MzNyuLnNCugLscBNPOEh7fPv2S3fT1e9bH7KnMAqCA7jDFVBRe6Ll1vANPPJABaXEaxrZCLQX7waQBJpaF2fi15USmX8mNbsg9LJUJXV0ncy7jpFy/gpl++7JlVG+oX4ZfmhzgdTKZjZBBSbimFEYieshh+pAOiJhCQQ0dvGBETM8TNsv2BqQU009eiB/YUE2IRfxMDw+jFdsxHk9QBDyq0oPzvvB6AGSUwRmhO9mIRQYtQMUe9wgpizKqdtjIzNm87iFbaQilJ8OaTl+Gtpy3DAxt3IUkIbzt9OU45fomm8P4Nr+Nf/2MTZuotz/Rbl/LH6gUCeUCjwi6HcfmqLSOd7kFrdAC6gEWktK4CgBhprS+/JwyNy0lrrzTC+8wbwtrLvsfKpJA2zIlG+TR8imI/rMuec1LnooYubul2ZGxpDTHX0BpVMI4qdHLtlTWZtA9RWgwcLU84Y2YsWtCNb/7V+Vh7VFZsOTw2g2de2YdyibD2qCHM7asCILy49QD+57X34+WtIzroCx8HY7tETpVJhxasmyrrJyt1ULmZl4OZgFVaA9VHdrhWglatiugEYKkAcSxCfqWnlN4drMNJZZoSExc4+Lu/9VgKinSKJlNxzrU/lg8SDAOzwSTa4HCbkzTtoo5UtGjoTJlx7puW4POfPBuHLewP0rBl5yi+8P8ewMNP70ESiXnsmn4pAxkYGVNuMAOTiukTRFQzohZSduKXkxdbQsrNLxd9L2kmoLTo2GxrmD9CMtOVKCB0NyjQcIseDKnmLK9hShfkPz1QrQBqb4A8kcwGfmSgJ7nPAUYmBGzdNYHnNu/DvLldmD/Qg0o5AaeMkYka/uuxbfjK9Y9j4wv7xdYyNU7/3cnmdTNBwN3jk0oDzYupzD8tHTFMSijEIC0P71I64qBT1uYY2ZbSP2MBRERK4twgYbc7STfI/kIQUYQF2AWb8ln5RCjPz/RNDV2e9kmwZ1L2eytN0dedYPXyuVi6qB8AYdueCby6bQy1esvEZZr5ZE8+nXML2gIzS49L3xR7E3GAB4KntmVhIX+Hj2pLPzkaE+Cn7CNQECKIsPJYe2EhtkGRAy15ft+aSe7RJQWWJrrVyxzrln0sdzORvgfI4OCpWgtPvXwQm14aBoiQ6NJ0l97wCEyQKnxjQsE0WnKiCA21J1GeWwR3sqil6sBXwfTUyMtXMPIPiZJv9rZACUeKodOnvPRMVKZSZObr2COEKLYDfyjLIlg+J8OBANsVnzKaEiFoGYwJKqSCKdhSZRoyyhYrpRYGP4vNK7o/0Z5rwtWys8dzr/LJl49dg5ndIdJA+wvJOmFgYbZj6XDbHwmz3ZZrJXTQI29yNm7aJbNaT/zgKgCokrnP0mFDEHyHZms4xWh2hzqbT/O9FBaUrbABGQtoXqjT0ux22qOikSAwXBEkv6TCprw9d1Azyphf5tR5Mr7ixjlAAv3um7Dm6t+F7Wt7ODW5fYWGZ1s4vRsxz34MxkHRPuTQQpU4Xl4vfxdpktoVpNI4A3D5LjEMANmxgX8qqv8AQ1oADnfmsFB8Rp7VZofLRXpqTsosvvvQT8J2pr2jPIZRgDSf6lg6qRyxAA0AKOU40EK2UJyR5aAZm/SYIMAhQ1c7JYgZ4sL6jfzJDs6AEwBHgUh13Zm+085hQgcsszODQhG181B7cv2HxI8UNhSt3ET+ft9AmqS5EHMBLknKUinBFvBMv6iCDS+k1YnFdZERBtpuf5C32MUU1nDTRcg9hFMLN+fU6wYBJbAZpx47FEGLdtnvy/UB+shZITDAgJCdUuClwFZyD6CdBVN5v1i40sLXVtf87j/sDLNDxVXPJ16U3KnwZ8WlzLdx4IW7MhDKAUB7waUDxpuVTDPzgtgMw3SQkH7xhYamWNzN5CNnEZ/qTh51PlG7QpjY6WXqcxNXKZqsDxAyl6FtdFEjQMGtYTYI4a6kucwoutQGUBPhFkYFUlRmISfEtMBAlP10jypwW0fUn5uH7eLXtoO0002d+qomfD9uFawE4zMZ/DrBJjPac95nkG2UTAtJ0IzIdQH4p3B1dHlaqiyJ8XTaVOvkPLufkXasYIKwqMCKt5ZZ37Q32eJ5tVhGlnuRPwMBhSiQkSCbik9k25lBk+v68mf72S/PDbY+J2Pxyv4hQmL2i4GZYHqW+ufh9OYjDaDo148pBbFnqIt8yRPJvL46rEBqT3ZBOipHZOfJUByzwCkYcMg728rrl9tYXGnq2OrzUAaut4e7FSYefB9sPCy07BF/Rhr8R5R0s/OJ54YwKwuk2GG9elZaGfduPR0N41XxhlUY00FEbY3Tmt0+x0JU+/dTwGsKS6oQR1GMkWeSOS8lTeGJmxSVDllSc4bBrF4iZePfVhZgNWNDo8zcibXt+LLa9+TsmmMVehueh9ZM3Ld+2q4xwtgc/InvK8wOcgmHqVkUrKHq6KRT9/ufBruMKC4z20fEePAn+WmOiY80VhUMHqMM0g3ZfTjgcaFSdnJ2nlUY4QBWeSMO14TlE226ZwKGUJd2brHdW9WCp6v6dxm+C9zAsh2xGChCFxFl5wPIO6X/Cq70FSwvdhIf6Pbd5d/IwJU5LUoH2WtHDjsMgwZ/D4yn3ZnCRWhbRzV7s2jPzjhmc45wvE8DBOU3qo0doZcj2cA3RYhgL2BzgRmr9qGTQciqYzcIU8QnofN+g9GUw3EOAjHm9nAbsXcnxNppP8TQ+AxGQOqFzaJcrl0f2mVZ6wT2v4TErNfejRH2P3kgJQ9zjNzkrPGrH4can1NH3/AsnsuYKpkCzVSXuYe+HmFf7j7L0PcWfWQmCUved9YZSMQrZomarfbLygeTs2qnPI5LbGz/SXjPv7Er+icHXEuRj4xMZOsWnV24D0buV8hKoHzcorvAhLctkUNccQoXd1I2E42d84IdXhy6Yuq0CGUZ4pEOAkyw09YcFjBA2hUu8FnR4Ej/z0HsNDcOjQlmJrowpw3NZUaOoubea6soOygYp/rO3WnEZLuGkMlXULrlOBgwb3mPrffp5eBANBwo2QqZJyvf7cDdFl1qwFYtuxa+29HsXYn/FIdvgnkjFLdZTrWAMuUSU0cY1M4SsRdaaQvVMfMI4A5WbL24m835AMrkO0lfXqgQM4UmF5FnBfkpHVnPxHhCzmT0pRNFpJwHiqEWwwRDozl/mPWwtJCKeB8gQVmOtlduIBV4I7fAKV1EYG+ClE+wWQLCM9+2eMy5BZD+3j56LF5jbu5R3FJuQx0fZ4AXImkSwzNYr51rLbUJNTyNRff5/8gIVB+FIqXjSkswzV69CyiR5SFSIzk1SXIa2JQrF4pMVUQFppfhRdTguVlDxL26qKGDtSRd5WTaTg3c3xBcYgyTA72A4YVk7VIjCgtfES0Ds6BVdkra7IWWEDIXcwqGF3pdPpaWw8hf/V44X0KBYoBHWvjt2uvgchwM9IIbM7oqSTPp6Sq9YMX4rLZxuXCpGyv41MV2/swmH7bTlPb5tF9S7gdpnQjfaTVc60r2PX4SmjrW1Hm+I2BIvZs4nJ4W8SF6h56dxloTMXq7kpeSuX3Ve5KkmB22KY0xJE6YOwA5NF9AbprlM2J2ChV7piiNE0ux8VYd2gidT9uwYIvh70Mfv9nhbdYgiIDertK9yby5ldurZTpgRzCB2RcYlzGNtunlAibI99qFB5PowAezmf0R5rTH2NsHWMEDMYKyog7uKX7OPoKeC1NQ73O3rExMItcpV0rJWE9X+fbk9LWLH+upJg8ZgineQfQKrw+EtZuh1pqjoIqti4WLKCy2tHFAIUN0uoUWMSsU4oOORcgXsFZ7BnRRaBC4ab945EHCHcgkakCssCL7r7e7vOGE4xY9XNrBpzWHFvSkE9Otd6egkg2BFmczVg2HFTkkliXxqOnQhHW+/m7M2mzbjTGSHEsYulcLXCpDfiClWrFLVGpNnY/Hp9XOZDQ9uQzCEHgAF83fAlsqU7poQc+Xf71h20PlU9cehmol+c/hidYD41Ot8yCEr3whyMfF9aYHK7Ow82q5SbJYgpLKsGBMpYxAM8g+EGI2RRteh4oUURDjAWAMK6q2x+eeJMIZww8BrfWLaUKNsKDBYOEKg4lnW0BvV/nxww/r/eniBd0ojXWfhAOjrZlli+dOTkw13tVKUfGecQM45hy4yPJdtfdPFkK63sQre7bAPaEBZOuvlY4qJge0Xn8XWrKNpsp+tG9mF3n3S14j8px+VrwYz63MCbo8N5kRYhaIilEzMsLWELbbTt6YhhOIUC5RffHC7s/dv2H7Q/d978ug7/7sJTz9zGYsGax23f7r7d8emUx/l9mdfdYI8umhQCARJGofSwUMUoseNnO8U8iUpSnIPqwYQupQQd5eBK5YAg4IT4/flZLVAVtKG2xD9umOWz7JaJ9pKVmwgt8yl+ECa2rBb6C/dPNbzlj8e6OjjanTTzgWycffvQYTk3U89tzwzKpl8/6hr7u0WZVChdaoM8CDIA9i1ownAigpWBiSZxCEhQ9iffK4L/w227CAfDUthf/6VCfwZCeJI5umqOA6z/CKb+M2n2k2yfjdMQ2pbTkz+s2+CDeJ7a4mry4d7P7iExv3TY1NzOD3L1md4ZVHHbkAN339vbjxlieeGRyofrarTBMG2WObIJEWah1QUU4e/co3YBuCWf8z+XUOnqi2KNWaa2UQJH8awc5u+ZhMmqR5Zv6TfDZ1F6FUNRzEmmDQqBUTClNIsu17wO/LieBaZTXhQvk5eRa3XKKJhfO6PvfTe19/6oavXobLLjoZALJzme++/XqsPPUKnH7CUnzr8xc9f9MvnmvU6q1zUxbnNntWnYSOKZ+ez/CQ70S8DBKOllNgsJZwHWBKxx+W/3MElUDHKlnHJCeO4VUkEC0CYIwgHD4Rgqmu/F4RLulVZ/1kglSooMADGFZ/YsQWV1UGUUqouaC//Le3/t27/7XBLX556yj+8NJ19uMA8Ndfvw8T0zWsXTW3ess9r39x1/7pP2+0WCtBkAGpIIw0ddYiklEOIWbOt4STqxjue3BEVqE+FyuPFtMAsbPXP9kzKLy8SbvaDgjN8szF28CMtc8hsgElFPSZMMk+9TwVCpDFNhQ059449GIYLN6XErQG5pS++vbTl/3Njj21Wl93N7722beZ72Uj9995A0548wewa1+tde7Jhz+wdffBVq2enp6yyQxs06IQBjI1efk/sggzGqIiZD1TNK3yXCKGa0lEgmlNW5WAEZyUCBQx4REtyGejhW7GUg7BB3ulM2wpVIm3NfMlfyyrw5ql5DOpzTCUPLK/yyXUh+ZVvnbSmgXXbNszVUsSwreuudB6xjuaf8N9P8Lpb/0Idh+caL7nHYf95qUtk7ubKZ/RamGOf14AG1Nq+SM3DoZWDOOHyZjIANgR9G3qE9GPZVg1s6QJtK8wVuDnT5r5wjvJ5mNLL/YahlCArPMci5GKbkQnH9PC7GDBhd12COiqYP/QvMrnLj//iH94bvPwTL3Rwg+/crn3bLBe6FtfeCda3MIDG8dad3/3y985cmnvBwfmlH9TEserxolwBJ4ge9OFIxydx8oTyTT3s/N75KqY3HVraYNOAU10H6VJfG7/E58p2p22rKF5MUrYyuhAzVAnDFsqG9RFn8QGPzCsbmP+df+Zgs3tKz22fGH3FXd958P/9NwrI/W+njJu+af3R8ZScH3xOw9i6aI5uOGWTVh31MLFL28dvmpkvHFVbaa13GQJSkA2QYLdsNyFI4iiQbW7x21HAUzu2cXcwXM+Y0zoasGtIq9u15Z1nqGiRCdVrNAZq02FsGpsMe+cA31JkCchoLtKe+f0lr+74rDebz765O6df3D5WuwfmcG1n3lHlHeFJ4R87sqzUeIqXt9xEDP1dM/d37niiysP67toQX/l2t6u0uaEKHsliLOb1z6tOg8K2Z95EamYVLGdgkj3ox4XvjYm/FjbFn0wS6c6s6PIvUXVv5S/HVxZwMQh0FEoCa+wqsiSblM/wgCnIDD3VGnr0LzKN9eumn/Jvddd8dl6I9354p0/w+qjlhYK37TVwfWPNz6OlSsW4Pu3bMCt//d9uOIzt63ZPzx9ydR0432T0+kp9SZ3EbU7cSZPHRXDEnJMNrTI5AJMfJ+dmgHqvB35FesIWgksSlXA2hRuuCCZdYi8PhRz6DiCg/0Y9E++6kXQ6vEo41+lhHp/T+mZvr7qTwcHum79t3+47NnL/+RmfvtbjsDufZP40qfO60iu/x+q1Y5+f1W0FAAAAABJRU5ErkJggg==
+      mediatype: image/png
+
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true
+
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+        - serviceAccountName: attune-controller-manager
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - limitranges
+                - nodes
+                - resourcequotas
+                - services
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods/eviction
+              verbs:
+                - create
+            - apiGroups:
+                - ""
+              resources:
+                - pods/resize
+              verbs:
+                - patch
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - get
+            - apiGroups:
+                - apps
+              resources:
+                - daemonsets
+                - deployments
+                - replicasets
+                - statefulsets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - attune.io
+              resources:
+                - attunedefaults
+                - attunenamespacedefaults
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - attune.io
+              resources:
+                - attunepolicies
+              verbs:
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - attune.io
+              resources:
+                - attunepolicies/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - attune.io
+              resources:
+                - attunepolicies/status
+              verbs:
+                - get
+                - update
+            - apiGroups:
+                - autoscaling
+              resources:
+                - horizontalpodautoscalers
+              verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - autoscaling.k8s.io
+              resources:
+                - verticalpodautoscalers
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - batch
+              resources:
+                - cronjobs
+                - jobs
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - events.k8s.io
+              resources:
+                - events
+              verbs:
+                - create
+                - get
+                - list
+                - patch
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - prometheuses
+              verbs:
+                - get
+                - list
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+      deployments:
+        - name: attune-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: attune
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: attune
+              spec:
+                serviceAccountName: attune-controller-manager
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                containers:
+                  - name: manager
+                    image: ghcr.io/attune-io/attune:v0.1.7
+                    imagePullPolicy: IfNotPresent
+                    args:
+                      - --leader-elect
+                      - --enable-webhooks=false
+                      - --health-probe-bind-address=:8081
+                    ports:
+                      - containerPort: 8080
+                        name: metrics
+                        protocol: TCP
+                      - containerPort: 8081
+                        name: health
+                        protocol: TCP
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 256Mi
+                      requests:
+                        cpu: 100m
+                        memory: 128Mi
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      readOnlyRootFilesystem: true
+                      runAsUser: 65532
+                      runAsGroup: 65532
+                      seccompProfile:
+                        type: RuntimeDefault
+
+  customresourcedefinitions:
+    owned:
+      - name: attunepolicies.attune.io
+        version: v1alpha1
+        kind: AttunePolicy
+        displayName: Attune Policy
+        description: Defines a resource right-sizing policy for a Kubernetes workload. Specifies the target workload, update strategy, resource bounds, and Prometheus query parameters.
+        resources:
+          - version: v1
+            kind: Pod
+          - version: apps/v1
+            kind: Deployment
+          - version: apps/v1
+            kind: StatefulSet
+      - name: attunedefaults.attune.io
+        version: v1alpha1
+        kind: AttuneDefaults
+        displayName: Attune Defaults
+        description: Cluster-wide default values for AttunePolicy fields. Provides organization-wide baseline configuration that individual policies inherit.
+      - name: attunenamespacedefaults.attune.io
+        version: v1alpha1
+        kind: AttuneNamespaceDefaults
+        displayName: Attune Namespace Defaults
+        description: Namespace-scoped default values for AttunePolicy fields. Overrides cluster defaults for a specific namespace.

--- a/operators/attune/0.1.7/manifests/attune.io_attunedefaults.yaml
+++ b/operators/attune/0.1.7/manifests/attune.io_attunedefaults.yaml
@@ -1,0 +1,923 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: attunedefaults.attune.io
+spec:
+  group: attune.io
+  names:
+    categories:
+    - attune
+    kind: AttuneDefaults
+    listKind: AttuneDefaultsList
+    plural: attunedefaults
+    shortNames:
+    - rsd
+    singular: attunedefaults
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.metricsSource.prometheus.address
+      name: Prometheus
+      type: string
+    - jsonPath: .spec.updateStrategy.type
+      name: Type
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'AttuneDefaults is the Schema for the attunedefaults API.
+
+          It defines cluster-scoped default values for AttunePolicy resources.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AttuneDefaultsSpec defines cluster-scoped default values
+              for AttunePolicy resources.
+            properties:
+              costPricing:
+                description: 'CostPricing configures the per-unit pricing used to
+                  compute
+
+                  EstimatedMonthlySavings. If omitted, defaults to standard
+
+                  on-demand Linux pricing ($0.031/vCPU-hour, $0.004/GiB-hour).'
+                properties:
+                  cpuPerCoreHour:
+                    description: 'CPUPerCoreHour is the cost per vCPU-hour (e.g. "0.031").
+
+                      Defaults to 0.031 if not specified.'
+                    type: string
+                  memoryPerGiBHour:
+                    description: 'MemoryPerGiBHour is the cost per GiB-hour (e.g.
+                      "0.004").
+
+                      Defaults to 0.004 if not specified.'
+                    type: string
+                type: object
+              cpu:
+                description: CPU configures default CPU resource recommendation parameters.
+                properties:
+                  allowDecrease:
+                    description: 'AllowDecrease controls whether the resource value
+                      can be decreased.
+
+                      For CPU: nil defaults to true (decreases allowed, throttle detected
+                      by safety monitor).
+
+                      For memory: nil defaults to false (decreases blocked to prevent
+                      OOMKill).'
+                    type: boolean
+                  burstSensitivity:
+                    description: 'BurstSensitivity controls how much burst detection
+                      inflates the
+
+                      recommendation. Expressed as a decimal string multiplied by
+
+                      log2(burstMagnitude). Default "0.1" gives ~20% boost for magnitude
+                      4,
+
+                      ~30% for 8, ~40% for 16. Set "0" to disable burst boost entirely
+
+                      (e.g. for batch jobs). Must be >= 0, max 1.0.'
+                    type: string
+                  controlledValues:
+                    description: 'ControlledValues specifies which resource values
+                      to manage.
+
+                      "RequestsOnly" (default) adjusts only requests, leaving limits
+                      unchanged.
+
+                      "RequestsAndLimits" adjusts both requests and limits in lockstep.
+
+                      For Guaranteed-QoS pods (where requests equal limits), use
+
+                      "RequestsAndLimits" or resizes will be skipped to preserve QoS
+                      class.'
+                    enum:
+                    - RequestsOnly
+                    - RequestsAndLimits
+                    type: string
+                  maxAllowed:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxAllowed is the maximum allowed resource value.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxChangePercent:
+                    description: 'MaxChangePercent is the maximum allowed change percentage
+                      per
+
+                      reconcile cycle for this resource (both directions). Limits
+                      how
+
+                      aggressively the recommendation can deviate from the current
+                      value
+
+                      in a single step, forcing gradual convergence. Overridden by
+
+                      MaxIncreasePercent/MaxDecreasePercent if those are set.
+
+                      Defaults to 50 for CPU, 30 for memory.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  maxDecreasePercent:
+                    description: 'MaxDecreasePercent is the maximum allowed decrease
+                      percentage per
+
+                      reconcile cycle. Takes precedence over MaxChangePercent for
+                      downward
+
+                      changes. Memory decreases are riskier (OOM), so a lower cap
+                      is
+
+                      recommended. Defaults to MaxChangePercent if not set.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  maxIncreasePercent:
+                    description: 'MaxIncreasePercent is the maximum allowed increase
+                      percentage per
+
+                      reconcile cycle. Takes precedence over MaxChangePercent for
+                      upward
+
+                      changes. Defaults to MaxChangePercent if not set.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  memoryFromCpuRatio:
+                    description: 'MemoryFromCPURatio derives memory recommendations
+                      from CPU recommendations
+
+                      using a fixed ratio, instead of using Prometheus memory metrics.
+                      Useful for
+
+                      JVM, Go, and .NET workloads where heap scales linearly with
+                      CPU allocation
+
+                      and Prometheus memory metrics are unreliable (JVM reserves heap
+                      upfront,
+
+                      Go GC targets a fixed percentage of available memory).
+
+                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+
+                      (e.g., 500m CPU -> 1Gi memory). The derived value still passes
+                      through
+
+                      minAllowed, maxAllowed, and maxChangePercent bounds.
+
+                      Only valid on the memory ResourceConfig; ignored on CPU.'
+                    type: string
+                  minAllowed:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MinAllowed is the minimum allowed resource value.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  overhead:
+                    description: 'Overhead is the percentage of additional resources
+                      added on top of the
+
+                      percentile recommendation. Expressed as a string (e.g. "20"
+                      means 20%
+
+                      extra headroom above the target percentile). Must be >= 0, max
+                      900.'
+                    pattern: ^([0-9]+(\.[0-9]+)?)?$
+                    type: string
+                  percentile:
+                    description: 'Percentile is the usage percentile to target for
+                      recommendations.
+
+                      Supported values: 50, 90, 95, 99. Omit or set to 0 to use the
+                      default.'
+                    enum:
+                    - 0
+                    - 50
+                    - 90
+                    - 95
+                    - 99
+                    format: int32
+                    type: integer
+                  startupBoost:
+                    description: 'StartupBoost temporarily increases CPU requests
+                      for newly created or
+
+                      restarted pods to accelerate JVM/.NET class loading, JIT compilation,
+
+                      and cache warming. After the duration expires (or the container
+                      reaches
+
+                      Ready), the CPU is reduced to the steady-state recommendation.
+
+                      Only applies to CPU resources.'
+                    properties:
+                      duration:
+                        description: 'Duration is the maximum time the boost remains
+                          active after pod
+
+                          creation or container restart. The boost is removed when
+                          the
+
+                          container reaches Ready or this duration expires, whichever
+                          comes first.
+
+                          Must be >= 10s and <= 1h.'
+                        type: string
+                      multiplier:
+                        description: 'Multiplier scales the recommended CPU request
+                          during startup.
+
+                          For example, "3.0" means 3x the steady-state recommendation.
+
+                          Must be > 1.0 and <= 10.0.'
+                        type: string
+                    required:
+                    - duration
+                    - multiplier
+                    type: object
+                type: object
+              memory:
+                description: Memory configures default memory resource recommendation
+                  parameters.
+                properties:
+                  allowDecrease:
+                    description: 'AllowDecrease controls whether the resource value
+                      can be decreased.
+
+                      For CPU: nil defaults to true (decreases allowed, throttle detected
+                      by safety monitor).
+
+                      For memory: nil defaults to false (decreases blocked to prevent
+                      OOMKill).'
+                    type: boolean
+                  burstSensitivity:
+                    description: 'BurstSensitivity controls how much burst detection
+                      inflates the
+
+                      recommendation. Expressed as a decimal string multiplied by
+
+                      log2(burstMagnitude). Default "0.1" gives ~20% boost for magnitude
+                      4,
+
+                      ~30% for 8, ~40% for 16. Set "0" to disable burst boost entirely
+
+                      (e.g. for batch jobs). Must be >= 0, max 1.0.'
+                    type: string
+                  controlledValues:
+                    description: 'ControlledValues specifies which resource values
+                      to manage.
+
+                      "RequestsOnly" (default) adjusts only requests, leaving limits
+                      unchanged.
+
+                      "RequestsAndLimits" adjusts both requests and limits in lockstep.
+
+                      For Guaranteed-QoS pods (where requests equal limits), use
+
+                      "RequestsAndLimits" or resizes will be skipped to preserve QoS
+                      class.'
+                    enum:
+                    - RequestsOnly
+                    - RequestsAndLimits
+                    type: string
+                  maxAllowed:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxAllowed is the maximum allowed resource value.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxChangePercent:
+                    description: 'MaxChangePercent is the maximum allowed change percentage
+                      per
+
+                      reconcile cycle for this resource (both directions). Limits
+                      how
+
+                      aggressively the recommendation can deviate from the current
+                      value
+
+                      in a single step, forcing gradual convergence. Overridden by
+
+                      MaxIncreasePercent/MaxDecreasePercent if those are set.
+
+                      Defaults to 50 for CPU, 30 for memory.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  maxDecreasePercent:
+                    description: 'MaxDecreasePercent is the maximum allowed decrease
+                      percentage per
+
+                      reconcile cycle. Takes precedence over MaxChangePercent for
+                      downward
+
+                      changes. Memory decreases are riskier (OOM), so a lower cap
+                      is
+
+                      recommended. Defaults to MaxChangePercent if not set.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  maxIncreasePercent:
+                    description: 'MaxIncreasePercent is the maximum allowed increase
+                      percentage per
+
+                      reconcile cycle. Takes precedence over MaxChangePercent for
+                      upward
+
+                      changes. Defaults to MaxChangePercent if not set.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  memoryFromCpuRatio:
+                    description: 'MemoryFromCPURatio derives memory recommendations
+                      from CPU recommendations
+
+                      using a fixed ratio, instead of using Prometheus memory metrics.
+                      Useful for
+
+                      JVM, Go, and .NET workloads where heap scales linearly with
+                      CPU allocation
+
+                      and Prometheus memory metrics are unreliable (JVM reserves heap
+                      upfront,
+
+                      Go GC targets a fixed percentage of available memory).
+
+                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+
+                      (e.g., 500m CPU -> 1Gi memory). The derived value still passes
+                      through
+
+                      minAllowed, maxAllowed, and maxChangePercent bounds.
+
+                      Only valid on the memory ResourceConfig; ignored on CPU.'
+                    type: string
+                  minAllowed:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MinAllowed is the minimum allowed resource value.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  overhead:
+                    description: 'Overhead is the percentage of additional resources
+                      added on top of the
+
+                      percentile recommendation. Expressed as a string (e.g. "20"
+                      means 20%
+
+                      extra headroom above the target percentile). Must be >= 0, max
+                      900.'
+                    pattern: ^([0-9]+(\.[0-9]+)?)?$
+                    type: string
+                  percentile:
+                    description: 'Percentile is the usage percentile to target for
+                      recommendations.
+
+                      Supported values: 50, 90, 95, 99. Omit or set to 0 to use the
+                      default.'
+                    enum:
+                    - 0
+                    - 50
+                    - 90
+                    - 95
+                    - 99
+                    format: int32
+                    type: integer
+                  startupBoost:
+                    description: 'StartupBoost temporarily increases CPU requests
+                      for newly created or
+
+                      restarted pods to accelerate JVM/.NET class loading, JIT compilation,
+
+                      and cache warming. After the duration expires (or the container
+                      reaches
+
+                      Ready), the CPU is reduced to the steady-state recommendation.
+
+                      Only applies to CPU resources.'
+                    properties:
+                      duration:
+                        description: 'Duration is the maximum time the boost remains
+                          active after pod
+
+                          creation or container restart. The boost is removed when
+                          the
+
+                          container reaches Ready or this duration expires, whichever
+                          comes first.
+
+                          Must be >= 10s and <= 1h.'
+                        type: string
+                      multiplier:
+                        description: 'Multiplier scales the recommended CPU request
+                          during startup.
+
+                          For example, "3.0" means 3x the steady-state recommendation.
+
+                          Must be > 1.0 and <= 10.0.'
+                        type: string
+                    required:
+                    - duration
+                    - multiplier
+                    type: object
+                type: object
+              metricsSource:
+                description: MetricsSource configures default metrics source settings.
+                properties:
+                  cloudwatch:
+                    description: CloudWatch configures an Amazon CloudWatch Container
+                      Insights metrics source.
+                    properties:
+                      clusterName:
+                        description: 'ClusterName is the EKS cluster name for Container
+                          Insights metrics.
+
+                          Required for metric filtering.'
+                        type: string
+                      region:
+                        description: Region is the AWS region (e.g. "us-east-1").
+                          Required.
+                        type: string
+                      roleArn:
+                        description: 'RoleARN is an optional IAM role ARN to assume
+                          for cross-account access.
+
+                          If not set, uses the pod''s service account IAM role (IRSA/Pod
+                          Identity).'
+                        type: string
+                    required:
+                    - clusterName
+                    - region
+                    type: object
+                  datadog:
+                    description: Datadog configures a Datadog metrics source.
+                    properties:
+                      apiKeySecretRef:
+                        description: 'APIKeySecretRef references a Secret containing
+                          the Datadog API key.
+
+                          The Secret must contain an "api-key" key and optionally
+                          an "app-key" key.'
+                        properties:
+                          key:
+                            description: Key within the Secret.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      site:
+                        default: datadoghq.com
+                        description: 'Site is the Datadog site (e.g. "datadoghq.com",
+                          "datadoghq.eu", "us5.datadoghq.com").
+
+                          Defaults to "datadoghq.com".'
+                        type: string
+                    required:
+                    - apiKeySecretRef
+                    type: object
+                  historyWindow:
+                    description: 'HistoryWindow is the time window for historical
+                      metrics data.
+
+                      Defaults to 7d (168h) if not specified.'
+                    type: string
+                  minimumDataPoints:
+                    description: 'MinimumDataPoints is the minimum number of data
+                      points required
+
+                      before generating recommendations. Minimum 1, default 48 samples.
+
+                      With the default queryStep of 5m, 48 samples is about 4 hours
+                      of data.
+
+                      Defaults to 48 if not set (applied by the controller so that
+
+                      AttuneDefaults cluster configuration can override it).'
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  prometheus:
+                    description: Prometheus configures a Prometheus metrics source.
+                    properties:
+                      address:
+                        description: Address is the URL of the Prometheus-compatible
+                          query endpoint.
+                        type: string
+                      bearerTokenSecret:
+                        description: 'BearerTokenSecret references a Kubernetes Secret
+                          containing a bearer
+
+                          token for authenticating with managed Prometheus services.'
+                        properties:
+                          key:
+                            description: Key within the Secret.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      headers:
+                        additionalProperties:
+                          type: string
+                        description: 'Headers are custom HTTP headers added to every
+                          query request.
+
+                          Use for non-secret tenant or routing headers (e.g. "X-Scope-OrgID"
+
+                          for Mimir). Do not put credentials here; use BearerTokenSecret
+                          for
+
+                          authentication tokens.'
+                        type: object
+                      queryParameters:
+                        additionalProperties:
+                          type: string
+                        description: 'QueryParameters are appended to every query
+                          request URL.
+
+                          Use for backend-specific settings such as Thanos deduplication
+
+                          (e.g. {"dedup": "true", "partial_response": "true"}). Reserved
+
+                          query keys controlled by the operator (`query`, `start`,
+                          `end`, `step`,
+
+                          `time`, `timeout`) are rejected.'
+                        type: object
+                      tls:
+                        description: TLS configures TLS settings for the connection.
+                        properties:
+                          insecureSkipVerify:
+                            description: 'InsecureSkipVerify disables TLS certificate
+                              verification.
+
+                              Use only for self-signed certificates in development.'
+                            type: boolean
+                        type: object
+                    required:
+                    - address
+                    type: object
+                  queryStep:
+                    description: 'QueryStep is the step interval for Prometheus range
+                      queries and ETA
+
+                      calculations. Should match your Prometheus scrape interval for
+
+                      accurate time estimates. Minimum 10s, maximum 1h. Default 5m.'
+                    type: string
+                  rateWindow:
+                    description: 'RateWindow is the window used in the PromQL rate()
+                      function for CPU
+
+                      queries. Defaults to queryStep if not set. Must be >= 30s and
+                      <= historyWindow.
+
+                      Advanced users may set this independently to control CPU rate
+                      smoothing
+
+                      (e.g. a short rateWindow for responsive tracking with a longer
+                      queryStep).'
+                    type: string
+                  vpa:
+                    description: VPA configures consumption of existing VerticalPodAutoscaler
+                      recommendations.
+                    properties:
+                      name:
+                        description: Name is the name of the VerticalPodAutoscaler
+                          object.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the VPA. Defaults
+                          to the policy's namespace.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              updateStrategy:
+                description: UpdateStrategy configures default update strategy settings.
+                properties:
+                  autoRevert:
+                    description: 'AutoRevert automatically reverts changes if degradation
+                      is detected.
+
+                      Defaults to true if not set (applied by the controller so that
+
+                      AttuneDefaults cluster configuration can override it).'
+                    type: boolean
+                  canary:
+                    description: Canary configures canary rollout behavior when Type
+                      is Canary.
+                    properties:
+                      autoPromote:
+                        description: 'AutoPromote controls whether the operator automatically
+                          promotes the
+
+                          resize to all pods after the observation period passes without
+                          safety
+
+                          violations. When false (default), the user must manually
+                          switch the
+
+                          mode to Auto to resize the remaining pods.'
+                        type: boolean
+                      observationPeriod:
+                        description: ObservationPeriod is how long to observe canary
+                          pods before proceeding.
+                        type: string
+                      percentage:
+                        description: Percentage is the percentage of pods to resize
+                          first.
+                        format: int32
+                        maximum: 100
+                        minimum: 1
+                        type: integer
+                    required:
+                    - observationPeriod
+                    - percentage
+                    type: object
+                  cooldown:
+                    description: 'Cooldown is the minimum time between successive
+                      resize operations.
+
+                      Defaults to 1h if not specified.'
+                    type: string
+                  export:
+                    description: 'Export configures how recommendations are exported
+                      for external
+
+                      consumption (e.g. GitOps workflows with ArgoCD or Flux).'
+                    properties:
+                      configMap:
+                        description: 'ConfigMap enables exporting recommendations
+                          to ConfigMaps.
+
+                          One ConfigMap per workload is created, named
+
+                          "<policy>-<workload>-recommendations", with an owner reference
+
+                          to the policy for automatic cleanup.'
+                        type: boolean
+                    type: object
+                  initialSizing:
+                    description: 'InitialSizing enables a mutating admission webhook
+                      that sets resource
+
+                      requests/limits on new pods at creation time, based on existing
+
+                      recommendations. This eliminates the "deploy with bad defaults,
+                      wait
+
+                      for first reconcile" gap. Requires the namespace label
+
+                      attune.io/initial-sizing=enabled. Defaults to false.'
+                    type: boolean
+                  maxConcurrentResizes:
+                    default: 1
+                    description: 'MaxConcurrentResizes is the maximum number of pods
+                      to resize
+
+                      concurrently within a single reconcile cycle. Default: 1 (serial).'
+                    format: int32
+                    maximum: 50
+                    minimum: 1
+                    type: integer
+                  maxTotalCpuIncrease:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'MaxTotalCPUIncrease is the maximum aggregate CPU
+                      increase allowed
+
+                      across all pods in a single reconcile cycle (e.g. "2000m", "4").
+
+                      Once exhausted, remaining pods are deferred to the next cycle.
+
+                      Decreases do not consume budget. Default: unlimited.'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxTotalMemoryIncrease:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'MaxTotalMemoryIncrease is the maximum aggregate
+                      memory increase
+
+                      allowed across all pods in a single reconcile cycle (e.g. "4Gi").
+
+                      Once exhausted, remaining pods are deferred to the next cycle.
+
+                      Decreases do not consume budget. Default: unlimited.'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  resizeMethod:
+                    description: "ResizeMethod controls what happens when an in-place\
+                      \ resize fails.\n  InPlaceOnly (default): skip the pod and retry\
+                      \ next cycle.\n  InPlaceOrRecreate: fall back to pod eviction\
+                      \ if in-place resize\n  fails or is marked Infeasible by kubelet.\
+                      \ The owning controller\n  recreates the pod with updated resources.\
+                      \ Evictions respect\n  PodDisruptionBudgets and never evict\
+                      \ the last replica.\nDefaults to InPlaceOnly if not set (applied\
+                      \ by the controller so that\nAttuneDefaults cluster configuration\
+                      \ can override it)."
+                    enum:
+                    - InPlaceOnly
+                    - InPlaceOrRecreate
+                    type: string
+                  safetyObservationPeriod:
+                    description: 'SafetyObservationPeriod is how long to observe a
+                      pod after resize before
+
+                      concluding the resize is safe. Applies to all modes (Auto, OneShot,
+                      Canary).
+
+                      Takes precedence over canary.observationPeriod when set. Must
+                      be >= 1m.
+
+                      Defaults to 5m if neither this nor canary.observationPeriod
+                      is set.'
+                    type: string
+                  schedule:
+                    description: 'Schedule restricts when resize operations can occur.
+                      Recommendations
+
+                      are always computed; only resize execution is gated. If omitted,
+
+                      resizes can occur at any time (current behavior).'
+                    properties:
+                      daysOfWeek:
+                        description: 'DaysOfWeek restricts resizes to specific days.
+                          Values: Monday through Sunday.
+
+                          If omitted, all days are allowed.'
+                        items:
+                          enum:
+                          - Monday
+                          - Tuesday
+                          - Wednesday
+                          - Thursday
+                          - Friday
+                          - Saturday
+                          - Sunday
+                          type: string
+                        type: array
+                      timezone:
+                        default: UTC
+                        description: 'Timezone for interpreting window start/end times.
+                          Must be a valid
+
+                          IANA timezone name (e.g. "America/New_York"). Default: "UTC".'
+                        type: string
+                      windows:
+                        description: 'Windows defines time-of-day ranges when resizes
+                          are allowed.
+
+                          If multiple windows are specified, resizes are allowed during
+                          any of them.'
+                        items:
+                          description: TimeWindow defines a daily time range.
+                          properties:
+                            end:
+                              description: 'End time in HH:MM format (24-hour). If
+                                end < start, the window
+
+                                wraps past midnight (e.g. start=22:00, end=06:00).'
+                              pattern: ^([01]\d|2[0-3]):[0-5]\d$
+                              type: string
+                            start:
+                              description: Start time in HH:MM format (24-hour).
+                              pattern: ^([01]\d|2[0-3]):[0-5]\d$
+                              type: string
+                          required:
+                          - end
+                          - start
+                          type: object
+                        type: array
+                    type: object
+                  sloGuardrails:
+                    description: 'SLOGuardrails defines application-level SLO metrics
+                      to check after
+
+                      a resize. If any metric breaches its threshold during the safety
+
+                      observation period, the resize is automatically reverted.
+
+                      Requires a Prometheus-compatible metrics source.'
+                    items:
+                      description: 'SLOGuardrail defines an application-level metric
+                        that is checked after
+
+                        a resize to detect degradation. If the metric breaches the
+                        threshold,
+
+                        the safety monitor triggers an automatic revert.'
+                      properties:
+                        comparison:
+                          default: above
+                          description: Comparison is "above" or "below". "above" reverts
+                            when value > threshold.
+                          enum:
+                          - above
+                          - below
+                          type: string
+                        evaluationWindow:
+                          description: EvaluationWindow is how long after resize to
+                            check. Defaults to 5m.
+                          type: string
+                        name:
+                          description: Name identifies this guardrail for logging
+                            and status reporting.
+                          type: string
+                        query:
+                          description: 'Query is a PromQL query that returns a scalar
+                            value.
+
+                            Template variables: {{ .Namespace }}, {{ .WorkloadName
+                            }}, {{ .PodName }}'
+                          type: string
+                        threshold:
+                          description: Threshold is the value that triggers a revert.
+                          type: string
+                      required:
+                      - name
+                      - query
+                      - threshold
+                      type: object
+                    maxItems: 10
+                    type: array
+                  type:
+                    description: "Mode determines the update behavior, graduated from\
+                      \ safe to automated:\n  Recommend: collects metrics and writes\
+                      \ recommendations to status, no pod changes.\n  OneShot: resizes\
+                      \ one pod per reconcile cycle.\n  Canary: resizes a percentage\
+                      \ of pods first, then the rest after observation.\n  Auto: resizes\
+                      \ all eligible pods each cycle.\n  Observe: collects metrics\
+                      \ and tracks data points but does not surface recommendations\
+                      \ or savings.\nStart with Recommend in production and promote\
+                      \ after reviewing status.\nDefaults to Recommend if not set\
+                      \ (applied by the controller, not the webhook,\nso that AttuneDefaults\
+                      \ cluster configuration can override it)."
+                    enum:
+                    - Observe
+                    - Recommend
+                    - OneShot
+                    - Canary
+                    - Auto
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/operators/attune/0.1.7/manifests/attune.io_attunenamespacedefaults.yaml
+++ b/operators/attune/0.1.7/manifests/attune.io_attunenamespacedefaults.yaml
@@ -1,0 +1,926 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: attunenamespacedefaults.attune.io
+spec:
+  group: attune.io
+  names:
+    categories:
+    - attune
+    kind: AttuneNamespaceDefaults
+    listKind: AttuneNamespaceDefaultsList
+    plural: attunenamespacedefaults
+    shortNames:
+    - rsnd
+    singular: attunenamespacedefaults
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.metricsSource.prometheus.address
+      name: Prometheus
+      type: string
+    - jsonPath: .spec.updateStrategy.type
+      name: Type
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: 'AttuneNamespaceDefaults is the Schema for namespace-scoped defaults.
+
+          Values here override cluster-scoped AttuneDefaults but are overridden
+
+          by per-policy values. Precedence: policy > namespace defaults > cluster
+          defaults.'
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AttuneDefaultsSpec defines cluster-scoped default values
+              for AttunePolicy resources.
+            properties:
+              costPricing:
+                description: 'CostPricing configures the per-unit pricing used to
+                  compute
+
+                  EstimatedMonthlySavings. If omitted, defaults to standard
+
+                  on-demand Linux pricing ($0.031/vCPU-hour, $0.004/GiB-hour).'
+                properties:
+                  cpuPerCoreHour:
+                    description: 'CPUPerCoreHour is the cost per vCPU-hour (e.g. "0.031").
+
+                      Defaults to 0.031 if not specified.'
+                    type: string
+                  memoryPerGiBHour:
+                    description: 'MemoryPerGiBHour is the cost per GiB-hour (e.g.
+                      "0.004").
+
+                      Defaults to 0.004 if not specified.'
+                    type: string
+                type: object
+              cpu:
+                description: CPU configures default CPU resource recommendation parameters.
+                properties:
+                  allowDecrease:
+                    description: 'AllowDecrease controls whether the resource value
+                      can be decreased.
+
+                      For CPU: nil defaults to true (decreases allowed, throttle detected
+                      by safety monitor).
+
+                      For memory: nil defaults to false (decreases blocked to prevent
+                      OOMKill).'
+                    type: boolean
+                  burstSensitivity:
+                    description: 'BurstSensitivity controls how much burst detection
+                      inflates the
+
+                      recommendation. Expressed as a decimal string multiplied by
+
+                      log2(burstMagnitude). Default "0.1" gives ~20% boost for magnitude
+                      4,
+
+                      ~30% for 8, ~40% for 16. Set "0" to disable burst boost entirely
+
+                      (e.g. for batch jobs). Must be >= 0, max 1.0.'
+                    type: string
+                  controlledValues:
+                    description: 'ControlledValues specifies which resource values
+                      to manage.
+
+                      "RequestsOnly" (default) adjusts only requests, leaving limits
+                      unchanged.
+
+                      "RequestsAndLimits" adjusts both requests and limits in lockstep.
+
+                      For Guaranteed-QoS pods (where requests equal limits), use
+
+                      "RequestsAndLimits" or resizes will be skipped to preserve QoS
+                      class.'
+                    enum:
+                    - RequestsOnly
+                    - RequestsAndLimits
+                    type: string
+                  maxAllowed:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxAllowed is the maximum allowed resource value.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxChangePercent:
+                    description: 'MaxChangePercent is the maximum allowed change percentage
+                      per
+
+                      reconcile cycle for this resource (both directions). Limits
+                      how
+
+                      aggressively the recommendation can deviate from the current
+                      value
+
+                      in a single step, forcing gradual convergence. Overridden by
+
+                      MaxIncreasePercent/MaxDecreasePercent if those are set.
+
+                      Defaults to 50 for CPU, 30 for memory.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  maxDecreasePercent:
+                    description: 'MaxDecreasePercent is the maximum allowed decrease
+                      percentage per
+
+                      reconcile cycle. Takes precedence over MaxChangePercent for
+                      downward
+
+                      changes. Memory decreases are riskier (OOM), so a lower cap
+                      is
+
+                      recommended. Defaults to MaxChangePercent if not set.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  maxIncreasePercent:
+                    description: 'MaxIncreasePercent is the maximum allowed increase
+                      percentage per
+
+                      reconcile cycle. Takes precedence over MaxChangePercent for
+                      upward
+
+                      changes. Defaults to MaxChangePercent if not set.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  memoryFromCpuRatio:
+                    description: 'MemoryFromCPURatio derives memory recommendations
+                      from CPU recommendations
+
+                      using a fixed ratio, instead of using Prometheus memory metrics.
+                      Useful for
+
+                      JVM, Go, and .NET workloads where heap scales linearly with
+                      CPU allocation
+
+                      and Prometheus memory metrics are unreliable (JVM reserves heap
+                      upfront,
+
+                      Go GC targets a fixed percentage of available memory).
+
+                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+
+                      (e.g., 500m CPU -> 1Gi memory). The derived value still passes
+                      through
+
+                      minAllowed, maxAllowed, and maxChangePercent bounds.
+
+                      Only valid on the memory ResourceConfig; ignored on CPU.'
+                    type: string
+                  minAllowed:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MinAllowed is the minimum allowed resource value.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  overhead:
+                    description: 'Overhead is the percentage of additional resources
+                      added on top of the
+
+                      percentile recommendation. Expressed as a string (e.g. "20"
+                      means 20%
+
+                      extra headroom above the target percentile). Must be >= 0, max
+                      900.'
+                    pattern: ^([0-9]+(\.[0-9]+)?)?$
+                    type: string
+                  percentile:
+                    description: 'Percentile is the usage percentile to target for
+                      recommendations.
+
+                      Supported values: 50, 90, 95, 99. Omit or set to 0 to use the
+                      default.'
+                    enum:
+                    - 0
+                    - 50
+                    - 90
+                    - 95
+                    - 99
+                    format: int32
+                    type: integer
+                  startupBoost:
+                    description: 'StartupBoost temporarily increases CPU requests
+                      for newly created or
+
+                      restarted pods to accelerate JVM/.NET class loading, JIT compilation,
+
+                      and cache warming. After the duration expires (or the container
+                      reaches
+
+                      Ready), the CPU is reduced to the steady-state recommendation.
+
+                      Only applies to CPU resources.'
+                    properties:
+                      duration:
+                        description: 'Duration is the maximum time the boost remains
+                          active after pod
+
+                          creation or container restart. The boost is removed when
+                          the
+
+                          container reaches Ready or this duration expires, whichever
+                          comes first.
+
+                          Must be >= 10s and <= 1h.'
+                        type: string
+                      multiplier:
+                        description: 'Multiplier scales the recommended CPU request
+                          during startup.
+
+                          For example, "3.0" means 3x the steady-state recommendation.
+
+                          Must be > 1.0 and <= 10.0.'
+                        type: string
+                    required:
+                    - duration
+                    - multiplier
+                    type: object
+                type: object
+              memory:
+                description: Memory configures default memory resource recommendation
+                  parameters.
+                properties:
+                  allowDecrease:
+                    description: 'AllowDecrease controls whether the resource value
+                      can be decreased.
+
+                      For CPU: nil defaults to true (decreases allowed, throttle detected
+                      by safety monitor).
+
+                      For memory: nil defaults to false (decreases blocked to prevent
+                      OOMKill).'
+                    type: boolean
+                  burstSensitivity:
+                    description: 'BurstSensitivity controls how much burst detection
+                      inflates the
+
+                      recommendation. Expressed as a decimal string multiplied by
+
+                      log2(burstMagnitude). Default "0.1" gives ~20% boost for magnitude
+                      4,
+
+                      ~30% for 8, ~40% for 16. Set "0" to disable burst boost entirely
+
+                      (e.g. for batch jobs). Must be >= 0, max 1.0.'
+                    type: string
+                  controlledValues:
+                    description: 'ControlledValues specifies which resource values
+                      to manage.
+
+                      "RequestsOnly" (default) adjusts only requests, leaving limits
+                      unchanged.
+
+                      "RequestsAndLimits" adjusts both requests and limits in lockstep.
+
+                      For Guaranteed-QoS pods (where requests equal limits), use
+
+                      "RequestsAndLimits" or resizes will be skipped to preserve QoS
+                      class.'
+                    enum:
+                    - RequestsOnly
+                    - RequestsAndLimits
+                    type: string
+                  maxAllowed:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxAllowed is the maximum allowed resource value.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxChangePercent:
+                    description: 'MaxChangePercent is the maximum allowed change percentage
+                      per
+
+                      reconcile cycle for this resource (both directions). Limits
+                      how
+
+                      aggressively the recommendation can deviate from the current
+                      value
+
+                      in a single step, forcing gradual convergence. Overridden by
+
+                      MaxIncreasePercent/MaxDecreasePercent if those are set.
+
+                      Defaults to 50 for CPU, 30 for memory.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  maxDecreasePercent:
+                    description: 'MaxDecreasePercent is the maximum allowed decrease
+                      percentage per
+
+                      reconcile cycle. Takes precedence over MaxChangePercent for
+                      downward
+
+                      changes. Memory decreases are riskier (OOM), so a lower cap
+                      is
+
+                      recommended. Defaults to MaxChangePercent if not set.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  maxIncreasePercent:
+                    description: 'MaxIncreasePercent is the maximum allowed increase
+                      percentage per
+
+                      reconcile cycle. Takes precedence over MaxChangePercent for
+                      upward
+
+                      changes. Defaults to MaxChangePercent if not set.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  memoryFromCpuRatio:
+                    description: 'MemoryFromCPURatio derives memory recommendations
+                      from CPU recommendations
+
+                      using a fixed ratio, instead of using Prometheus memory metrics.
+                      Useful for
+
+                      JVM, Go, and .NET workloads where heap scales linearly with
+                      CPU allocation
+
+                      and Prometheus memory metrics are unreliable (JVM reserves heap
+                      upfront,
+
+                      Go GC targets a fixed percentage of available memory).
+
+                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+
+                      (e.g., 500m CPU -> 1Gi memory). The derived value still passes
+                      through
+
+                      minAllowed, maxAllowed, and maxChangePercent bounds.
+
+                      Only valid on the memory ResourceConfig; ignored on CPU.'
+                    type: string
+                  minAllowed:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MinAllowed is the minimum allowed resource value.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  overhead:
+                    description: 'Overhead is the percentage of additional resources
+                      added on top of the
+
+                      percentile recommendation. Expressed as a string (e.g. "20"
+                      means 20%
+
+                      extra headroom above the target percentile). Must be >= 0, max
+                      900.'
+                    pattern: ^([0-9]+(\.[0-9]+)?)?$
+                    type: string
+                  percentile:
+                    description: 'Percentile is the usage percentile to target for
+                      recommendations.
+
+                      Supported values: 50, 90, 95, 99. Omit or set to 0 to use the
+                      default.'
+                    enum:
+                    - 0
+                    - 50
+                    - 90
+                    - 95
+                    - 99
+                    format: int32
+                    type: integer
+                  startupBoost:
+                    description: 'StartupBoost temporarily increases CPU requests
+                      for newly created or
+
+                      restarted pods to accelerate JVM/.NET class loading, JIT compilation,
+
+                      and cache warming. After the duration expires (or the container
+                      reaches
+
+                      Ready), the CPU is reduced to the steady-state recommendation.
+
+                      Only applies to CPU resources.'
+                    properties:
+                      duration:
+                        description: 'Duration is the maximum time the boost remains
+                          active after pod
+
+                          creation or container restart. The boost is removed when
+                          the
+
+                          container reaches Ready or this duration expires, whichever
+                          comes first.
+
+                          Must be >= 10s and <= 1h.'
+                        type: string
+                      multiplier:
+                        description: 'Multiplier scales the recommended CPU request
+                          during startup.
+
+                          For example, "3.0" means 3x the steady-state recommendation.
+
+                          Must be > 1.0 and <= 10.0.'
+                        type: string
+                    required:
+                    - duration
+                    - multiplier
+                    type: object
+                type: object
+              metricsSource:
+                description: MetricsSource configures default metrics source settings.
+                properties:
+                  cloudwatch:
+                    description: CloudWatch configures an Amazon CloudWatch Container
+                      Insights metrics source.
+                    properties:
+                      clusterName:
+                        description: 'ClusterName is the EKS cluster name for Container
+                          Insights metrics.
+
+                          Required for metric filtering.'
+                        type: string
+                      region:
+                        description: Region is the AWS region (e.g. "us-east-1").
+                          Required.
+                        type: string
+                      roleArn:
+                        description: 'RoleARN is an optional IAM role ARN to assume
+                          for cross-account access.
+
+                          If not set, uses the pod''s service account IAM role (IRSA/Pod
+                          Identity).'
+                        type: string
+                    required:
+                    - clusterName
+                    - region
+                    type: object
+                  datadog:
+                    description: Datadog configures a Datadog metrics source.
+                    properties:
+                      apiKeySecretRef:
+                        description: 'APIKeySecretRef references a Secret containing
+                          the Datadog API key.
+
+                          The Secret must contain an "api-key" key and optionally
+                          an "app-key" key.'
+                        properties:
+                          key:
+                            description: Key within the Secret.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      site:
+                        default: datadoghq.com
+                        description: 'Site is the Datadog site (e.g. "datadoghq.com",
+                          "datadoghq.eu", "us5.datadoghq.com").
+
+                          Defaults to "datadoghq.com".'
+                        type: string
+                    required:
+                    - apiKeySecretRef
+                    type: object
+                  historyWindow:
+                    description: 'HistoryWindow is the time window for historical
+                      metrics data.
+
+                      Defaults to 7d (168h) if not specified.'
+                    type: string
+                  minimumDataPoints:
+                    description: 'MinimumDataPoints is the minimum number of data
+                      points required
+
+                      before generating recommendations. Minimum 1, default 48 samples.
+
+                      With the default queryStep of 5m, 48 samples is about 4 hours
+                      of data.
+
+                      Defaults to 48 if not set (applied by the controller so that
+
+                      AttuneDefaults cluster configuration can override it).'
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  prometheus:
+                    description: Prometheus configures a Prometheus metrics source.
+                    properties:
+                      address:
+                        description: Address is the URL of the Prometheus-compatible
+                          query endpoint.
+                        type: string
+                      bearerTokenSecret:
+                        description: 'BearerTokenSecret references a Kubernetes Secret
+                          containing a bearer
+
+                          token for authenticating with managed Prometheus services.'
+                        properties:
+                          key:
+                            description: Key within the Secret.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      headers:
+                        additionalProperties:
+                          type: string
+                        description: 'Headers are custom HTTP headers added to every
+                          query request.
+
+                          Use for non-secret tenant or routing headers (e.g. "X-Scope-OrgID"
+
+                          for Mimir). Do not put credentials here; use BearerTokenSecret
+                          for
+
+                          authentication tokens.'
+                        type: object
+                      queryParameters:
+                        additionalProperties:
+                          type: string
+                        description: 'QueryParameters are appended to every query
+                          request URL.
+
+                          Use for backend-specific settings such as Thanos deduplication
+
+                          (e.g. {"dedup": "true", "partial_response": "true"}). Reserved
+
+                          query keys controlled by the operator (`query`, `start`,
+                          `end`, `step`,
+
+                          `time`, `timeout`) are rejected.'
+                        type: object
+                      tls:
+                        description: TLS configures TLS settings for the connection.
+                        properties:
+                          insecureSkipVerify:
+                            description: 'InsecureSkipVerify disables TLS certificate
+                              verification.
+
+                              Use only for self-signed certificates in development.'
+                            type: boolean
+                        type: object
+                    required:
+                    - address
+                    type: object
+                  queryStep:
+                    description: 'QueryStep is the step interval for Prometheus range
+                      queries and ETA
+
+                      calculations. Should match your Prometheus scrape interval for
+
+                      accurate time estimates. Minimum 10s, maximum 1h. Default 5m.'
+                    type: string
+                  rateWindow:
+                    description: 'RateWindow is the window used in the PromQL rate()
+                      function for CPU
+
+                      queries. Defaults to queryStep if not set. Must be >= 30s and
+                      <= historyWindow.
+
+                      Advanced users may set this independently to control CPU rate
+                      smoothing
+
+                      (e.g. a short rateWindow for responsive tracking with a longer
+                      queryStep).'
+                    type: string
+                  vpa:
+                    description: VPA configures consumption of existing VerticalPodAutoscaler
+                      recommendations.
+                    properties:
+                      name:
+                        description: Name is the name of the VerticalPodAutoscaler
+                          object.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the VPA. Defaults
+                          to the policy's namespace.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              updateStrategy:
+                description: UpdateStrategy configures default update strategy settings.
+                properties:
+                  autoRevert:
+                    description: 'AutoRevert automatically reverts changes if degradation
+                      is detected.
+
+                      Defaults to true if not set (applied by the controller so that
+
+                      AttuneDefaults cluster configuration can override it).'
+                    type: boolean
+                  canary:
+                    description: Canary configures canary rollout behavior when Type
+                      is Canary.
+                    properties:
+                      autoPromote:
+                        description: 'AutoPromote controls whether the operator automatically
+                          promotes the
+
+                          resize to all pods after the observation period passes without
+                          safety
+
+                          violations. When false (default), the user must manually
+                          switch the
+
+                          mode to Auto to resize the remaining pods.'
+                        type: boolean
+                      observationPeriod:
+                        description: ObservationPeriod is how long to observe canary
+                          pods before proceeding.
+                        type: string
+                      percentage:
+                        description: Percentage is the percentage of pods to resize
+                          first.
+                        format: int32
+                        maximum: 100
+                        minimum: 1
+                        type: integer
+                    required:
+                    - observationPeriod
+                    - percentage
+                    type: object
+                  cooldown:
+                    description: 'Cooldown is the minimum time between successive
+                      resize operations.
+
+                      Defaults to 1h if not specified.'
+                    type: string
+                  export:
+                    description: 'Export configures how recommendations are exported
+                      for external
+
+                      consumption (e.g. GitOps workflows with ArgoCD or Flux).'
+                    properties:
+                      configMap:
+                        description: 'ConfigMap enables exporting recommendations
+                          to ConfigMaps.
+
+                          One ConfigMap per workload is created, named
+
+                          "<policy>-<workload>-recommendations", with an owner reference
+
+                          to the policy for automatic cleanup.'
+                        type: boolean
+                    type: object
+                  initialSizing:
+                    description: 'InitialSizing enables a mutating admission webhook
+                      that sets resource
+
+                      requests/limits on new pods at creation time, based on existing
+
+                      recommendations. This eliminates the "deploy with bad defaults,
+                      wait
+
+                      for first reconcile" gap. Requires the namespace label
+
+                      attune.io/initial-sizing=enabled. Defaults to false.'
+                    type: boolean
+                  maxConcurrentResizes:
+                    default: 1
+                    description: 'MaxConcurrentResizes is the maximum number of pods
+                      to resize
+
+                      concurrently within a single reconcile cycle. Default: 1 (serial).'
+                    format: int32
+                    maximum: 50
+                    minimum: 1
+                    type: integer
+                  maxTotalCpuIncrease:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'MaxTotalCPUIncrease is the maximum aggregate CPU
+                      increase allowed
+
+                      across all pods in a single reconcile cycle (e.g. "2000m", "4").
+
+                      Once exhausted, remaining pods are deferred to the next cycle.
+
+                      Decreases do not consume budget. Default: unlimited.'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxTotalMemoryIncrease:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'MaxTotalMemoryIncrease is the maximum aggregate
+                      memory increase
+
+                      allowed across all pods in a single reconcile cycle (e.g. "4Gi").
+
+                      Once exhausted, remaining pods are deferred to the next cycle.
+
+                      Decreases do not consume budget. Default: unlimited.'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  resizeMethod:
+                    description: "ResizeMethod controls what happens when an in-place\
+                      \ resize fails.\n  InPlaceOnly (default): skip the pod and retry\
+                      \ next cycle.\n  InPlaceOrRecreate: fall back to pod eviction\
+                      \ if in-place resize\n  fails or is marked Infeasible by kubelet.\
+                      \ The owning controller\n  recreates the pod with updated resources.\
+                      \ Evictions respect\n  PodDisruptionBudgets and never evict\
+                      \ the last replica.\nDefaults to InPlaceOnly if not set (applied\
+                      \ by the controller so that\nAttuneDefaults cluster configuration\
+                      \ can override it)."
+                    enum:
+                    - InPlaceOnly
+                    - InPlaceOrRecreate
+                    type: string
+                  safetyObservationPeriod:
+                    description: 'SafetyObservationPeriod is how long to observe a
+                      pod after resize before
+
+                      concluding the resize is safe. Applies to all modes (Auto, OneShot,
+                      Canary).
+
+                      Takes precedence over canary.observationPeriod when set. Must
+                      be >= 1m.
+
+                      Defaults to 5m if neither this nor canary.observationPeriod
+                      is set.'
+                    type: string
+                  schedule:
+                    description: 'Schedule restricts when resize operations can occur.
+                      Recommendations
+
+                      are always computed; only resize execution is gated. If omitted,
+
+                      resizes can occur at any time (current behavior).'
+                    properties:
+                      daysOfWeek:
+                        description: 'DaysOfWeek restricts resizes to specific days.
+                          Values: Monday through Sunday.
+
+                          If omitted, all days are allowed.'
+                        items:
+                          enum:
+                          - Monday
+                          - Tuesday
+                          - Wednesday
+                          - Thursday
+                          - Friday
+                          - Saturday
+                          - Sunday
+                          type: string
+                        type: array
+                      timezone:
+                        default: UTC
+                        description: 'Timezone for interpreting window start/end times.
+                          Must be a valid
+
+                          IANA timezone name (e.g. "America/New_York"). Default: "UTC".'
+                        type: string
+                      windows:
+                        description: 'Windows defines time-of-day ranges when resizes
+                          are allowed.
+
+                          If multiple windows are specified, resizes are allowed during
+                          any of them.'
+                        items:
+                          description: TimeWindow defines a daily time range.
+                          properties:
+                            end:
+                              description: 'End time in HH:MM format (24-hour). If
+                                end < start, the window
+
+                                wraps past midnight (e.g. start=22:00, end=06:00).'
+                              pattern: ^([01]\d|2[0-3]):[0-5]\d$
+                              type: string
+                            start:
+                              description: Start time in HH:MM format (24-hour).
+                              pattern: ^([01]\d|2[0-3]):[0-5]\d$
+                              type: string
+                          required:
+                          - end
+                          - start
+                          type: object
+                        type: array
+                    type: object
+                  sloGuardrails:
+                    description: 'SLOGuardrails defines application-level SLO metrics
+                      to check after
+
+                      a resize. If any metric breaches its threshold during the safety
+
+                      observation period, the resize is automatically reverted.
+
+                      Requires a Prometheus-compatible metrics source.'
+                    items:
+                      description: 'SLOGuardrail defines an application-level metric
+                        that is checked after
+
+                        a resize to detect degradation. If the metric breaches the
+                        threshold,
+
+                        the safety monitor triggers an automatic revert.'
+                      properties:
+                        comparison:
+                          default: above
+                          description: Comparison is "above" or "below". "above" reverts
+                            when value > threshold.
+                          enum:
+                          - above
+                          - below
+                          type: string
+                        evaluationWindow:
+                          description: EvaluationWindow is how long after resize to
+                            check. Defaults to 5m.
+                          type: string
+                        name:
+                          description: Name identifies this guardrail for logging
+                            and status reporting.
+                          type: string
+                        query:
+                          description: 'Query is a PromQL query that returns a scalar
+                            value.
+
+                            Template variables: {{ .Namespace }}, {{ .WorkloadName
+                            }}, {{ .PodName }}'
+                          type: string
+                        threshold:
+                          description: Threshold is the value that triggers a revert.
+                          type: string
+                      required:
+                      - name
+                      - query
+                      - threshold
+                      type: object
+                    maxItems: 10
+                    type: array
+                  type:
+                    description: "Mode determines the update behavior, graduated from\
+                      \ safe to automated:\n  Recommend: collects metrics and writes\
+                      \ recommendations to status, no pod changes.\n  OneShot: resizes\
+                      \ one pod per reconcile cycle.\n  Canary: resizes a percentage\
+                      \ of pods first, then the rest after observation.\n  Auto: resizes\
+                      \ all eligible pods each cycle.\n  Observe: collects metrics\
+                      \ and tracks data points but does not surface recommendations\
+                      \ or savings.\nStart with Recommend in production and promote\
+                      \ after reviewing status.\nDefaults to Recommend if not set\
+                      \ (applied by the controller, not the webhook,\nso that AttuneDefaults\
+                      \ cluster configuration can override it)."
+                    enum:
+                    - Observe
+                    - Recommend
+                    - OneShot
+                    - Canary
+                    - Auto
+                    type: string
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/operators/attune/0.1.7/manifests/attune.io_attunepolicies.yaml
+++ b/operators/attune/0.1.7/manifests/attune.io_attunepolicies.yaml
@@ -1,0 +1,1772 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: attunepolicies.attune.io
+spec:
+  group: attune.io
+  names:
+    categories:
+    - attune
+    kind: AttunePolicy
+    listKind: AttunePolicyList
+    plural: attunepolicies
+    shortNames:
+    - rsp
+    singular: attunepolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.updateStrategy.type
+      name: Type
+      type: string
+    - jsonPath: .status.workloads.discovered
+      name: Workloads
+      type: integer
+    - jsonPath: .status.workloads.withRecommendations
+      name: Recs
+      type: integer
+    - jsonPath: .status.workloads.resized
+      name: Resized
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.savings.cpuRequestReduction
+      name: CPU Saved
+      priority: 1
+      type: string
+    - jsonPath: .status.savings.memoryRequestReduction
+      name: Mem Saved
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AttunePolicy is the Schema for the attunepolicies API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object.
+
+              Servers should convert recognized schemas to the latest internal value,
+              and
+
+              may reject unrecognized values.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents.
+
+              Servers may infer this from the endpoint the client submits requests
+              to.
+
+              Cannot be updated.
+
+              In CamelCase.
+
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AttunePolicySpec defines the desired state of AttunePolicy.
+            properties:
+              cpu:
+                description: CPU configures CPU resource recommendations.
+                properties:
+                  allowDecrease:
+                    description: 'AllowDecrease controls whether the resource value
+                      can be decreased.
+
+                      For CPU: nil defaults to true (decreases allowed, throttle detected
+                      by safety monitor).
+
+                      For memory: nil defaults to false (decreases blocked to prevent
+                      OOMKill).'
+                    type: boolean
+                  burstSensitivity:
+                    description: 'BurstSensitivity controls how much burst detection
+                      inflates the
+
+                      recommendation. Expressed as a decimal string multiplied by
+
+                      log2(burstMagnitude). Default "0.1" gives ~20% boost for magnitude
+                      4,
+
+                      ~30% for 8, ~40% for 16. Set "0" to disable burst boost entirely
+
+                      (e.g. for batch jobs). Must be >= 0, max 1.0.'
+                    type: string
+                  controlledValues:
+                    description: 'ControlledValues specifies which resource values
+                      to manage.
+
+                      "RequestsOnly" (default) adjusts only requests, leaving limits
+                      unchanged.
+
+                      "RequestsAndLimits" adjusts both requests and limits in lockstep.
+
+                      For Guaranteed-QoS pods (where requests equal limits), use
+
+                      "RequestsAndLimits" or resizes will be skipped to preserve QoS
+                      class.'
+                    enum:
+                    - RequestsOnly
+                    - RequestsAndLimits
+                    type: string
+                  maxAllowed:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxAllowed is the maximum allowed resource value.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxChangePercent:
+                    description: 'MaxChangePercent is the maximum allowed change percentage
+                      per
+
+                      reconcile cycle for this resource (both directions). Limits
+                      how
+
+                      aggressively the recommendation can deviate from the current
+                      value
+
+                      in a single step, forcing gradual convergence. Overridden by
+
+                      MaxIncreasePercent/MaxDecreasePercent if those are set.
+
+                      Defaults to 50 for CPU, 30 for memory.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  maxDecreasePercent:
+                    description: 'MaxDecreasePercent is the maximum allowed decrease
+                      percentage per
+
+                      reconcile cycle. Takes precedence over MaxChangePercent for
+                      downward
+
+                      changes. Memory decreases are riskier (OOM), so a lower cap
+                      is
+
+                      recommended. Defaults to MaxChangePercent if not set.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  maxIncreasePercent:
+                    description: 'MaxIncreasePercent is the maximum allowed increase
+                      percentage per
+
+                      reconcile cycle. Takes precedence over MaxChangePercent for
+                      upward
+
+                      changes. Defaults to MaxChangePercent if not set.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  memoryFromCpuRatio:
+                    description: 'MemoryFromCPURatio derives memory recommendations
+                      from CPU recommendations
+
+                      using a fixed ratio, instead of using Prometheus memory metrics.
+                      Useful for
+
+                      JVM, Go, and .NET workloads where heap scales linearly with
+                      CPU allocation
+
+                      and Prometheus memory metrics are unreliable (JVM reserves heap
+                      upfront,
+
+                      Go GC targets a fixed percentage of available memory).
+
+                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+
+                      (e.g., 500m CPU -> 1Gi memory). The derived value still passes
+                      through
+
+                      minAllowed, maxAllowed, and maxChangePercent bounds.
+
+                      Only valid on the memory ResourceConfig; ignored on CPU.'
+                    type: string
+                  minAllowed:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MinAllowed is the minimum allowed resource value.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  overhead:
+                    description: 'Overhead is the percentage of additional resources
+                      added on top of the
+
+                      percentile recommendation. Expressed as a string (e.g. "20"
+                      means 20%
+
+                      extra headroom above the target percentile). Must be >= 0, max
+                      900.'
+                    pattern: ^([0-9]+(\.[0-9]+)?)?$
+                    type: string
+                  percentile:
+                    description: 'Percentile is the usage percentile to target for
+                      recommendations.
+
+                      Supported values: 50, 90, 95, 99. Omit or set to 0 to use the
+                      default.'
+                    enum:
+                    - 0
+                    - 50
+                    - 90
+                    - 95
+                    - 99
+                    format: int32
+                    type: integer
+                  startupBoost:
+                    description: 'StartupBoost temporarily increases CPU requests
+                      for newly created or
+
+                      restarted pods to accelerate JVM/.NET class loading, JIT compilation,
+
+                      and cache warming. After the duration expires (or the container
+                      reaches
+
+                      Ready), the CPU is reduced to the steady-state recommendation.
+
+                      Only applies to CPU resources.'
+                    properties:
+                      duration:
+                        description: 'Duration is the maximum time the boost remains
+                          active after pod
+
+                          creation or container restart. The boost is removed when
+                          the
+
+                          container reaches Ready or this duration expires, whichever
+                          comes first.
+
+                          Must be >= 10s and <= 1h.'
+                        type: string
+                      multiplier:
+                        description: 'Multiplier scales the recommended CPU request
+                          during startup.
+
+                          For example, "3.0" means 3x the steady-state recommendation.
+
+                          Must be > 1.0 and <= 10.0.'
+                        type: string
+                    required:
+                    - duration
+                    - multiplier
+                    type: object
+                type: object
+              excludedContainers:
+                description: 'ExcludedContainers is a list of container names to skip
+                  when computing
+
+                  recommendations and performing resizes. Use this for sidecar containers
+
+                  (e.g., istio-proxy, linkerd-proxy) that are managed by a service
+                  mesh
+
+                  and should not be right-sized.'
+                items:
+                  type: string
+                type: array
+              memory:
+                description: Memory configures memory resource recommendations.
+                properties:
+                  allowDecrease:
+                    description: 'AllowDecrease controls whether the resource value
+                      can be decreased.
+
+                      For CPU: nil defaults to true (decreases allowed, throttle detected
+                      by safety monitor).
+
+                      For memory: nil defaults to false (decreases blocked to prevent
+                      OOMKill).'
+                    type: boolean
+                  burstSensitivity:
+                    description: 'BurstSensitivity controls how much burst detection
+                      inflates the
+
+                      recommendation. Expressed as a decimal string multiplied by
+
+                      log2(burstMagnitude). Default "0.1" gives ~20% boost for magnitude
+                      4,
+
+                      ~30% for 8, ~40% for 16. Set "0" to disable burst boost entirely
+
+                      (e.g. for batch jobs). Must be >= 0, max 1.0.'
+                    type: string
+                  controlledValues:
+                    description: 'ControlledValues specifies which resource values
+                      to manage.
+
+                      "RequestsOnly" (default) adjusts only requests, leaving limits
+                      unchanged.
+
+                      "RequestsAndLimits" adjusts both requests and limits in lockstep.
+
+                      For Guaranteed-QoS pods (where requests equal limits), use
+
+                      "RequestsAndLimits" or resizes will be skipped to preserve QoS
+                      class.'
+                    enum:
+                    - RequestsOnly
+                    - RequestsAndLimits
+                    type: string
+                  maxAllowed:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MaxAllowed is the maximum allowed resource value.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxChangePercent:
+                    description: 'MaxChangePercent is the maximum allowed change percentage
+                      per
+
+                      reconcile cycle for this resource (both directions). Limits
+                      how
+
+                      aggressively the recommendation can deviate from the current
+                      value
+
+                      in a single step, forcing gradual convergence. Overridden by
+
+                      MaxIncreasePercent/MaxDecreasePercent if those are set.
+
+                      Defaults to 50 for CPU, 30 for memory.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  maxDecreasePercent:
+                    description: 'MaxDecreasePercent is the maximum allowed decrease
+                      percentage per
+
+                      reconcile cycle. Takes precedence over MaxChangePercent for
+                      downward
+
+                      changes. Memory decreases are riskier (OOM), so a lower cap
+                      is
+
+                      recommended. Defaults to MaxChangePercent if not set.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  maxIncreasePercent:
+                    description: 'MaxIncreasePercent is the maximum allowed increase
+                      percentage per
+
+                      reconcile cycle. Takes precedence over MaxChangePercent for
+                      upward
+
+                      changes. Defaults to MaxChangePercent if not set.'
+                    format: int32
+                    maximum: 100
+                    minimum: 1
+                    type: integer
+                  memoryFromCpuRatio:
+                    description: 'MemoryFromCPURatio derives memory recommendations
+                      from CPU recommendations
+
+                      using a fixed ratio, instead of using Prometheus memory metrics.
+                      Useful for
+
+                      JVM, Go, and .NET workloads where heap scales linearly with
+                      CPU allocation
+
+                      and Prometheus memory metrics are unreliable (JVM reserves heap
+                      upfront,
+
+                      Go GC targets a fixed percentage of available memory).
+
+                      Example: "2.0" means memory = 2x the CPU recommendation in bytes
+
+                      (e.g., 500m CPU -> 1Gi memory). The derived value still passes
+                      through
+
+                      minAllowed, maxAllowed, and maxChangePercent bounds.
+
+                      Only valid on the memory ResourceConfig; ignored on CPU.'
+                    type: string
+                  minAllowed:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: MinAllowed is the minimum allowed resource value.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  overhead:
+                    description: 'Overhead is the percentage of additional resources
+                      added on top of the
+
+                      percentile recommendation. Expressed as a string (e.g. "20"
+                      means 20%
+
+                      extra headroom above the target percentile). Must be >= 0, max
+                      900.'
+                    pattern: ^([0-9]+(\.[0-9]+)?)?$
+                    type: string
+                  percentile:
+                    description: 'Percentile is the usage percentile to target for
+                      recommendations.
+
+                      Supported values: 50, 90, 95, 99. Omit or set to 0 to use the
+                      default.'
+                    enum:
+                    - 0
+                    - 50
+                    - 90
+                    - 95
+                    - 99
+                    format: int32
+                    type: integer
+                  startupBoost:
+                    description: 'StartupBoost temporarily increases CPU requests
+                      for newly created or
+
+                      restarted pods to accelerate JVM/.NET class loading, JIT compilation,
+
+                      and cache warming. After the duration expires (or the container
+                      reaches
+
+                      Ready), the CPU is reduced to the steady-state recommendation.
+
+                      Only applies to CPU resources.'
+                    properties:
+                      duration:
+                        description: 'Duration is the maximum time the boost remains
+                          active after pod
+
+                          creation or container restart. The boost is removed when
+                          the
+
+                          container reaches Ready or this duration expires, whichever
+                          comes first.
+
+                          Must be >= 10s and <= 1h.'
+                        type: string
+                      multiplier:
+                        description: 'Multiplier scales the recommended CPU request
+                          during startup.
+
+                          For example, "3.0" means 3x the steady-state recommendation.
+
+                          Must be > 1.0 and <= 10.0.'
+                        type: string
+                    required:
+                    - duration
+                    - multiplier
+                    type: object
+                type: object
+              metricsSource:
+                description: MetricsSource configures where and how to collect metrics.
+                properties:
+                  cloudwatch:
+                    description: CloudWatch configures an Amazon CloudWatch Container
+                      Insights metrics source.
+                    properties:
+                      clusterName:
+                        description: 'ClusterName is the EKS cluster name for Container
+                          Insights metrics.
+
+                          Required for metric filtering.'
+                        type: string
+                      region:
+                        description: Region is the AWS region (e.g. "us-east-1").
+                          Required.
+                        type: string
+                      roleArn:
+                        description: 'RoleARN is an optional IAM role ARN to assume
+                          for cross-account access.
+
+                          If not set, uses the pod''s service account IAM role (IRSA/Pod
+                          Identity).'
+                        type: string
+                    required:
+                    - clusterName
+                    - region
+                    type: object
+                  datadog:
+                    description: Datadog configures a Datadog metrics source.
+                    properties:
+                      apiKeySecretRef:
+                        description: 'APIKeySecretRef references a Secret containing
+                          the Datadog API key.
+
+                          The Secret must contain an "api-key" key and optionally
+                          an "app-key" key.'
+                        properties:
+                          key:
+                            description: Key within the Secret.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      site:
+                        default: datadoghq.com
+                        description: 'Site is the Datadog site (e.g. "datadoghq.com",
+                          "datadoghq.eu", "us5.datadoghq.com").
+
+                          Defaults to "datadoghq.com".'
+                        type: string
+                    required:
+                    - apiKeySecretRef
+                    type: object
+                  historyWindow:
+                    description: 'HistoryWindow is the time window for historical
+                      metrics data.
+
+                      Defaults to 7d (168h) if not specified.'
+                    type: string
+                  minimumDataPoints:
+                    description: 'MinimumDataPoints is the minimum number of data
+                      points required
+
+                      before generating recommendations. Minimum 1, default 48 samples.
+
+                      With the default queryStep of 5m, 48 samples is about 4 hours
+                      of data.
+
+                      Defaults to 48 if not set (applied by the controller so that
+
+                      AttuneDefaults cluster configuration can override it).'
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  prometheus:
+                    description: Prometheus configures a Prometheus metrics source.
+                    properties:
+                      address:
+                        description: Address is the URL of the Prometheus-compatible
+                          query endpoint.
+                        type: string
+                      bearerTokenSecret:
+                        description: 'BearerTokenSecret references a Kubernetes Secret
+                          containing a bearer
+
+                          token for authenticating with managed Prometheus services.'
+                        properties:
+                          key:
+                            description: Key within the Secret.
+                            type: string
+                          name:
+                            description: Name of the Secret.
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      headers:
+                        additionalProperties:
+                          type: string
+                        description: 'Headers are custom HTTP headers added to every
+                          query request.
+
+                          Use for non-secret tenant or routing headers (e.g. "X-Scope-OrgID"
+
+                          for Mimir). Do not put credentials here; use BearerTokenSecret
+                          for
+
+                          authentication tokens.'
+                        type: object
+                      queryParameters:
+                        additionalProperties:
+                          type: string
+                        description: 'QueryParameters are appended to every query
+                          request URL.
+
+                          Use for backend-specific settings such as Thanos deduplication
+
+                          (e.g. {"dedup": "true", "partial_response": "true"}). Reserved
+
+                          query keys controlled by the operator (`query`, `start`,
+                          `end`, `step`,
+
+                          `time`, `timeout`) are rejected.'
+                        type: object
+                      tls:
+                        description: TLS configures TLS settings for the connection.
+                        properties:
+                          insecureSkipVerify:
+                            description: 'InsecureSkipVerify disables TLS certificate
+                              verification.
+
+                              Use only for self-signed certificates in development.'
+                            type: boolean
+                        type: object
+                    required:
+                    - address
+                    type: object
+                  queryStep:
+                    description: 'QueryStep is the step interval for Prometheus range
+                      queries and ETA
+
+                      calculations. Should match your Prometheus scrape interval for
+
+                      accurate time estimates. Minimum 10s, maximum 1h. Default 5m.'
+                    type: string
+                  rateWindow:
+                    description: 'RateWindow is the window used in the PromQL rate()
+                      function for CPU
+
+                      queries. Defaults to queryStep if not set. Must be >= 30s and
+                      <= historyWindow.
+
+                      Advanced users may set this independently to control CPU rate
+                      smoothing
+
+                      (e.g. a short rateWindow for responsive tracking with a longer
+                      queryStep).'
+                    type: string
+                  vpa:
+                    description: VPA configures consumption of existing VerticalPodAutoscaler
+                      recommendations.
+                    properties:
+                      name:
+                        description: Name is the name of the VerticalPodAutoscaler
+                          object.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the VPA. Defaults
+                          to the policy's namespace.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              paused:
+                description: 'Paused stops the operator from reconciling this policy.
+                  Metrics
+
+                  collection, recommendations, and resizes are all halted. Existing
+
+                  resizes are not reverted. Use this during maintenance windows or
+
+                  when debugging unexpected behavior. The operator sets Ready=False
+
+                  with reason=Paused while this field is true.'
+                type: boolean
+              targetRef:
+                description: TargetRef identifies the workload(s) to be attuned.
+                properties:
+                  kind:
+                    description: Kind is the kind of the target resource.
+                    enum:
+                    - Deployment
+                    - StatefulSet
+                    - DaemonSet
+                    - CronJob
+                    - Job
+                    - ReplicaSet
+                    type: string
+                  name:
+                    description: Name is the name of a specific target resource.
+                    type: string
+                  selector:
+                    description: Selector selects target resources by labels.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: 'A label selector requirement is a selector
+                            that contains values, a key, and an operator that
+
+                            relates the key and values.'
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: 'operator represents a key''s relationship
+                                to a set of values.
+
+                                Valid operators are In, NotIn, Exists and DoesNotExist.'
+                              type: string
+                            values:
+                              description: 'values is an array of string values. If
+                                the operator is In or NotIn,
+
+                                the values array must be non-empty. If the operator
+                                is Exists or DoesNotExist,
+
+                                the values array must be empty. This array is replaced
+                                during a strategic
+
+                                merge patch.'
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: 'matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels
+
+                          map is equivalent to an element of matchExpressions, whose
+                          key field is "key", the
+
+                          operator is "In", and the values array contains only "value".
+                          The requirements are ANDed.'
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - kind
+                type: object
+              updateStrategy:
+                description: UpdateStrategy configures how and when to apply resource
+                  changes.
+                properties:
+                  autoRevert:
+                    description: 'AutoRevert automatically reverts changes if degradation
+                      is detected.
+
+                      Defaults to true if not set (applied by the controller so that
+
+                      AttuneDefaults cluster configuration can override it).'
+                    type: boolean
+                  canary:
+                    description: Canary configures canary rollout behavior when Type
+                      is Canary.
+                    properties:
+                      autoPromote:
+                        description: 'AutoPromote controls whether the operator automatically
+                          promotes the
+
+                          resize to all pods after the observation period passes without
+                          safety
+
+                          violations. When false (default), the user must manually
+                          switch the
+
+                          mode to Auto to resize the remaining pods.'
+                        type: boolean
+                      observationPeriod:
+                        description: ObservationPeriod is how long to observe canary
+                          pods before proceeding.
+                        type: string
+                      percentage:
+                        description: Percentage is the percentage of pods to resize
+                          first.
+                        format: int32
+                        maximum: 100
+                        minimum: 1
+                        type: integer
+                    required:
+                    - observationPeriod
+                    - percentage
+                    type: object
+                  cooldown:
+                    description: 'Cooldown is the minimum time between successive
+                      resize operations.
+
+                      Defaults to 1h if not specified.'
+                    type: string
+                  export:
+                    description: 'Export configures how recommendations are exported
+                      for external
+
+                      consumption (e.g. GitOps workflows with ArgoCD or Flux).'
+                    properties:
+                      configMap:
+                        description: 'ConfigMap enables exporting recommendations
+                          to ConfigMaps.
+
+                          One ConfigMap per workload is created, named
+
+                          "<policy>-<workload>-recommendations", with an owner reference
+
+                          to the policy for automatic cleanup.'
+                        type: boolean
+                    type: object
+                  initialSizing:
+                    description: 'InitialSizing enables a mutating admission webhook
+                      that sets resource
+
+                      requests/limits on new pods at creation time, based on existing
+
+                      recommendations. This eliminates the "deploy with bad defaults,
+                      wait
+
+                      for first reconcile" gap. Requires the namespace label
+
+                      attune.io/initial-sizing=enabled. Defaults to false.'
+                    type: boolean
+                  maxConcurrentResizes:
+                    default: 1
+                    description: 'MaxConcurrentResizes is the maximum number of pods
+                      to resize
+
+                      concurrently within a single reconcile cycle. Default: 1 (serial).'
+                    format: int32
+                    maximum: 50
+                    minimum: 1
+                    type: integer
+                  maxTotalCpuIncrease:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'MaxTotalCPUIncrease is the maximum aggregate CPU
+                      increase allowed
+
+                      across all pods in a single reconcile cycle (e.g. "2000m", "4").
+
+                      Once exhausted, remaining pods are deferred to the next cycle.
+
+                      Decreases do not consume budget. Default: unlimited.'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxTotalMemoryIncrease:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: 'MaxTotalMemoryIncrease is the maximum aggregate
+                      memory increase
+
+                      allowed across all pods in a single reconcile cycle (e.g. "4Gi").
+
+                      Once exhausted, remaining pods are deferred to the next cycle.
+
+                      Decreases do not consume budget. Default: unlimited.'
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  resizeMethod:
+                    description: "ResizeMethod controls what happens when an in-place\
+                      \ resize fails.\n  InPlaceOnly (default): skip the pod and retry\
+                      \ next cycle.\n  InPlaceOrRecreate: fall back to pod eviction\
+                      \ if in-place resize\n  fails or is marked Infeasible by kubelet.\
+                      \ The owning controller\n  recreates the pod with updated resources.\
+                      \ Evictions respect\n  PodDisruptionBudgets and never evict\
+                      \ the last replica.\nDefaults to InPlaceOnly if not set (applied\
+                      \ by the controller so that\nAttuneDefaults cluster configuration\
+                      \ can override it)."
+                    enum:
+                    - InPlaceOnly
+                    - InPlaceOrRecreate
+                    type: string
+                  safetyObservationPeriod:
+                    description: 'SafetyObservationPeriod is how long to observe a
+                      pod after resize before
+
+                      concluding the resize is safe. Applies to all modes (Auto, OneShot,
+                      Canary).
+
+                      Takes precedence over canary.observationPeriod when set. Must
+                      be >= 1m.
+
+                      Defaults to 5m if neither this nor canary.observationPeriod
+                      is set.'
+                    type: string
+                  schedule:
+                    description: 'Schedule restricts when resize operations can occur.
+                      Recommendations
+
+                      are always computed; only resize execution is gated. If omitted,
+
+                      resizes can occur at any time (current behavior).'
+                    properties:
+                      daysOfWeek:
+                        description: 'DaysOfWeek restricts resizes to specific days.
+                          Values: Monday through Sunday.
+
+                          If omitted, all days are allowed.'
+                        items:
+                          enum:
+                          - Monday
+                          - Tuesday
+                          - Wednesday
+                          - Thursday
+                          - Friday
+                          - Saturday
+                          - Sunday
+                          type: string
+                        type: array
+                      timezone:
+                        default: UTC
+                        description: 'Timezone for interpreting window start/end times.
+                          Must be a valid
+
+                          IANA timezone name (e.g. "America/New_York"). Default: "UTC".'
+                        type: string
+                      windows:
+                        description: 'Windows defines time-of-day ranges when resizes
+                          are allowed.
+
+                          If multiple windows are specified, resizes are allowed during
+                          any of them.'
+                        items:
+                          description: TimeWindow defines a daily time range.
+                          properties:
+                            end:
+                              description: 'End time in HH:MM format (24-hour). If
+                                end < start, the window
+
+                                wraps past midnight (e.g. start=22:00, end=06:00).'
+                              pattern: ^([01]\d|2[0-3]):[0-5]\d$
+                              type: string
+                            start:
+                              description: Start time in HH:MM format (24-hour).
+                              pattern: ^([01]\d|2[0-3]):[0-5]\d$
+                              type: string
+                          required:
+                          - end
+                          - start
+                          type: object
+                        type: array
+                    type: object
+                  sloGuardrails:
+                    description: 'SLOGuardrails defines application-level SLO metrics
+                      to check after
+
+                      a resize. If any metric breaches its threshold during the safety
+
+                      observation period, the resize is automatically reverted.
+
+                      Requires a Prometheus-compatible metrics source.'
+                    items:
+                      description: 'SLOGuardrail defines an application-level metric
+                        that is checked after
+
+                        a resize to detect degradation. If the metric breaches the
+                        threshold,
+
+                        the safety monitor triggers an automatic revert.'
+                      properties:
+                        comparison:
+                          default: above
+                          description: Comparison is "above" or "below". "above" reverts
+                            when value > threshold.
+                          enum:
+                          - above
+                          - below
+                          type: string
+                        evaluationWindow:
+                          description: EvaluationWindow is how long after resize to
+                            check. Defaults to 5m.
+                          type: string
+                        name:
+                          description: Name identifies this guardrail for logging
+                            and status reporting.
+                          type: string
+                        query:
+                          description: 'Query is a PromQL query that returns a scalar
+                            value.
+
+                            Template variables: {{ .Namespace }}, {{ .WorkloadName
+                            }}, {{ .PodName }}'
+                          type: string
+                        threshold:
+                          description: Threshold is the value that triggers a revert.
+                          type: string
+                      required:
+                      - name
+                      - query
+                      - threshold
+                      type: object
+                    maxItems: 10
+                    type: array
+                  type:
+                    description: "Mode determines the update behavior, graduated from\
+                      \ safe to automated:\n  Recommend: collects metrics and writes\
+                      \ recommendations to status, no pod changes.\n  OneShot: resizes\
+                      \ one pod per reconcile cycle.\n  Canary: resizes a percentage\
+                      \ of pods first, then the rest after observation.\n  Auto: resizes\
+                      \ all eligible pods each cycle.\n  Observe: collects metrics\
+                      \ and tracks data points but does not surface recommendations\
+                      \ or savings.\nStart with Recommend in production and promote\
+                      \ after reviewing status.\nDefaults to Recommend if not set\
+                      \ (applied by the controller, not the webhook,\nso that AttuneDefaults\
+                      \ cluster configuration can override it)."
+                    enum:
+                    - Observe
+                    - Recommend
+                    - OneShot
+                    - Canary
+                    - Auto
+                    type: string
+                type: object
+              weight:
+                default: 100
+                description: 'Weight determines the priority of this policy when multiple
+                  policies
+
+                  match the same workload. Higher values take precedence.'
+                format: int32
+                maximum: 1000
+                minimum: 1
+                type: integer
+            required:
+            - cpu
+            - memory
+            - metricsSource
+            - targetRef
+            type: object
+          status:
+            description: AttunePolicyStatus defines the observed state of AttunePolicy.
+            properties:
+              canary:
+                description: Canary tracks the canary rollout phase when autoPromote
+                  is enabled.
+                properties:
+                  observedGeneration:
+                    description: 'ObservedGeneration is the policy generation when
+                      this canary cycle
+
+                      started. If the policy spec changes (generation increments),
+                      the
+
+                      canary observation resets so the new configuration is re-validated.'
+                    format: int64
+                    type: integer
+                  phase:
+                    description: 'Phase indicates the current canary state.
+
+                      CanaryInProgress: canary pods resized, observing for safety
+                      violations.
+
+                      FullRollout: observation passed with no violations, all pods
+                      are being resized.'
+                    type: string
+                  pods:
+                    description: 'Pods lists the names of pods selected for the canary
+                      subset.
+
+                      Populated when Mode is Canary and pods have been resized.'
+                    items:
+                      type: string
+                    maxItems: 100
+                    type: array
+                  startTime:
+                    description: StartTime is when the canary subset was first resized.
+                    format: date-time
+                    type: string
+                type: object
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the policy's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: 'lastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+
+                        This should be when the underlying condition changed.  If
+                        that is not known, then using the time when the API field
+                        changed is acceptable.'
+                      format: date-time
+                      type: string
+                    message:
+                      description: 'message is a human readable message indicating
+                        details about the transition.
+
+                        This may be an empty string.'
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: 'observedGeneration represents the .metadata.generation
+                        that the condition was set based upon.
+
+                        For instance, if .metadata.generation is currently 12, but
+                        the .status.conditions[x].observedGeneration is 9, the condition
+                        is out of date
+
+                        with respect to the current state of the instance.'
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: 'reason contains a programmatic identifier indicating
+                        the reason for the condition''s last transition.
+
+                        Producers of specific condition types may define expected
+                        values and meanings for this field,
+
+                        and whether the values are considered a guaranteed API.
+
+                        The value should be a CamelCase string.
+
+                        This field may not be empty.'
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - 'True'
+                      - 'False'
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              cooldown:
+                description: Cooldown exposes the effective cooldown including exponential
+                  backoff.
+                properties:
+                  backoffMultiplier:
+                    description: BackoffMultiplier is the current backoff multiplier
+                      (1, 2, 4, 8, or 16).
+                    format: int32
+                    type: integer
+                  consecutiveReverts:
+                    description: ConsecutiveReverts is the number of consecutive reverts
+                      driving the backoff.
+                    format: int32
+                    type: integer
+                  effectiveCooldown:
+                    description: EffectiveCooldown is the current cooldown duration
+                      including backoff.
+                    type: string
+                type: object
+              lastReconcileTime:
+                description: 'LastReconcileTime is the timestamp of the most recent
+                  reconciliation.
+
+                  Serves as a heartbeat to confirm the operator is actively evaluating
+
+                  this policy, even when no state changes occur.'
+                format: date-time
+                type: string
+              recommendations:
+                description: Recommendations contains per-workload resource recommendations.
+                items:
+                  description: WorkloadRecommendation contains recommendations for
+                    a single workload.
+                  properties:
+                    containers:
+                      description: Containers contains per-container recommendations.
+                      items:
+                        description: ContainerRecommendation contains recommendations
+                          for a single container.
+                        properties:
+                          confidence:
+                            description: Confidence is the confidence score of the
+                              recommendation (0-1).
+                            type: number
+                          current:
+                            description: Current contains the current resource values.
+                            properties:
+                              cpuLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: CPULimit is the CPU limit value.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              cpuRequest:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: CPURequest is the CPU request value.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memoryLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: MemoryLimit is the memory limit value.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memoryRequest:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: MemoryRequest is the memory request value.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - cpuLimit
+                            - cpuRequest
+                            - memoryLimit
+                            - memoryRequest
+                            type: object
+                          dataPoints:
+                            description: DataPoints is the number of data points used
+                              to generate the recommendation.
+                            format: int32
+                            type: integer
+                          explanation:
+                            description: Explanation contains the reasoning chain
+                              behind the recommendation.
+                            properties:
+                              cpu:
+                                description: CPU contains the CPU recommendation reasoning.
+                                properties:
+                                  afterBounds:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: AfterBounds is the value after bounds
+                                      clamping.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  afterBurst:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: AfterBurst is the value after applying
+                                      the burst factor.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  afterChangeFilter:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: AfterChangeFilter is the value after
+                                      change filtering.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  afterConfidence:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: AfterConfidence is the value after
+                                      applying the confidence adjustment.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  afterOverhead:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: AfterOverhead is the value after
+                                      applying the overhead.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  bounds:
+                                    description: Bounds are the configured minimum
+                                      and maximum limits.
+                                    properties:
+                                      max:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Max is the maximum allowed resource
+                                          value.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      min:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Min is the minimum allowed resource
+                                          value.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - max
+                                    - min
+                                    type: object
+                                  boundsApplied:
+                                    description: BoundsApplied indicates whether the
+                                      value was clamped to min, max, or neither.
+                                    type: string
+                                  burstFactor:
+                                    description: 'BurstFactor is the multiplier applied
+                                      when burst is detected (max > 3x p95).
+
+                                      1.0 when no burst. Uses logarithmic scaling
+                                      to avoid excessive inflation.'
+                                    type: number
+                                  changeFilterApplied:
+                                    description: ChangeFilterApplied indicates whether
+                                      the result was filtered or capped.
+                                    type: string
+                                  confidence:
+                                    description: Confidence is the profile confidence
+                                      score used for adjustment.
+                                    type: number
+                                  confidenceFactor:
+                                    description: ConfidenceFactor is the multiplier
+                                      derived from the confidence score.
+                                    type: number
+                                  final:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Final is the final resource recommendation
+                                      after any post-processing.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  finalAdjustment:
+                                    description: FinalAdjustment describes any controller-level
+                                      adjustment after the estimator chain.
+                                    type: string
+                                  maxChangePercent:
+                                    description: MaxChangePercent is the maximum allowed
+                                      change threshold.
+                                    type: number
+                                  minChangePercent:
+                                    description: MinChangePercent is the minimum change
+                                      threshold required to alter the current value.
+                                    type: number
+                                  overhead:
+                                    description: Overhead is the configured overhead
+                                      percentage applied to the raw percentile.
+                                    type: number
+                                  rawPercentile:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: RawPercentile is the selected percentile
+                                      before any adjustments.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - afterBounds
+                                - afterChangeFilter
+                                - afterConfidence
+                                - afterOverhead
+                                - bounds
+                                - confidence
+                                - confidenceFactor
+                                - final
+                                - maxChangePercent
+                                - minChangePercent
+                                - overhead
+                                - rawPercentile
+                                type: object
+                              memory:
+                                description: Memory contains the memory recommendation
+                                  reasoning.
+                                properties:
+                                  afterBounds:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: AfterBounds is the value after bounds
+                                      clamping.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  afterBurst:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: AfterBurst is the value after applying
+                                      the burst factor.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  afterChangeFilter:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: AfterChangeFilter is the value after
+                                      change filtering.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  afterConfidence:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: AfterConfidence is the value after
+                                      applying the confidence adjustment.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  afterOverhead:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: AfterOverhead is the value after
+                                      applying the overhead.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  bounds:
+                                    description: Bounds are the configured minimum
+                                      and maximum limits.
+                                    properties:
+                                      max:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Max is the maximum allowed resource
+                                          value.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      min:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Min is the minimum allowed resource
+                                          value.
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - max
+                                    - min
+                                    type: object
+                                  boundsApplied:
+                                    description: BoundsApplied indicates whether the
+                                      value was clamped to min, max, or neither.
+                                    type: string
+                                  burstFactor:
+                                    description: 'BurstFactor is the multiplier applied
+                                      when burst is detected (max > 3x p95).
+
+                                      1.0 when no burst. Uses logarithmic scaling
+                                      to avoid excessive inflation.'
+                                    type: number
+                                  changeFilterApplied:
+                                    description: ChangeFilterApplied indicates whether
+                                      the result was filtered or capped.
+                                    type: string
+                                  confidence:
+                                    description: Confidence is the profile confidence
+                                      score used for adjustment.
+                                    type: number
+                                  confidenceFactor:
+                                    description: ConfidenceFactor is the multiplier
+                                      derived from the confidence score.
+                                    type: number
+                                  final:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Final is the final resource recommendation
+                                      after any post-processing.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  finalAdjustment:
+                                    description: FinalAdjustment describes any controller-level
+                                      adjustment after the estimator chain.
+                                    type: string
+                                  maxChangePercent:
+                                    description: MaxChangePercent is the maximum allowed
+                                      change threshold.
+                                    type: number
+                                  minChangePercent:
+                                    description: MinChangePercent is the minimum change
+                                      threshold required to alter the current value.
+                                    type: number
+                                  overhead:
+                                    description: Overhead is the configured overhead
+                                      percentage applied to the raw percentile.
+                                    type: number
+                                  rawPercentile:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: RawPercentile is the selected percentile
+                                      before any adjustments.
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                - afterBounds
+                                - afterChangeFilter
+                                - afterConfidence
+                                - afterOverhead
+                                - bounds
+                                - confidence
+                                - confidenceFactor
+                                - final
+                                - maxChangePercent
+                                - minChangePercent
+                                - overhead
+                                - rawPercentile
+                                type: object
+                            type: object
+                          lastUpdated:
+                            description: LastUpdated is the timestamp of the last
+                              recommendation update.
+                            format: date-time
+                            type: string
+                          name:
+                            description: Name is the container name.
+                            type: string
+                          recommended:
+                            description: Recommended contains the recommended resource
+                              values.
+                            properties:
+                              cpuLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: CPULimit is the CPU limit value.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              cpuRequest:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: CPURequest is the CPU request value.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memoryLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: MemoryLimit is the memory limit value.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memoryRequest:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: MemoryRequest is the memory request value.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - cpuLimit
+                            - cpuRequest
+                            - memoryLimit
+                            - memoryRequest
+                            type: object
+                        required:
+                        - confidence
+                        - current
+                        - dataPoints
+                        - lastUpdated
+                        - name
+                        - recommended
+                        type: object
+                      type: array
+                    kind:
+                      description: Kind is the kind of the workload (e.g. Deployment,
+                        StatefulSet).
+                      type: string
+                    lastDataTime:
+                      description: 'LastDataTime is the timestamp when Prometheus
+                        last returned non-empty
+
+                        data for this workload. Used for staleness detection.'
+                      format: date-time
+                      type: string
+                    stale:
+                      description: 'Stale indicates the recommendation is based on
+                        cached data because
+
+                        Prometheus did not return fresh data during the most recent
+                        query.
+
+                        Resizes are not executed with stale recommendations.'
+                      type: boolean
+                    workload:
+                      description: Workload is the name of the workload.
+                      type: string
+                  required:
+                  - containers
+                  - kind
+                  - workload
+                  type: object
+                maxItems: 500
+                type: array
+              resizeHistory:
+                description: ResizeHistory records past resize operations.
+                items:
+                  description: ResizeHistoryEntry records a single resize operation.
+                  properties:
+                    container:
+                      description: Container is the name of the resized container.
+                      type: string
+                    from:
+                      description: From is the previous resource value.
+                      type: string
+                    method:
+                      description: Method is the resize method used.
+                      enum:
+                      - InPlace
+                      - Eviction
+                      type: string
+                    reason:
+                      description: 'Reason explains why the resize was reverted or
+                        failed.
+
+                        Only populated when Result is Reverted or Failed.
+
+                        Values include: oomkill, restart, notready, throttle,
+
+                        annotation-conflict, immediate-safety-check, slo:<name>.'
+                      type: string
+                    resource:
+                      description: Resource is the resource type that was resized.
+                      enum:
+                      - cpu
+                      - memory
+                      - cpu+memory
+                      type: string
+                    result:
+                      description: Result is the outcome of the resize operation.
+                      enum:
+                      - Success
+                      - Failed
+                      - Reverted
+                      - Evicted
+                      type: string
+                    timestamp:
+                      description: Timestamp is when the resize operation occurred.
+                      format: date-time
+                      type: string
+                    to:
+                      description: To is the new resource value.
+                      type: string
+                    workload:
+                      description: Workload is the name of the resized workload.
+                      type: string
+                  required:
+                  - container
+                  - from
+                  - method
+                  - resource
+                  - result
+                  - timestamp
+                  - to
+                  - workload
+                  type: object
+                maxItems: 50
+                type: array
+              savings:
+                description: Savings summarizes estimated resource savings.
+                properties:
+                  cpuRequestIncrease:
+                    description: 'CPURequestIncrease is the total CPU request increase
+                      for under-provisioned
+
+                      workloads (e.g. "500m"). Empty when all recommendations are
+                      decreases.'
+                    type: string
+                  cpuRequestReduction:
+                    description: CPURequestReduction is the total CPU request reduction
+                      (e.g. "200m").
+                    type: string
+                  cpuRequestTotal:
+                    description: CPURequestTotal is the total current CPU requests
+                      across all workloads (e.g. "2000m").
+                    type: string
+                  estimatedMonthlyCostIncrease:
+                    description: 'EstimatedMonthlyCostIncrease is the estimated monthly
+                      cost increase for
+
+                      under-provisioned workloads based on configured or default pricing
+                      (e.g. "$5.00").'
+                    type: string
+                  estimatedMonthlySavings:
+                    description: 'EstimatedMonthlySavings is the estimated monthly
+                      cost savings based on
+
+                      configured or default pricing (e.g. "$12.50").'
+                    type: string
+                  memoryRequestIncrease:
+                    description: 'MemoryRequestIncrease is the total memory request
+                      increase for under-provisioned
+
+                      workloads (e.g. "512Mi"). Empty when all recommendations are
+                      decreases.'
+                    type: string
+                  memoryRequestReduction:
+                    description: MemoryRequestReduction is the total memory request
+                      reduction (e.g. "256Mi").
+                    type: string
+                  memoryRequestTotal:
+                    description: MemoryRequestTotal is the total current memory requests
+                      across all workloads (e.g. "2Gi").
+                    type: string
+                type: object
+              workloadErrors:
+                description: 'WorkloadErrors records per-workload errors from the
+                  most recent
+
+                  reconcile cycle. Capped at 10 entries to limit status size.'
+                items:
+                  description: WorkloadError records an error encountered while processing
+                    a specific workload.
+                  properties:
+                    error:
+                      description: Error is a human-readable description of the error.
+                      type: string
+                    workload:
+                      description: Workload is the name of the affected workload.
+                      type: string
+                  required:
+                  - error
+                  - workload
+                  type: object
+                maxItems: 10
+                type: array
+              workloads:
+                description: Workloads summarizes workload discovery and resize counts.
+                properties:
+                  dataPointsCollected:
+                    description: 'DataPointsCollected is the maximum number of data
+                      points collected across
+
+                      all containers in the discovered workloads.'
+                    format: int32
+                    type: integer
+                  dataPointsRequired:
+                    description: 'DataPointsRequired is the minimum number of data
+                      points needed before
+
+                      generating recommendations (from metricsSource.minimumDataPoints).'
+                    format: int32
+                    type: integer
+                  discovered:
+                    description: Discovered is the number of workloads matching the
+                      target selector.
+                    format: int32
+                    type: integer
+                  pending:
+                    description: Pending is the number of workloads awaiting resize.
+                    format: int32
+                    type: integer
+                  resized:
+                    description: Resized is the number of workloads that have been
+                      resized.
+                    format: int32
+                    type: integer
+                  withRecommendations:
+                    description: WithRecommendations is the number of workloads with
+                      active recommendations.
+                    format: int32
+                    type: integer
+                required:
+                - discovered
+                - pending
+                - resized
+                - withRecommendations
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/attune/0.1.7/metadata/annotations.yaml
+++ b/operators/attune/0.1.7/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: attune
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable

--- a/operators/attune/ci.yaml
+++ b/operators/attune/ci.yaml
@@ -1,1 +1,3 @@
 updateGraph: semver-mode
+reviewers:
+  - SebTardif


### PR DESCRIPTION
Update operator attune to version 0.1.7.

Changes from 0.1.5:
- FIPS 140-3 compliance toggle (GODEBUG=fips140 runtime flag)
- Release workflow hardening (idempotent re-runs)
- Documentation improvements (savings calculator, examples, FIPS guide)
- Krew manifest fixes

Container image: ghcr.io/attune-io/attune:v0.1.7