### PR TITLE
operator [O] apicurio-registry-3 (3.3.0)

### DIFF
--- a/operators/apicurio-registry-3/3.3.0/bundle.Dockerfile
+++ b/operators/apicurio-registry-3/3.3.0/bundle.Dockerfile
@@ -6,8 +6,8 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=apicurio-registry-3
-LABEL operators.operatorframework.io.bundle.channels.v1=3.3.x
-LABEL operators.operatorframework.io.bundle.channel.default.v1=3.3.x
+LABEL operators.operatorframework.io.bundle.channels.v1=3.x,3.3.x
+LABEL operators.operatorframework.io.bundle.channel.default.v1=3.x
 
 COPY target/bundle/apicurio-registry-3/3.3.0/manifests /manifests/
 COPY target/bundle/apicurio-registry-3/3.3.0/metadata /metadata/

--- a/operators/apicurio-registry-3/3.3.0/manifests/apicurio-registry-3.clusterserviceversion.yaml
+++ b/operators/apicurio-registry-3/3.3.0/manifests/apicurio-registry-3.clusterserviceversion.yaml
@@ -305,6 +305,6 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Apicurio
-  replaces: apicurio-registry-3.v3.2.5
+  replaces: apicurio-registry-3.v3.2.4
   selector: {}
   version: 3.3.0

--- a/operators/apicurio-registry-3/3.3.0/metadata/annotations.yaml
+++ b/operators/apicurio-registry-3/3.3.0/metadata/annotations.yaml
@@ -1,7 +1,7 @@
 annotations:
   com.redhat.openshift.versions: v4.12
-  operators.operatorframework.io.bundle.channel.default.v1: 3.3.x
-  operators.operatorframework.io.bundle.channels.v1: 3.3.x
+  operators.operatorframework.io.bundle.channel.default.v1: 3.x
+  operators.operatorframework.io.bundle.channels.v1: 3.x,3.3.x
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/


### PR DESCRIPTION
## Summary

The 3.3.0 bundle was published with only the `3.3.x` channel, missing the rolling `3.x` channel. Without `3.x`, users on the rolling channel have no upgrade path from 3.2.x to 3.3.0.

## Changes

- Add `3.x` to `channels.v1` → `3.x,3.3.x` (in both `annotations.yaml` and `bundle.Dockerfile`)
- Set `channel.default.v1` to `3.x` (new installations should default to the rolling channel)

This is a metadata-only fix — no manifests, CSVs, or CRDs are changed.

**We kindly request maintainers to apply the appropriate override labels to allow this modification to an existing bundle.**

## Context

- Companion fix for 3.2.5: https://github.com/k8s-operatorhub/community-operators/pull/8347
- Same fixes applied to community-operators-prod: https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/10010
- Multi-channel OLM design: https://github.com/Apicurio/apicurio-registry/issues/7742