### PR TITLE
operator [CI] paperclip-operator

### DIFF
--- a/operators/paperclip-operator/ci.yaml
+++ b/operators/paperclip-operator/ci.yaml
@@ -1,0 +1,3 @@
+reviewers:
+  - stubbi
+updateGraph: semver-mode


### PR DESCRIPTION
Adds an `operators/paperclip-operator/ci.yaml` with `reviewers: [stubbi]` so paperclip-operator version submissions auto-merge (matching the existing openclaw-operator setup, where stubbi is already an established reviewer in this catalog). stubbi maintains paperclipinc/paperclip-operator (live here since 0.11.x).