### PR TITLE
operator [R] apicurio-registry-3 (3.2.5 3.3.0)

### DIFF
--- a/operators/apicurio-registry-3/3.2.5/bundle.Dockerfile
+++ b/operators/apicurio-registry-3/3.2.5/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=apicurio-registry-3
-LABEL operators.operatorframework.io.bundle.channels.v1=3.2.x
+LABEL operators.operatorframework.io.bundle.channels.v1=3.x,3.2.x
 LABEL operators.operatorframework.io.bundle.channel.default.v1=3.2.x
 
 COPY target/bundle/apicurio-registry-3/3.2.5/manifests /manifests/

--- a/operators/apicurio-registry-3/3.2.5/metadata/annotations.yaml
+++ b/operators/apicurio-registry-3/3.2.5/metadata/annotations.yaml
@@ -1,7 +1,7 @@
 annotations:
   com.redhat.openshift.versions: v4.12
   operators.operatorframework.io.bundle.channel.default.v1: 3.2.x
-  operators.operatorframework.io.bundle.channels.v1: 3.2.x
+  operators.operatorframework.io.bundle.channels.v1: 3.x,3.2.x
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/operators/apicurio-registry-3/3.3.0/bundle.Dockerfile
+++ b/operators/apicurio-registry-3/3.3.0/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=apicurio-registry-3
-LABEL operators.operatorframework.io.bundle.channels.v1=3.3.x
+LABEL operators.operatorframework.io.bundle.channels.v1=3.x,3.3.x
 LABEL operators.operatorframework.io.bundle.channel.default.v1=3.3.x
 
 COPY target/bundle/apicurio-registry-3/3.3.0/manifests /manifests/

--- a/operators/apicurio-registry-3/3.3.0/metadata/annotations.yaml
+++ b/operators/apicurio-registry-3/3.3.0/metadata/annotations.yaml
@@ -1,7 +1,7 @@
 annotations:
   com.redhat.openshift.versions: v4.12
   operators.operatorframework.io.bundle.channel.default.v1: 3.3.x
-  operators.operatorframework.io.bundle.channels.v1: 3.3.x
+  operators.operatorframework.io.bundle.channels.v1: 3.x,3.3.x
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/


### PR DESCRIPTION
The 3.2.5 and 3.3.0 operator bundles were submitted with only their minor channel (`3.2.x` / `3.3.x`) in the bundle annotations, missing the rolling `3.x` channel. Users subscribed to the `3.x` channel cannot discover these releases on OperatorHub.

This PR adds `3.x` to `operators.operatorframework.io.bundle.channels.v1` in both `annotations.yaml` and `bundle.Dockerfile` for versions 3.2.5 and 3.3.0.

### Changes

| File | Before | After |
|------|--------|-------|
| `3.2.5/metadata/annotations.yaml` | `channels.v1: 3.2.x` | `channels.v1: 3.x,3.2.x` |
| `3.2.5/bundle.Dockerfile` | `channels.v1=3.2.x` | `channels.v1=3.x,3.2.x` |
| `3.3.0/metadata/annotations.yaml` | `channels.v1: 3.3.x` | `channels.v1: 3.x,3.3.x` |
| `3.3.0/bundle.Dockerfile` | `channels.v1=3.3.x` | `channels.v1=3.x,3.3.x` |