### PR TITLE
operator [O] apicurio-registry-3 (3.2.5)

### DIFF
--- a/operators/apicurio-registry-3/3.2.5/bundle.Dockerfile
+++ b/operators/apicurio-registry-3/3.2.5/bundle.Dockerfile
@@ -6,8 +6,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=apicurio-registry-3
-LABEL operators.operatorframework.io.bundle.channels.v1=3.2.x
-LABEL operators.operatorframework.io.bundle.channel.default.v1=3.2.x
+LABEL operators.operatorframework.io.bundle.channels.v1=3.x,3.2.x
+LABEL operators.operatorframework.io.bundle.channel.default.v1=3.x
 
 COPY target/bundle/apicurio-registry-3/3.2.5/manifests /manifests/
 COPY target/bundle/apicurio-registry-3/3.2.5/metadata /metadata/

--- a/operators/apicurio-registry-3/3.2.5/metadata/annotations.yaml
+++ b/operators/apicurio-registry-3/3.2.5/metadata/annotations.yaml
@@ -1,7 +1,7 @@
 annotations:
   com.redhat.openshift.versions: v4.12
-  operators.operatorframework.io.bundle.channel.default.v1: 3.2.x
-  operators.operatorframework.io.bundle.channels.v1: 3.2.x
+  operators.operatorframework.io.bundle.channel.default.v1: 3.x
+  operators.operatorframework.io.bundle.channels.v1: 3.x,3.2.x
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/


### PR DESCRIPTION
## Summary

The 3.2.5 bundle was accidentally published with only the `3.2.x` channel, removing it from the rolling `3.x` channel. This broke the `3.x` upgrade chain, leaving `3.2.4` as a dangling bundle with no upgrade path.

## Changes

- Add `3.x` back to `channels.v1` → `3.x,3.2.x` (in both `annotations.yaml` and `bundle.Dockerfile`)
- Restore `channel.default.v1` to `3.x`

This is a metadata-only fix — no manifests, CSVs, or CRDs are changed.

**We kindly request maintainers to apply the appropriate override labels to allow this modification to an existing bundle.**

## Context

- Same fix applied to community-operators-prod: https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/10010
- Multi-channel OLM design: https://github.com/Apicurio/apicurio-registry/issues/7742