### PR TITLE
operator [CI] hermes-operator

### DIFF
--- a/operators/hermes-operator/ci.yaml
+++ b/operators/hermes-operator/ci.yaml
@@ -1,2 +1,4 @@
-index_images: registry.redhat.io/redhat/community-operator-index:v4.15
+reviewers:
+  - stubbi
 updateGraph: semver-mode
+index_images: registry.redhat.io/redhat/community-operator-index:v4.15


### PR DESCRIPTION
Adds `reviewers: [stubbi]` to operators/hermes-operator/ci.yaml so subsequent hermes-operator version submissions auto-merge (matching the existing openclaw-operator setup, where stubbi is already an established reviewer in this catalog). Existing keys preserved. stubbi maintains paperclipinc/hermes-operator.