### PR TITLE
operator [N] [CI] forge-operator (1.0.0)

### DIFF
--- a/operators/forge-operator/1.0.0/bundle.Dockerfile
+++ b/operators/forge-operator/1.0.0/bundle.Dockerfile
@@ -1,0 +1,15 @@
+# OperatorHub.io bundle image for forge-operator 1.0.0.
+#
+# Build context is this directory (operators/forge-operator/1.0.0/),
+# so the COPY paths are relative to the bundle layout siblings.
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=forge-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+
+COPY manifests /manifests/
+COPY metadata  /metadata/

--- a/operators/forge-operator/1.0.0/manifests/forge-operator.clusterserviceversion.yaml
+++ b/operators/forge-operator/1.0.0/manifests/forge-operator.clusterserviceversion.yaml
@@ -1,0 +1,303 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: forge-operator.v1.0.0
+  namespace: placeholder
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "forge.forgeplatform.io/v1alpha1",
+          "kind": "Organization",
+          "metadata": { "name": "platform-team" },
+          "spec": { "description": "Platform engineering", "maxHosts": 500 }
+        },
+        {
+          "apiVersion": "forge.forgeplatform.io/v1alpha1",
+          "kind": "Project",
+          "metadata": { "name": "platform-roles" },
+          "spec": {
+            "organization": "Default",
+            "scmType": "git",
+            "scmUrl": "https://github.com/mycorp/ansible.git",
+            "scmBranch": "main"
+          }
+        },
+        {
+          "apiVersion": "forge.forgeplatform.io/v1alpha1",
+          "kind": "Team",
+          "metadata": { "name": "platform-oncall" },
+          "spec": { "organization": "Default", "users": ["admin"] }
+        },
+        {
+          "apiVersion": "forge.forgeplatform.io/v1alpha1",
+          "kind": "Workflow",
+          "metadata": { "name": "build-and-deploy" },
+          "spec": {
+            "organization": "Default",
+            "nodes": [
+              { "identifier": "build", "unifiedJobTemplate": "Provision EC2", "successNodes": ["deploy"] },
+              { "identifier": "deploy", "unifiedJobTemplate": "Deploy App" }
+            ]
+          }
+        },
+        {
+          "apiVersion": "forge.forgeplatform.io/v1alpha1",
+          "kind": "ForgeInstance",
+          "metadata": { "name": "forge-eu" },
+          "spec": {
+            "url": "https://forge-eu.example.com",
+            "tokenSecretRef": { "name": "forge-eu-token", "key": "token" }
+          }
+        },
+        {
+          "apiVersion": "forge.forgeplatform.io/v1alpha1",
+          "kind": "Inventory",
+          "metadata": { "name": "production" },
+          "spec": {
+            "organization": "Default",
+            "description": "Production inventory",
+            "hosts": [
+              { "name": "web-1.prod", "enabled": true }
+            ]
+          }
+        },
+        {
+          "apiVersion": "forge.forgeplatform.io/v1alpha1",
+          "kind": "Credential",
+          "metadata": { "name": "deploy-key" },
+          "spec": {
+            "organization": "Default",
+            "credentialType": "Machine",
+            "inputs": { "username": "deploy" },
+            "inputsFrom": [
+              { "name": "ssh_key_data", "valueFrom": { "name": "deploy-ssh", "key": "ssh_key_data" } }
+            ]
+          }
+        },
+        {
+          "apiVersion": "forge.forgeplatform.io/v1alpha1",
+          "kind": "JobTemplate",
+          "metadata": { "name": "deploy-web" },
+          "spec": {
+            "jobType": "run",
+            "inventory": "Demo Inventory",
+            "project": "Demo Project",
+            "playbook": "hello_world.yml"
+          }
+        },
+        {
+          "apiVersion": "forge.forgeplatform.io/v1alpha1",
+          "kind": "Schedule",
+          "metadata": { "name": "nightly-deploy" },
+          "spec": {
+            "jobTemplate": "deploy-web",
+            "enabled": true,
+            "rrule": "DTSTART:20260101T020000Z RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR"
+          }
+        }
+      ]
+    capabilities: Deep Insights
+    categories: "Application Runtime,Integration & Delivery"
+    repository: https://github.com/forgeplatform/forge-operator
+    support: forgeplatform
+    containerImage: ghcr.io/forgeplatform/forge-operator:1.0.0
+    createdAt: "2026-05-26T11:00:00Z"
+    description: |
+      Manage Forge automation resources declaratively from Kubernetes.
+spec:
+  displayName: Forge Operator
+  icon:
+    - base64data: PHN2ZyB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCIgdmlld0JveD0iMCAwIDUwMCA1MDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPCEtLSBCYWNrZ3JvdW5kIC0tPgogIDxyZWN0IHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiByeD0iNjAiIGZpbGw9IiMwRDBGMTIiLz4KICAKICA8IS0tIFN1YnRsZSByYWRpYWwgZ2xvdyBiZWhpbmQgYW52aWwgLS0+CiAgPHJhZGlhbEdyYWRpZW50IGlkPSJnbG93IiBjeD0iMjUwIiBjeT0iMjgwIiByPSIxODAiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj4KICAgIDxzdG9wIG9mZnNldD0iMCUiIHN0b3AtY29sb3I9IiNFODUzMUUiIHN0b3Atb3BhY2l0eT0iMC4xMiIvPgogICAgPHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjRTg1MzFFIiBzdG9wLW9wYWNpdHk9IjAiLz4KICA8L3JhZGlhbEdyYWRpZW50PgogIDxjaXJjbGUgY3g9IjI1MCIgY3k9IjI4MCIgcj0iMTgwIiBmaWxsPSJ1cmwoI2dsb3cpIi8+CgogIDwhLS0gRmxvb3IgcmVmbGVjdGlvbiBsaW5lIC0tPgogIDxsaW5lIHgxPSIxMDAiIHkxPSI0MTAiIHgyPSI0MDAiIHkyPSI0MTAiIHN0cm9rZT0iIzFBMUQyMyIgc3Ryb2tlLXdpZHRoPSIyIi8+CgogIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDk1LCA4MCkgc2NhbGUoNC4yKSI+CiAgICA8IS0tIEFudmlsIGJhc2UgKHdpZGVyIHRyYXBlem9pZCkgLS0+CiAgICA8cGF0aCBkPSJNMTAgNjIgTDE3IDUwIEw1NyA1MCBMNjQgNjIgWiIgZmlsbD0iI0U4NTMxRSIvPgogICAgCiAgICA8IS0tIEFudmlsIGJvZHkgLS0+CiAgICA8cGF0aCBkPSJNMTUgNTAgTDE1IDM1IEMxNSAyOSAyMCAyNCAyOCAyNCBMNTAgMjQgQzU1IDI0IDU4IDI3IDU4IDMyIEw1OCA1MCBaIiBmaWxsPSIjRkY2QjM1Ii8+CiAgICAKICAgIDwhLS0gQW52aWwgaG9ybiAobGVmdCBzaWRlKSAtLT4KICAgIDxwYXRoIGQ9Ik0yIDM1IEwxNSAzNSBMMTUgNDMgTDYgNDMgWiIgZmlsbD0iI0ZGNkIzNSIvPgogICAgCiAgICA8IS0tIEFudmlsIHRvcCBmYWNlIGhpZ2hsaWdodCAtLT4KICAgIDxwYXRoIGQ9Ik0xNSAyNCBMNTggMjQgTDU4IDI5IEwxNSAyOSBaIiBmaWxsPSIjRjVBNjIzIiBvcGFjaXR5PSIwLjUiLz4KICAgIAogICAgPCEtLSBBbnZpbCBlZGdlIGhpZ2hsaWdodCAtLT4KICAgIDxwYXRoIGQ9Ik0xNSAyNCBMNTggMjQiIHN0cm9rZT0iI0ZGRDkzRCIgc3Ryb2tlLXdpZHRoPSIwLjgiIG9wYWNpdHk9IjAuNCIvPgogICAgCiAgICA8IS0tIEhhbW1lciAtLT4KICAgIDxnIHRyYW5zZm9ybT0icm90YXRlKC0zOCwgNDQsIDE0KSI+CiAgICAgIDwhLS0gSGFuZGxlIC0tPgogICAgICA8cmVjdCB4PSI0MSIgeT0iNCIgd2lkdGg9IjUuNSIgaGVpZ2h0PSIyMiIgcng9IjEuOCIgZmlsbD0iI0Y1RjZGOCIvPgogICAgICA8IS0tIEhlYWQgLS0+CiAgICAgIDxyZWN0IHg9IjM1IiB5PSIxIiB3aWR0aD0iMTgiIGhlaWdodD0iOSIgcng9IjIuMiIgZmlsbD0iI0M0QzlENCIvPgogICAgICA8IS0tIEhlYWQgdG9wIGhpZ2hsaWdodCAtLT4KICAgICAgPHJlY3QgeD0iMzUiIHk9IjEiIHdpZHRoPSIxOCIgaGVpZ2h0PSIzLjUiIHJ4PSIxLjIiIGZpbGw9IiNGNUY2RjgiIG9wYWNpdHk9IjAuNDUiLz4KICAgICAgPCEtLSBIZWFkIGJvdHRvbSBzaGFkb3cgLS0+CiAgICAgIDxyZWN0IHg9IjM1IiB5PSI3IiB3aWR0aD0iMTgiIGhlaWdodD0iMyIgcng9IjEiIGZpbGw9IiM4QjkxOUUiIG9wYWNpdHk9IjAuMyIvPgogICAgPC9nPgogICAgCiAgICA8IS0tIEltcGFjdCBzcGFya3MgY2x1c3RlciAtLT4KICAgIDxjaXJjbGUgY3g9IjM2IiBjeT0iMjIiIHI9IjIuMiIgZmlsbD0iI0ZGRDkzRCI+CiAgICAgIDxhbmltYXRlIGF0dHJpYnV0ZU5hbWU9Im9wYWNpdHkiIHZhbHVlcz0iMC45OzAuNTswLjkiIGR1cj0iMnMiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIi8+CiAgICA8L2NpcmNsZT4KICAgIDxjaXJjbGUgY3g9IjI4IiBjeT0iMTgiIHI9IjEuNCIgZmlsbD0iI0ZGRDkzRCIgb3BhY2l0eT0iMC43Ij4KICAgICAgPGFuaW1hdGUgYXR0cmlidXRlTmFtZT0ib3BhY2l0eSIgdmFsdWVzPSIwLjc7MC4zOzAuNyIgZHVyPSIyLjVzIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSIvPgogICAgPC9jaXJjbGU+CiAgICA8Y2lyY2xlIGN4PSI0NCIgY3k9IjE5IiByPSIxLjYiIGZpbGw9IiNGNUE2MjMiIG9wYWNpdHk9IjAuODUiPgogICAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjAuODU7MC40OzAuODUiIGR1cj0iMS44cyIgcmVwZWF0Q291bnQ9ImluZGVmaW5pdGUiLz4KICAgIDwvY2lyY2xlPgogICAgPGNpcmNsZSBjeD0iMzEiIGN5PSIxNSIgcj0iMS4wIiBmaWxsPSIjRkZEOTNEIiBvcGFjaXR5PSIwLjYiPgogICAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjAuNjswLjI7MC42IiBkdXI9IjNzIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSIvPgogICAgPC9jaXJjbGU+CiAgICA8Y2lyY2xlIGN4PSI0MSIgY3k9IjE1IiByPSIwLjgiIGZpbGw9IiNGRkQ5M0QiIG9wYWNpdHk9IjAuNSIvPgogICAgPGNpcmNsZSBjeD0iMjUiIGN5PSIyMSIgcj0iMC45IiBmaWxsPSIjRjVBNjIzIiBvcGFjaXR5PSIwLjU1Ii8+CiAgICAKICAgIDwhLS0gU21hbGwgZmx5aW5nIHNwYXJrIHRyYWlscyAtLT4KICAgIDxsaW5lIHgxPSIyOCIgeTE9IjE4IiB4Mj0iMjIiIHkyPSIxMiIgc3Ryb2tlPSIjRkZEOTNEIiBzdHJva2Utd2lkdGg9IjAuNSIgb3BhY2l0eT0iMC40IiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICAgIDxsaW5lIHgxPSI0NCIgeTE9IjE5IiB4Mj0iNTAiIHkyPSIxMyIgc3Ryb2tlPSIjRjVBNjIzIiBzdHJva2Utd2lkdGg9IjAuNSIgb3BhY2l0eT0iMC4zNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+CiAgICA8bGluZSB4MT0iMzEiIHkxPSIxNSIgeDI9IjI3IiB5Mj0iOSIgc3Ryb2tlPSIjRkZEOTNEIiBzdHJva2Utd2lkdGg9IjAuNCIgb3BhY2l0eT0iMC4zIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICA8L2c+Cjwvc3ZnPgo=
+      mediatype: image/svg+xml
+  description: |
+    The Forge Operator reconciles native Forge Platform resources
+    (Organizations, Teams, Projects, Inventories, Credentials,
+    JobTemplates, Schedules, Workflows) declared as Kubernetes Custom
+    Resources, calling the Forge REST API to converge desired state.
+
+    Features:
+
+    * Nine CRDs spanning the full Forge resource model
+    * Multi-cluster routing via `ForgeInstance` CR — each CR can target
+      a different Forge backend by name + Secret-stored bearer token
+    * Workflow CRD with declarative DAG (nodes + success/failure/always
+      edges) reconciled against `/workflow_job_template_nodes/`
+    * Finalizer-driven cleanup (deleting a CR removes the resource in
+      Forge unless the cluster is unreachable)
+    * 60-second drift reconcile that re-asserts desired state if the
+      Forge UI mutates a managed resource
+
+  keywords:
+    - ansible
+    - automation
+    - forge
+    - awx
+    - playbook
+    - infrastructure-as-code
+  maintainers:
+    - name: Krstan Vjestica
+      email: office@krletron.xyz
+  provider:
+    name: Forge Platform
+    url: https://forgeplatform.github.io
+  links:
+    - name: Documentation
+      url: https://forgeplatform.github.io
+    - name: Source
+      url: https://github.com/forgeplatform/forge-operator
+  maturity: alpha
+  version: 1.0.0
+  minKubeVersion: 1.27.0
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+        - serviceAccountName: forge-operator
+          rules:
+            - apiGroups: ["forge.forgeplatform.io"]
+              resources:
+                - jobtemplates
+                - inventories
+                - credentials
+                - schedules
+                - projects
+                - organizations
+                - teams
+                - workflows
+                - forgeinstances
+              verbs: [get, list, watch, create, update, patch, delete]
+            - apiGroups: ["forge.forgeplatform.io"]
+              resources:
+                - jobtemplates/status
+                - inventories/status
+                - credentials/status
+                - schedules/status
+                - projects/status
+                - organizations/status
+                - teams/status
+                - workflows/status
+                - forgeinstances/status
+              verbs: [get, update, patch]
+            - apiGroups: ["forge.forgeplatform.io"]
+              resources:
+                - jobtemplates/finalizers
+                - inventories/finalizers
+                - credentials/finalizers
+                - schedules/finalizers
+                - projects/finalizers
+                - organizations/finalizers
+                - teams/finalizers
+                - workflows/finalizers
+              verbs: [update]
+            - apiGroups: [""]
+              resources: [secrets]
+              verbs: [get, list, watch]
+            - apiGroups: [""]
+              resources: [events]
+              verbs: [create, patch]
+            - apiGroups: ["coordination.k8s.io"]
+              resources: [leases]
+              verbs: [get, create, update]
+      deployments:
+        - name: forge-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: forge-operator
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: forge-operator
+              spec:
+                serviceAccountName: forge-operator
+                containers:
+                  - name: manager
+                    image: ghcr.io/forgeplatform/forge-operator:1.0.0
+                    args:
+                      - --leader-elect
+                    env:
+                      - name: FORGE_URL
+                        valueFrom:
+                          secretKeyRef:
+                            name: forge-operator-default
+                            key: url
+                            optional: true
+                      - name: FORGE_TOKEN
+                        valueFrom:
+                          secretKeyRef:
+                            name: forge-operator-default
+                            key: token
+                            optional: true
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 128Mi
+                      limits:
+                        cpu: 500m
+                        memory: 256Mi
+  customresourcedefinitions:
+    owned:
+      - name: organizations.forge.forgeplatform.io
+        version: v1alpha1
+        kind: Organization
+        displayName: Organization
+        description: A Forge organization — top-level tenant container.
+      - name: teams.forge.forgeplatform.io
+        version: v1alpha1
+        kind: Team
+        displayName: Team
+        description: A Forge team within an organization, with declarative user membership.
+      - name: projects.forge.forgeplatform.io
+        version: v1alpha1
+        kind: Project
+        displayName: Project
+        description: A Forge project (SCM-backed source of playbooks).
+      - name: inventories.forge.forgeplatform.io
+        version: v1alpha1
+        kind: Inventory
+        displayName: Inventory
+        description: A Forge inventory of hosts and groups.
+      - name: credentials.forge.forgeplatform.io
+        version: v1alpha1
+        kind: Credential
+        displayName: Credential
+        description: A Forge credential — inputs sourced from k8s Secrets via inputsFrom.
+      - name: jobtemplates.forge.forgeplatform.io
+        version: v1alpha1
+        kind: JobTemplate
+        displayName: JobTemplate
+        description: A Forge job template.
+      - name: workflows.forge.forgeplatform.io
+        version: v1alpha1
+        kind: Workflow
+        displayName: Workflow
+        description: A Forge workflow job template with declarative DAG of nodes.
+      - name: schedules.forge.forgeplatform.io
+        version: v1alpha1
+        kind: Schedule
+        displayName: Schedule
+        description: A Forge schedule (RFC 5545 RRULE-driven recurring job).
+      - name: forgeinstances.forge.forgeplatform.io
+        version: v1alpha1
+        kind: ForgeInstance
+        displayName: ForgeInstance
+        description: A managed Forge backend that other CRs reference via spec.forgeInstance.

--- a/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_credentials.yaml
+++ b/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_credentials.yaml
@@ -1,0 +1,207 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: credentials.forge.forgeplatform.io
+spec:
+  group: forge.forgeplatform.io
+  names:
+    categories:
+    - forge
+    kind: Credential
+    listKind: CredentialList
+    plural: credentials
+    shortNames:
+    - cred
+    singular: credential
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forgeId
+      name: Forge ID
+      type: integer
+    - jsonPath: .spec.credentialType
+      name: Type
+      type: string
+    - jsonPath: .spec.organization
+      name: Org
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Credential is the Schema for the credentials API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CredentialSpec defines the desired state of a Forge Credential.
+            properties:
+              credentialType:
+                description: |-
+                  CredentialType is the Forge built-in or custom type name, e.g.:
+                  "Machine", "Source Control", "Vault", "Amazon Web Services",
+                  "Container Registry", "GitHub Personal Access Token".
+                type: string
+              description:
+                type: string
+              inputs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Inputs is a free-form map of non-sensitive fields. Field names
+                  must match the credentialType schema (e.g. {username: deploy}
+                  for Machine credential).
+                type: object
+              inputsFrom:
+                description: |-
+                  InputsFrom pulls sensitive fields from a k8s Secret. Each entry
+                  maps a Forge input field name to a Secret/key.
+                items:
+                  description: |-
+                    CredentialInputFromSecret maps one Forge input field name to a Secret
+                    key. Example: ssh_key_data → Secret 'deploy-key' / key 'id_rsa'.
+                  properties:
+                    name:
+                      description: |-
+                        Forge input field name (e.g. "username", "password", "ssh_key_data",
+                        "vault_token"). The set of valid names depends on credentialType.
+                      type: string
+                    valueFrom:
+                      description: |-
+                        SecretKeyRef points at a key inside a k8s Secret in the same namespace
+                        as the Credential CR. Used for sensitive credential fields (passwords,
+                        private keys, tokens) so they never appear in the CR YAML directly.
+                      properties:
+                        key:
+                          description: Key inside the Secret's data block.
+                          type: string
+                        name:
+                          description: Name of the Secret in the same namespace as
+                            the Credential.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                  required:
+                  - name
+                  - valueFrom
+                  type: object
+                type: array
+              name:
+                type: string
+              organization:
+                type: string
+            required:
+            - credentialType
+            - organization
+            type: object
+          status:
+            description: CredentialStatus reflects the observed Forge state.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              credentialTypeId:
+                description: |-
+                  CredentialTypeID is the resolved numeric ID of the credentialType
+                  (cached so we don't look it up every reconcile).
+                format: int64
+                type: integer
+              forgeId:
+                format: int64
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+              secretsHash:
+                description: |-
+                  SecretsHash is a SHA256 of the resolved (sensitive + non-sensitive)
+                  inputs at last successful sync. Used to detect Secret rotation —
+                  when the hash changes, the operator pushes a fresh PATCH to Forge.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_forgeinstances.yaml
+++ b/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_forgeinstances.yaml
@@ -1,0 +1,186 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: forgeinstances.forge.forgeplatform.io
+spec:
+  group: forge.forgeplatform.io
+  names:
+    categories:
+    - forge
+    kind: ForgeInstance
+    listKind: ForgeInstanceList
+    plural: forgeinstances
+    shortNames:
+    - fi
+    - forgeinst
+    singular: forgeinstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.reachable
+      name: Reachable
+      type: boolean
+    - jsonPath: .status.serverVersion
+      name: Version
+      type: string
+    - jsonPath: .status.lastChecked
+      name: Last Checked
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ForgeInstance is the Schema for the forgeinstances API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ForgeInstanceSpec describes a Forge backend the operator should sync to.
+              Other CRs reference this by name (in the same namespace) via their
+              `spec.forgeInstance` field. When that field is empty, the operator uses
+              the default Forge config supplied via --forge-url / --forge-token flags
+              (FORGE_URL / FORGE_TOKEN env vars).
+            properties:
+              hostHeader:
+                description: |-
+                  Optional Host header to send (when reaching Forge via an Ingress
+                  that routes by hostname but URL uses a node IP).
+                type: string
+              insecureSkipVerify:
+                description: Skip TLS verification (development only).
+                type: boolean
+              tokenSecretRef:
+                description: |-
+                  Secret holding the OAuth2 PAT used as `Authorization: Bearer ...`.
+                  The token must be under the key specified by tokenKey (default "token").
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              url:
+                description: |-
+                  Base URL of the Forge backend (e.g.
+                  "https://forge-web.forge.svc.cluster.local:8013").
+                type: string
+            required:
+            - tokenSecretRef
+            - url
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastChecked:
+                description: LastChecked is the timestamp of the last probe.
+                format: date-time
+                type: string
+              reachable:
+                description: Reachable is true when the last health probe succeeded.
+                type: boolean
+              serverVersion:
+                description: ServerVersion is the Forge release reported by /api/v2/ping/.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_inventories.yaml
+++ b/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_inventories.yaml
@@ -1,0 +1,210 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: inventories.forge.forgeplatform.io
+spec:
+  group: forge.forgeplatform.io
+  names:
+    categories:
+    - forge
+    kind: Inventory
+    listKind: InventoryList
+    plural: inventories
+    shortNames:
+    - inv
+    singular: inventory
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forgeId
+      name: Forge ID
+      type: integer
+    - jsonPath: .spec.organization
+      name: Org
+      type: string
+    - jsonPath: .status.hostCount
+      name: Hosts
+      type: integer
+    - jsonPath: .status.groupCount
+      name: Groups
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Inventory is the Schema for the inventories API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: InventorySpec defines the desired state of a Forge Inventory.
+            properties:
+              description:
+                type: string
+              groups:
+                description: Groups to ensure exist. Same idempotency semantics as
+                  Hosts.
+                items:
+                  description: InventoryGroup is a group of hosts and/or sub-groups.
+                  properties:
+                    children:
+                      description: |-
+                        Child group names (must also be declared at top level under
+                        spec.groups). Forms group-of-groups hierarchies.
+                      items:
+                        type: string
+                      type: array
+                    description:
+                      type: string
+                    hosts:
+                      description: |-
+                        Hosts that belong to this group (must also be declared at top
+                        level under spec.hosts).
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      type: string
+                    variables:
+                      description: Free-form YAML / JSON group variables.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              hosts:
+                description: |-
+                  Hosts to ensure exist in this inventory. Operator will add new
+                  ones, update changed ones, and remove ones that are no longer
+                  listed (idempotent reconcile).
+                items:
+                  description: InventoryHost is a single host inside the inventory.
+                  properties:
+                    description:
+                      type: string
+                    enabled:
+                      default: true
+                      type: boolean
+                    name:
+                      type: string
+                    variables:
+                      description: Free-form YAML / JSON host variables.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              name:
+                description: Display name in Forge. Defaults to metadata.name.
+                type: string
+              organization:
+                type: string
+              variables:
+                description: Free-form inventory-wide variables (YAML/JSON).
+                type: string
+            required:
+            - organization
+            type: object
+          status:
+            description: InventoryStatus reflects the observed Forge state.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forgeId:
+                format: int64
+                type: integer
+              groupCount:
+                format: int32
+                type: integer
+              hostCount:
+                format: int32
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_jobtemplates.yaml
+++ b/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_jobtemplates.yaml
@@ -1,0 +1,212 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: jobtemplates.forge.forgeplatform.io
+spec:
+  group: forge.forgeplatform.io
+  names:
+    categories:
+    - forge
+    kind: JobTemplate
+    listKind: JobTemplateList
+    plural: jobtemplates
+    shortNames:
+    - jt
+    - jobtmpl
+    singular: jobtemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forgeId
+      name: Forge ID
+      type: integer
+    - jsonPath: .spec.inventory
+      name: Inventory
+      type: string
+    - jsonPath: .spec.project
+      name: Project
+      type: string
+    - jsonPath: .spec.playbook
+      name: Playbook
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: JobTemplate is the Schema for the jobtemplates API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              JobTemplateSpec defines the desired state of a Forge JobTemplate.
+
+              Mirrors a subset of the upstream Forge `/api/v2/job_templates/` resource.
+              Reference fields (inventory, project, organization) are by name — the
+              operator resolves them to numeric IDs via the Forge API at reconcile time.
+            properties:
+              askCredentialOnLaunch:
+                type: boolean
+              askInventoryOnLaunch:
+                description: AskInventoryOnLaunch and friends — prompts the user at
+                  launch.
+                type: boolean
+              askLimitOnLaunch:
+                type: boolean
+              askVariablesOnLaunch:
+                type: boolean
+              credentials:
+                description: Names of credentials to attach (looked up by name).
+                items:
+                  type: string
+                type: array
+              description:
+                type: string
+              extraVars:
+                description: Free-form YAML/JSON extra_vars passed to ansible.
+                type: string
+              forks:
+                default: 0
+                description: Forks (parallelism). 0 = use Forge default.
+                format: int32
+                minimum: 0
+                type: integer
+              inventory:
+                description: Inventory name (looked up by name in Forge).
+                type: string
+              jobType:
+                default: run
+                enum:
+                - run
+                - check
+                type: string
+              limit:
+                description: Limit (host pattern), --limit equivalent.
+                type: string
+              name:
+                description: Display name in Forge. Defaults to the metadata.name
+                  of the CR.
+                type: string
+              organization:
+                description: Forge organization name. Required if Forge has multi-tenant
+                  orgs.
+                type: string
+              playbook:
+                description: Playbook file path within the project (e.g. site.yml).
+                type: string
+              project:
+                description: Project name (looked up by name in Forge).
+                type: string
+              verbosity:
+                default: 0
+                description: Verbosity 0..5.
+                format: int32
+                maximum: 5
+                minimum: 0
+                type: integer
+            required:
+            - inventory
+            - playbook
+            - project
+            type: object
+          status:
+            description: JobTemplateStatus reflects the observed state in Forge.
+            properties:
+              conditions:
+                description: Conditions surface Ready and Synced state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forgeId:
+                description: Forge JobTemplate numeric ID (assigned on first successful
+                  create).
+                format: int64
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration tracks the last spec generation reconciled.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_organizations.yaml
+++ b/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_organizations.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: organizations.forge.forgeplatform.io
+spec:
+  group: forge.forgeplatform.io
+  names:
+    categories:
+    - forge
+    kind: Organization
+    listKind: OrganizationList
+    plural: organizations
+    shortNames:
+    - org
+    singular: organization
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forgeId
+      name: Forge ID
+      type: integer
+    - jsonPath: .spec.maxHosts
+      name: Max Hosts
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Organization is the Schema for the organizations API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              OrganizationSpec mirrors Forge `/api/v2/organizations/`.
+              Organizations are the top-level tenant container — every other resource
+              (Project, Inventory, JobTemplate, Team) belongs to exactly one.
+            properties:
+              defaultEnvironment:
+                description: Default Execution Environment name for jobs in this org.
+                type: string
+              description:
+                type: string
+              forgeInstance:
+                description: Optional ForgeInstance reference (for multi-cluster).
+                  Empty = default.
+                type: string
+              maxHosts:
+                default: 0
+                description: Hard cap on hosts visible to this org (0 = unlimited).
+                format: int32
+                minimum: 0
+                type: integer
+              name:
+                description: Display name in Forge. Defaults to metadata.name.
+                type: string
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forgeId:
+                format: int64
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_projects.yaml
+++ b/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_projects.yaml
@@ -1,0 +1,208 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: projects.forge.forgeplatform.io
+spec:
+  group: forge.forgeplatform.io
+  names:
+    categories:
+    - forge
+    kind: Project
+    listKind: ProjectList
+    plural: projects
+    shortNames:
+    - prj
+    singular: project
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forgeId
+      name: Forge ID
+      type: integer
+    - jsonPath: .spec.scmType
+      name: SCM
+      type: string
+    - jsonPath: .spec.scmUrl
+      name: URL
+      priority: 1
+      type: string
+    - jsonPath: .spec.scmBranch
+      name: Branch
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Project is the Schema for the projects API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ProjectSpec mirrors a subset of Forge `/api/v2/projects/`.
+              SCM credential (if any) is referenced by name and resolved at reconcile.
+            properties:
+              allowOverride:
+                type: boolean
+              defaultEnvironment:
+                description: Default Execution Environment name. Empty = global default.
+                type: string
+              description:
+                type: string
+              forgeInstance:
+                description: Optional ForgeInstance reference (for multi-cluster).
+                  Empty = default.
+                type: string
+              name:
+                description: Display name in Forge. Defaults to metadata.name.
+                type: string
+              organization:
+                description: Forge organization name. Required.
+                type: string
+              scmBranch:
+                description: Branch / revision / tag.
+                type: string
+              scmClean:
+                type: boolean
+              scmCredential:
+                description: SCM credential name (looked up in Forge). Empty = public/no
+                  auth.
+                type: string
+              scmDeleteOnUpdate:
+                type: boolean
+              scmRefspec:
+                description: Refspec (git only). Useful for fetching PR refs.
+                type: string
+              scmType:
+                default: git
+                description: SCM type. "manual" means a pre-populated project directory
+                  on disk.
+                enum:
+                - git
+                - hg
+                - svn
+                - insights
+                - archive
+                - manual
+                type: string
+              scmUpdateCacheTimeout:
+                description: SCM update cache TTL in seconds (Forge default 0 = always
+                  update).
+                format: int32
+                minimum: 0
+                type: integer
+              scmUpdateOnLaunch:
+                type: boolean
+              scmUrl:
+                description: Repository URL. Required for non-manual SCM types.
+                type: string
+              timeout:
+                description: Timeout in seconds for SCM update (0 = Forge default).
+                format: int32
+                minimum: 0
+                type: integer
+            required:
+            - organization
+            type: object
+          status:
+            description: ProjectStatus reflects observed state in Forge.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forgeId:
+                format: int64
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+              scmRevision:
+                description: Last SCM update status reported by Forge (successful
+                  / failed / never).
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_schedules.yaml
+++ b/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_schedules.yaml
@@ -1,0 +1,179 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: schedules.forge.forgeplatform.io
+spec:
+  group: forge.forgeplatform.io
+  names:
+    categories:
+    - forge
+    kind: Schedule
+    listKind: ScheduleList
+    plural: schedules
+    shortNames:
+    - sch
+    singular: schedule
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forgeId
+      name: Forge ID
+      type: integer
+    - jsonPath: .spec.jobTemplate
+      name: JobTemplate
+      type: string
+    - jsonPath: .spec.enabled
+      name: Enabled
+      type: boolean
+    - jsonPath: .status.nextRun
+      name: Next Run
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Schedule is the Schema for the schedules API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ScheduleSpec defines the desired state of a Forge Schedule.
+
+              Forge schedules attach to a "unified job template" (JobTemplate or
+              WorkflowJobTemplate). MVP supports only JobTemplate references.
+            properties:
+              description:
+                type: string
+              enabled:
+                default: true
+                description: Whether the schedule is active. Defaults to true.
+                type: boolean
+              extraData:
+                description: |-
+                  Free-form YAML/JSON passed as extra_data overrides at launch
+                  time. Same shape as JobTemplate.spec.extraVars.
+                type: string
+              jobTemplate:
+                description: |-
+                  JobTemplate is the name of the JobTemplate (Forge entity) this
+                  schedule fires. Operator resolves it to a numeric ID.
+                type: string
+              name:
+                type: string
+              rrule:
+                description: |-
+                  RRule is an RFC 5545 recurrence rule. Examples:
+                    "DTSTART;TZID=America/New_York:20260101T090000 RRULE:FREQ=DAILY;INTERVAL=1"
+                    "DTSTART:20260101T000000Z RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"
+                type: string
+            required:
+            - jobTemplate
+            - rrule
+            type: object
+          status:
+            description: ScheduleStatus reflects the observed Forge state.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forgeId:
+                format: int64
+                type: integer
+              jobTemplateId:
+                description: JobTemplateID is the resolved Forge ID of the referenced
+                  JT.
+                format: int64
+                type: integer
+              nextRun:
+                description: NextRun is the next scheduled execution time as reported
+                  by Forge.
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_teams.yaml
+++ b/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_teams.yaml
@@ -1,0 +1,155 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: teams.forge.forgeplatform.io
+spec:
+  group: forge.forgeplatform.io
+  names:
+    categories:
+    - forge
+    kind: Team
+    listKind: TeamList
+    plural: teams
+    shortNames:
+    - tm
+    singular: team
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forgeId
+      name: Forge ID
+      type: integer
+    - jsonPath: .spec.organization
+      name: Organization
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Team is the Schema for the teams API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              TeamSpec mirrors Forge `/api/v2/teams/`. Team membership is a separate
+              M2M relation handled by the controller (/teams/{id}/users/).
+            properties:
+              description:
+                type: string
+              forgeInstance:
+                description: Optional ForgeInstance reference (for multi-cluster).
+                  Empty = default.
+                type: string
+              name:
+                description: Display name in Forge. Defaults to metadata.name.
+                type: string
+              organization:
+                description: Owning organization (by name).
+                type: string
+              users:
+                description: |-
+                  Members (Forge usernames). The controller adds/removes users on the
+                  team via /api/v2/teams/{id}/users/ to converge to this list.
+                items:
+                  type: string
+                type: array
+            required:
+            - organization
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forgeId:
+                format: int64
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_workflows.yaml
+++ b/operators/forge-operator/1.0.0/manifests/forge.forgeplatform.io_workflows.yaml
@@ -1,0 +1,233 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: workflows.forge.forgeplatform.io
+spec:
+  group: forge.forgeplatform.io
+  names:
+    categories:
+    - forge
+    kind: Workflow
+    listKind: WorkflowList
+    plural: workflows
+    shortNames:
+    - wf
+    - workflow
+    singular: workflow
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forgeId
+      name: Forge ID
+      type: integer
+    - jsonPath: .spec.organization
+      name: Organization
+      type: string
+    - jsonPath: .status.nodeCount
+      name: Nodes
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Workflow is the Schema for the workflows API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              WorkflowSpec mirrors Forge `/api/v2/workflow_job_templates/` plus a
+              declarative list of nodes that the controller reconciles to/from
+              `/workflow_job_template_nodes/`.
+            properties:
+              allowSimultaneous:
+                type: boolean
+              askInventoryOnLaunch:
+                type: boolean
+              askLimitOnLaunch:
+                type: boolean
+              askVariablesOnLaunch:
+                type: boolean
+              description:
+                type: string
+              extraVars:
+                description: Workflow-level extra_vars (YAML or JSON).
+                type: string
+              forgeInstance:
+                description: Optional ForgeInstance reference (for multi-cluster).
+                  Empty = default.
+                type: string
+              inventory:
+                description: |-
+                  Optional default inventory name. Each node can override via its
+                  own job template.
+                type: string
+              name:
+                description: Display name in Forge. Defaults to metadata.name.
+                type: string
+              nodes:
+                description: Nodes is the DAG. Order is irrelevant — edges are by
+                  identifier.
+                items:
+                  description: |-
+                    WorkflowNode is one step in a workflow DAG. Each node references a
+                    unified_job_template (typically a JobTemplate, possibly a nested
+                    Workflow) and has three successor lists keyed by upstream outcome.
+                  properties:
+                    alwaysNodes:
+                      description: Identifiers of nodes to run regardless of outcome.
+                      items:
+                        type: string
+                      type: array
+                    extraData:
+                      description: Free-form YAML/JSON extra_data for this node (per-node
+                        vars).
+                      type: string
+                    failureNodes:
+                      description: Identifiers of nodes to run when this node fails.
+                      items:
+                        type: string
+                      type: array
+                    identifier:
+                      description: |-
+                        Identifier is unique within this workflow. Used for graph edges
+                        (other nodes reference this node by identifier in their
+                        success/failure/always lists).
+                      type: string
+                    successNodes:
+                      description: Identifiers of nodes to run when this node finishes
+                        successfully.
+                      items:
+                        type: string
+                      type: array
+                    unifiedJobTemplate:
+                      description: |-
+                        UnifiedJobTemplate is the name of a JobTemplate (preferred) or
+                        nested WorkflowJobTemplate to invoke. The controller resolves
+                        this to a numeric ID at reconcile.
+                      type: string
+                    unifiedJobTemplateKind:
+                      default: job_template
+                      description: |-
+                        Kind of template ref. Default is "job_template". Set to
+                        "workflow_job_template" for nested workflows.
+                      enum:
+                      - job_template
+                      - workflow_job_template
+                      type: string
+                  required:
+                  - identifier
+                  - unifiedJobTemplate
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - identifier
+                x-kubernetes-list-type: map
+              organization:
+                description: Owning organization (by name).
+                type: string
+            required:
+            - organization
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forgeId:
+                format: int64
+                type: integer
+              nodeCount:
+                description: |-
+                  Count of reconciled nodes (helps quickly check graph size from
+                  `kubectl get`).
+                format: int32
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forge-operator/1.0.0/metadata/annotations.yaml
+++ b/operators/forge-operator/1.0.0/metadata/annotations.yaml
@@ -1,0 +1,10 @@
+annotations:
+  # Operator Bundle Format v1
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: forge-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  # Tested against OpenShift 4.13+ / OLM 0.27+
+  com.redhat.openshift.versions: "v4.13"

--- a/operators/forge-operator/ci.yaml
+++ b/operators/forge-operator/ci.yaml
@@ -1,0 +1,18 @@
+# OperatorHub.io CI configuration for forge-operator.
+# Docs: https://github.com/k8s-operatorhub/community-operators/blob/main/docs/operator-ci-yaml.md
+
+# Reviewers tagged on PRs that touch this operator's directory.
+reviewers:
+  - krlex
+
+# Upgrade graph strategy:
+# - `replaces-mode` requires every new CSV to declare `spec.replaces` (and
+#   optionally `spec.skips`) pointing at the previous version. Since 1.0.0
+#   is the initial release with no predecessor, this is fine — `replaces`
+#   will be added on 1.0.1+.
+updateGraph: replaces-mode
+
+# File-Based Catalog opt-in. We don't ship an FBC yet (registry+v1 bundle
+# is the canonical form for forge-operator 1.0.0), so leave this off.
+fbc:
+  enabled: false


### PR DESCRIPTION
## New operator: forge-operator

Initial submission of `forge-operator` 1.0.0 — Kubernetes operator for the [Forge Platform](https://forgeplatform.github.io/) automation suite.

### What does it do
Reconciles native Forge Platform resources (Organizations, Teams, Projects, Inventories, Credentials, JobTemplates, Schedules, Workflows) declared as Kubernetes Custom Resources, calling the Forge REST API to converge state.

- **9 CRDs** spanning the full Forge resource model
- **Multi-cluster routing** via `ForgeInstance` CR — each CR can target a different Forge backend by name + Secret-stored bearer token
- **Workflow CRD with declarative DAG** (nodes + success/failure/always edges) reconciled against `/workflow_job_template_nodes/`
- **Finalizer-driven cleanup** + 60-second drift reconcile

### Bundle
- Image: `ghcr.io/forgeplatform/forge-operator:1.0.0` (public, anonymous-pullable)
- Channel: `alpha` (single channel for this release)
- Min Kubernetes: 1.27
- Install mode: AllNamespaces (cluster-scoped operator)

### Validation
`operator-sdk bundle validate` (v1.40.0) passes:
- default validator
- `operatorhub`
- `community`
- `alpha-deprecated-apis`

Tested end-to-end on a 3-master + 4-worker k3s 1.30 Vagrant cluster (`forge-dev-cluster` in the source org).

### Authors / contact
- Krstan Vjestica `<office@krletron.xyz>`
- Source: https://github.com/forgeplatform/forge-operator
- Docs: https://forgeplatform.github.io/docs/operator-v1.html
- Issues: https://github.com/forgeplatform/forge-operator/issues

### Submission checklist
- [x] `operators/forge-operator/ci.yaml` present with `reviewers` + `updateGraph: replaces-mode`
- [x] Bundle layout under `operators/forge-operator/1.0.0/` (`manifests/`, `metadata/annotations.yaml`, `bundle.Dockerfile`)
- [x] `alm-examples` annotation populated for all 9 CRDs
- [x] CSV `spec.icon` set (svg, base64)
- [x] `containerImage` + `createdAt` annotations set
- [x] Image is public + anonymously pullable
- [x] CSV `replaces` intentionally omitted (1.0.0 is the initial release)
