### PR TITLE
operator [N] [CI] forail-operator (2026.6.0)

### DIFF
--- a/operators/forail-operator/2026.6.0/manifests/forail-operator.clusterserviceversion.yaml
+++ b/operators/forail-operator/2026.6.0/manifests/forail-operator.clusterserviceversion.yaml
@@ -1,0 +1,303 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: forail-operator.v2026.6.0
+  namespace: placeholder
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "forail.forail-platform.io/v1alpha1",
+          "kind": "Organization",
+          "metadata": { "name": "platform-team" },
+          "spec": { "description": "Platform engineering", "maxHosts": 500 }
+        },
+        {
+          "apiVersion": "forail.forail-platform.io/v1alpha1",
+          "kind": "Project",
+          "metadata": { "name": "platform-roles" },
+          "spec": {
+            "organization": "Default",
+            "scmType": "git",
+            "scmUrl": "https://github.com/mycorp/ansible.git",
+            "scmBranch": "main"
+          }
+        },
+        {
+          "apiVersion": "forail.forail-platform.io/v1alpha1",
+          "kind": "Team",
+          "metadata": { "name": "platform-oncall" },
+          "spec": { "organization": "Default", "users": ["admin"] }
+        },
+        {
+          "apiVersion": "forail.forail-platform.io/v1alpha1",
+          "kind": "Workflow",
+          "metadata": { "name": "build-and-deploy" },
+          "spec": {
+            "organization": "Default",
+            "nodes": [
+              { "identifier": "build", "unifiedJobTemplate": "Provision EC2", "successNodes": ["deploy"] },
+              { "identifier": "deploy", "unifiedJobTemplate": "Deploy App" }
+            ]
+          }
+        },
+        {
+          "apiVersion": "forail.forail-platform.io/v1alpha1",
+          "kind": "ForailInstance",
+          "metadata": { "name": "forail-eu" },
+          "spec": {
+            "url": "https://forail-eu.example.com",
+            "tokenSecretRef": { "name": "forail-eu-token", "key": "token" }
+          }
+        },
+        {
+          "apiVersion": "forail.forail-platform.io/v1alpha1",
+          "kind": "Inventory",
+          "metadata": { "name": "production" },
+          "spec": {
+            "organization": "Default",
+            "description": "Production inventory",
+            "hosts": [
+              { "name": "web-1.prod", "enabled": true }
+            ]
+          }
+        },
+        {
+          "apiVersion": "forail.forail-platform.io/v1alpha1",
+          "kind": "Credential",
+          "metadata": { "name": "deploy-key" },
+          "spec": {
+            "organization": "Default",
+            "credentialType": "Machine",
+            "inputs": { "username": "deploy" },
+            "inputsFrom": [
+              { "name": "ssh_key_data", "valueFrom": { "name": "deploy-ssh", "key": "ssh_key_data" } }
+            ]
+          }
+        },
+        {
+          "apiVersion": "forail.forail-platform.io/v1alpha1",
+          "kind": "JobTemplate",
+          "metadata": { "name": "deploy-web" },
+          "spec": {
+            "jobType": "run",
+            "inventory": "Demo Inventory",
+            "project": "Demo Project",
+            "playbook": "hello_world.yml"
+          }
+        },
+        {
+          "apiVersion": "forail.forail-platform.io/v1alpha1",
+          "kind": "Schedule",
+          "metadata": { "name": "nightly-deploy" },
+          "spec": {
+            "jobTemplate": "deploy-web",
+            "enabled": true,
+            "rrule": "DTSTART:20260101T020000Z RRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR"
+          }
+        }
+      ]
+    capabilities: Deep Insights
+    categories: "Application Runtime,Integration & Delivery"
+    repository: https://github.com/forail-platform/forail-operator
+    support: forail-platform
+    containerImage: ghcr.io/forail-platform/forail-operator:2026.06.0
+    createdAt: "2026-05-26T11:00:00Z"
+    description: |
+      Manage Forail automation resources declaratively from Kubernetes.
+spec:
+  displayName: Forail Operator
+  icon:
+    - base64data: PHN2ZyB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCIgdmlld0JveD0iMCAwIDUwMCA1MDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPCEtLSBCYWNrZ3JvdW5kIC0tPgogIDxyZWN0IHdpZHRoPSI1MDAiIGhlaWdodD0iNTAwIiByeD0iNjAiIGZpbGw9IiMwRDBGMTIiLz4KICAKICA8IS0tIFN1YnRsZSByYWRpYWwgZ2xvdyBiZWhpbmQgYW52aWwgLS0+CiAgPHJhZGlhbEdyYWRpZW50IGlkPSJnbG93IiBjeD0iMjUwIiBjeT0iMjgwIiByPSIxODAiIGdyYWRpZW50VW5pdHM9InVzZXJTcGFjZU9uVXNlIj4KICAgIDxzdG9wIG9mZnNldD0iMCUiIHN0b3AtY29sb3I9IiNFODUzMUUiIHN0b3Atb3BhY2l0eT0iMC4xMiIvPgogICAgPHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjRTg1MzFFIiBzdG9wLW9wYWNpdHk9IjAiLz4KICA8L3JhZGlhbEdyYWRpZW50PgogIDxjaXJjbGUgY3g9IjI1MCIgY3k9IjI4MCIgcj0iMTgwIiBmaWxsPSJ1cmwoI2dsb3cpIi8+CgogIDwhLS0gRmxvb3IgcmVmbGVjdGlvbiBsaW5lIC0tPgogIDxsaW5lIHgxPSIxMDAiIHkxPSI0MTAiIHgyPSI0MDAiIHkyPSI0MTAiIHN0cm9rZT0iIzFBMUQyMyIgc3Ryb2tlLXdpZHRoPSIyIi8+CgogIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDk1LCA4MCkgc2NhbGUoNC4yKSI+CiAgICA8IS0tIEFudmlsIGJhc2UgKHdpZGVyIHRyYXBlem9pZCkgLS0+CiAgICA8cGF0aCBkPSJNMTAgNjIgTDE3IDUwIEw1NyA1MCBMNjQgNjIgWiIgZmlsbD0iI0U4NTMxRSIvPgogICAgCiAgICA8IS0tIEFudmlsIGJvZHkgLS0+CiAgICA8cGF0aCBkPSJNMTUgNTAgTDE1IDM1IEMxNSAyOSAyMCAyNCAyOCAyNCBMNTAgMjQgQzU1IDI0IDU4IDI3IDU4IDMyIEw1OCA1MCBaIiBmaWxsPSIjRkY2QjM1Ii8+CiAgICAKICAgIDwhLS0gQW52aWwgaG9ybiAobGVmdCBzaWRlKSAtLT4KICAgIDxwYXRoIGQ9Ik0yIDM1IEwxNSAzNSBMMTUgNDMgTDYgNDMgWiIgZmlsbD0iI0ZGNkIzNSIvPgogICAgCiAgICA8IS0tIEFudmlsIHRvcCBmYWNlIGhpZ2hsaWdodCAtLT4KICAgIDxwYXRoIGQ9Ik0xNSAyNCBMNTggMjQgTDU4IDI5IEwxNSAyOSBaIiBmaWxsPSIjRjVBNjIzIiBvcGFjaXR5PSIwLjUiLz4KICAgIAogICAgPCEtLSBBbnZpbCBlZGdlIGhpZ2hsaWdodCAtLT4KICAgIDxwYXRoIGQ9Ik0xNSAyNCBMNTggMjQiIHN0cm9rZT0iI0ZGRDkzRCIgc3Ryb2tlLXdpZHRoPSIwLjgiIG9wYWNpdHk9IjAuNCIvPgogICAgCiAgICA8IS0tIEhhbW1lciAtLT4KICAgIDxnIHRyYW5zZm9ybT0icm90YXRlKC0zOCwgNDQsIDE0KSI+CiAgICAgIDwhLS0gSGFuZGxlIC0tPgogICAgICA8cmVjdCB4PSI0MSIgeT0iNCIgd2lkdGg9IjUuNSIgaGVpZ2h0PSIyMiIgcng9IjEuOCIgZmlsbD0iI0Y1RjZGOCIvPgogICAgICA8IS0tIEhlYWQgLS0+CiAgICAgIDxyZWN0IHg9IjM1IiB5PSIxIiB3aWR0aD0iMTgiIGhlaWdodD0iOSIgcng9IjIuMiIgZmlsbD0iI0M0QzlENCIvPgogICAgICA8IS0tIEhlYWQgdG9wIGhpZ2hsaWdodCAtLT4KICAgICAgPHJlY3QgeD0iMzUiIHk9IjEiIHdpZHRoPSIxOCIgaGVpZ2h0PSIzLjUiIHJ4PSIxLjIiIGZpbGw9IiNGNUY2RjgiIG9wYWNpdHk9IjAuNDUiLz4KICAgICAgPCEtLSBIZWFkIGJvdHRvbSBzaGFkb3cgLS0+CiAgICAgIDxyZWN0IHg9IjM1IiB5PSI3IiB3aWR0aD0iMTgiIGhlaWdodD0iMyIgcng9IjEiIGZpbGw9IiM4QjkxOUUiIG9wYWNpdHk9IjAuMyIvPgogICAgPC9nPgogICAgCiAgICA8IS0tIEltcGFjdCBzcGFya3MgY2x1c3RlciAtLT4KICAgIDxjaXJjbGUgY3g9IjM2IiBjeT0iMjIiIHI9IjIuMiIgZmlsbD0iI0ZGRDkzRCI+CiAgICAgIDxhbmltYXRlIGF0dHJpYnV0ZU5hbWU9Im9wYWNpdHkiIHZhbHVlcz0iMC45OzAuNTswLjkiIGR1cj0iMnMiIHJlcGVhdENvdW50PSJpbmRlZmluaXRlIi8+CiAgICA8L2NpcmNsZT4KICAgIDxjaXJjbGUgY3g9IjI4IiBjeT0iMTgiIHI9IjEuNCIgZmlsbD0iI0ZGRDkzRCIgb3BhY2l0eT0iMC43Ij4KICAgICAgPGFuaW1hdGUgYXR0cmlidXRlTmFtZT0ib3BhY2l0eSIgdmFsdWVzPSIwLjc7MC4zOzAuNyIgZHVyPSIyLjVzIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSIvPgogICAgPC9jaXJjbGU+CiAgICA8Y2lyY2xlIGN4PSI0NCIgY3k9IjE5IiByPSIxLjYiIGZpbGw9IiNGNUE2MjMiIG9wYWNpdHk9IjAuODUiPgogICAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjAuODU7MC40OzAuODUiIGR1cj0iMS44cyIgcmVwZWF0Q291bnQ9ImluZGVmaW5pdGUiLz4KICAgIDwvY2lyY2xlPgogICAgPGNpcmNsZSBjeD0iMzEiIGN5PSIxNSIgcj0iMS4wIiBmaWxsPSIjRkZEOTNEIiBvcGFjaXR5PSIwLjYiPgogICAgICA8YW5pbWF0ZSBhdHRyaWJ1dGVOYW1lPSJvcGFjaXR5IiB2YWx1ZXM9IjAuNjswLjI7MC42IiBkdXI9IjNzIiByZXBlYXRDb3VudD0iaW5kZWZpbml0ZSIvPgogICAgPC9jaXJjbGU+CiAgICA8Y2lyY2xlIGN4PSI0MSIgY3k9IjE1IiByPSIwLjgiIGZpbGw9IiNGRkQ5M0QiIG9wYWNpdHk9IjAuNSIvPgogICAgPGNpcmNsZSBjeD0iMjUiIGN5PSIyMSIgcj0iMC45IiBmaWxsPSIjRjVBNjIzIiBvcGFjaXR5PSIwLjU1Ii8+CiAgICAKICAgIDwhLS0gU21hbGwgZmx5aW5nIHNwYXJrIHRyYWlscyAtLT4KICAgIDxsaW5lIHgxPSIyOCIgeTE9IjE4IiB4Mj0iMjIiIHkyPSIxMiIgc3Ryb2tlPSIjRkZEOTNEIiBzdHJva2Utd2lkdGg9IjAuNSIgb3BhY2l0eT0iMC40IiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICAgIDxsaW5lIHgxPSI0NCIgeTE9IjE5IiB4Mj0iNTAiIHkyPSIxMyIgc3Ryb2tlPSIjRjVBNjIzIiBzdHJva2Utd2lkdGg9IjAuNSIgb3BhY2l0eT0iMC4zNSIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+CiAgICA8bGluZSB4MT0iMzEiIHkxPSIxNSIgeDI9IjI3IiB5Mj0iOSIgc3Ryb2tlPSIjRkZEOTNEIiBzdHJva2Utd2lkdGg9IjAuNCIgb3BhY2l0eT0iMC4zIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICA8L2c+Cjwvc3ZnPgo=
+      mediatype: image/svg+xml
+  description: |
+    The Forail Operator reconciles native Forail Platform resources
+    (Organizations, Teams, Projects, Inventories, Credentials,
+    JobTemplates, Schedules, Workflows) declared as Kubernetes Custom
+    Resources, calling the Forail REST API to converge desired state.
+
+    Features:
+
+    * Nine CRDs spanning the full Forail resource model
+    * Multi-cluster routing via `ForailInstance` CR — each CR can target
+      a different Forail backend by name + Secret-stored bearer token
+    * Workflow CRD with declarative DAG (nodes + success/failure/always
+      edges) reconciled against `/workflow_job_template_nodes/`
+    * Finalizer-driven cleanup (deleting a CR removes the resource in
+      Forail unless the cluster is unreachable)
+    * 60-second drift reconcile that re-asserts desired state if the
+      Forail UI mutates a managed resource
+
+  keywords:
+    - ansible
+    - automation
+    - forail
+    - awx
+    - playbook
+    - infrastructure-as-code
+  maintainers:
+    - name: Krstan Vjestica
+      email: office@krletron.xyz
+  provider:
+    name: Forail Platform
+    url: https://forail-platform.github.io
+  links:
+    - name: Documentation
+      url: https://forail-platform.github.io
+    - name: Source
+      url: https://github.com/forail-platform/forail-operator
+  maturity: alpha
+  version: 2026.6.0
+  minKubeVersion: 1.27.0
+  installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+        - serviceAccountName: forail-operator
+          rules:
+            - apiGroups: ["forail.forail-platform.io"]
+              resources:
+                - jobtemplates
+                - inventories
+                - credentials
+                - schedules
+                - projects
+                - organizations
+                - teams
+                - workflows
+                - forailinstances
+              verbs: [get, list, watch, create, update, patch, delete]
+            - apiGroups: ["forail.forail-platform.io"]
+              resources:
+                - jobtemplates/status
+                - inventories/status
+                - credentials/status
+                - schedules/status
+                - projects/status
+                - organizations/status
+                - teams/status
+                - workflows/status
+                - forailinstances/status
+              verbs: [get, update, patch]
+            - apiGroups: ["forail.forail-platform.io"]
+              resources:
+                - jobtemplates/finalizers
+                - inventories/finalizers
+                - credentials/finalizers
+                - schedules/finalizers
+                - projects/finalizers
+                - organizations/finalizers
+                - teams/finalizers
+                - workflows/finalizers
+              verbs: [update]
+            - apiGroups: [""]
+              resources: [secrets]
+              verbs: [get, list, watch]
+            - apiGroups: [""]
+              resources: [events]
+              verbs: [create, patch]
+            - apiGroups: ["coordination.k8s.io"]
+              resources: [leases]
+              verbs: [get, create, update]
+      deployments:
+        - name: forail-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: forail-operator
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: forail-operator
+              spec:
+                serviceAccountName: forail-operator
+                containers:
+                  - name: manager
+                    image: ghcr.io/forail-platform/forail-operator:2026.06.0
+                    args:
+                      - --leader-elect
+                    env:
+                      - name: FORAIL_URL
+                        valueFrom:
+                          secretKeyRef:
+                            name: forail-operator-default
+                            key: url
+                            optional: true
+                      - name: FORAIL_TOKEN
+                        valueFrom:
+                          secretKeyRef:
+                            name: forail-operator-default
+                            key: token
+                            optional: true
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                    resources:
+                      requests:
+                        cpu: 100m
+                        memory: 128Mi
+                      limits:
+                        cpu: 500m
+                        memory: 256Mi
+  customresourcedefinitions:
+    owned:
+      - name: organizations.forail.forail-platform.io
+        version: v1alpha1
+        kind: Organization
+        displayName: Organization
+        description: A Forail organization — top-level tenant container.
+      - name: teams.forail.forail-platform.io
+        version: v1alpha1
+        kind: Team
+        displayName: Team
+        description: A Forail team within an organization, with declarative user membership.
+      - name: projects.forail.forail-platform.io
+        version: v1alpha1
+        kind: Project
+        displayName: Project
+        description: A Forail project (SCM-backed source of playbooks).
+      - name: inventories.forail.forail-platform.io
+        version: v1alpha1
+        kind: Inventory
+        displayName: Inventory
+        description: A Forail inventory of hosts and groups.
+      - name: credentials.forail.forail-platform.io
+        version: v1alpha1
+        kind: Credential
+        displayName: Credential
+        description: A Forail credential — inputs sourced from k8s Secrets via inputsFrom.
+      - name: jobtemplates.forail.forail-platform.io
+        version: v1alpha1
+        kind: JobTemplate
+        displayName: JobTemplate
+        description: A Forail job template.
+      - name: workflows.forail.forail-platform.io
+        version: v1alpha1
+        kind: Workflow
+        displayName: Workflow
+        description: A Forail workflow job template with declarative DAG of nodes.
+      - name: schedules.forail.forail-platform.io
+        version: v1alpha1
+        kind: Schedule
+        displayName: Schedule
+        description: A Forail schedule (RFC 5545 RRULE-driven recurring job).
+      - name: forailinstances.forail.forail-platform.io
+        version: v1alpha1
+        kind: ForailInstance
+        displayName: ForailInstance
+        description: A managed Forail backend that other CRs reference via spec.forailInstance.

--- a/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_credentials.yaml
+++ b/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_credentials.yaml
@@ -1,0 +1,207 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: credentials.forail.forail-platform.io
+spec:
+  group: forail.forail-platform.io
+  names:
+    categories:
+    - forail
+    kind: Credential
+    listKind: CredentialList
+    plural: credentials
+    shortNames:
+    - cred
+    singular: credential
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forailId
+      name: Forail ID
+      type: integer
+    - jsonPath: .spec.credentialType
+      name: Type
+      type: string
+    - jsonPath: .spec.organization
+      name: Org
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Credential is the Schema for the credentials API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CredentialSpec defines the desired state of a Forail Credential.
+            properties:
+              credentialType:
+                description: |-
+                  CredentialType is the Forail built-in or custom type name, e.g.:
+                  "Machine", "Source Control", "Vault", "Amazon Web Services",
+                  "Container Registry", "GitHub Personal Access Token".
+                type: string
+              description:
+                type: string
+              inputs:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Inputs is a free-form map of non-sensitive fields. Field names
+                  must match the credentialType schema (e.g. {username: deploy}
+                  for Machine credential).
+                type: object
+              inputsFrom:
+                description: |-
+                  InputsFrom pulls sensitive fields from a k8s Secret. Each entry
+                  maps a Forail input field name to a Secret/key.
+                items:
+                  description: |-
+                    CredentialInputFromSecret maps one Forail input field name to a Secret
+                    key. Example: ssh_key_data → Secret 'deploy-key' / key 'id_rsa'.
+                  properties:
+                    name:
+                      description: |-
+                        Forail input field name (e.g. "username", "password", "ssh_key_data",
+                        "vault_token"). The set of valid names depends on credentialType.
+                      type: string
+                    valueFrom:
+                      description: |-
+                        SecretKeyRef points at a key inside a k8s Secret in the same namespace
+                        as the Credential CR. Used for sensitive credential fields (passwords,
+                        private keys, tokens) so they never appear in the CR YAML directly.
+                      properties:
+                        key:
+                          description: Key inside the Secret's data block.
+                          type: string
+                        name:
+                          description: Name of the Secret in the same namespace as
+                            the Credential.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      type: object
+                  required:
+                  - name
+                  - valueFrom
+                  type: object
+                type: array
+              name:
+                type: string
+              organization:
+                type: string
+            required:
+            - credentialType
+            - organization
+            type: object
+          status:
+            description: CredentialStatus reflects the observed Forail state.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              credentialTypeId:
+                description: |-
+                  CredentialTypeID is the resolved numeric ID of the credentialType
+                  (cached so we don't look it up every reconcile).
+                format: int64
+                type: integer
+              forailId:
+                format: int64
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+              secretsHash:
+                description: |-
+                  SecretsHash is a SHA256 of the resolved (sensitive + non-sensitive)
+                  inputs at last successful sync. Used to detect Secret rotation —
+                  when the hash changes, the operator pushes a fresh PATCH to Forail.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_forailinstances.yaml
+++ b/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_forailinstances.yaml
@@ -1,0 +1,186 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: forailinstances.forail.forail-platform.io
+spec:
+  group: forail.forail-platform.io
+  names:
+    categories:
+    - forail
+    kind: ForailInstance
+    listKind: ForailInstanceList
+    plural: forailinstances
+    shortNames:
+    - fi
+    - forailinst
+    singular: forailinstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.url
+      name: URL
+      type: string
+    - jsonPath: .status.reachable
+      name: Reachable
+      type: boolean
+    - jsonPath: .status.serverVersion
+      name: Version
+      type: string
+    - jsonPath: .status.lastChecked
+      name: Last Checked
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ForailInstance is the Schema for the forailinstances API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ForailInstanceSpec describes a Forail backend the operator should sync to.
+              Other CRs reference this by name (in the same namespace) via their
+              `spec.forailInstance` field. When that field is empty, the operator uses
+              the default Forail config supplied via --forail-url / --forail-token flags
+              (FORAIL_URL / FORAIL_TOKEN env vars).
+            properties:
+              hostHeader:
+                description: |-
+                  Optional Host header to send (when reaching Forail via an Ingress
+                  that routes by hostname but URL uses a node IP).
+                type: string
+              insecureSkipVerify:
+                description: Skip TLS verification (development only).
+                type: boolean
+              tokenSecretRef:
+                description: |-
+                  Secret holding the OAuth2 PAT used as `Authorization: Bearer ...`.
+                  The token must be under the key specified by tokenKey (default "token").
+                properties:
+                  key:
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
+                    type: string
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  optional:
+                    description: Specify whether the Secret or its key must be defined
+                    type: boolean
+                required:
+                - key
+                type: object
+                x-kubernetes-map-type: atomic
+              url:
+                description: |-
+                  Base URL of the Forail backend (e.g.
+                  "https://forail-web.forail.svc.cluster.local:8013").
+                type: string
+            required:
+            - tokenSecretRef
+            - url
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              lastChecked:
+                description: LastChecked is the timestamp of the last probe.
+                format: date-time
+                type: string
+              reachable:
+                description: Reachable is true when the last health probe succeeded.
+                type: boolean
+              serverVersion:
+                description: ServerVersion is the Forail release reported by /api/v2/ping/.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_inventories.yaml
+++ b/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_inventories.yaml
@@ -1,0 +1,210 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: inventories.forail.forail-platform.io
+spec:
+  group: forail.forail-platform.io
+  names:
+    categories:
+    - forail
+    kind: Inventory
+    listKind: InventoryList
+    plural: inventories
+    shortNames:
+    - inv
+    singular: inventory
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forailId
+      name: Forail ID
+      type: integer
+    - jsonPath: .spec.organization
+      name: Org
+      type: string
+    - jsonPath: .status.hostCount
+      name: Hosts
+      type: integer
+    - jsonPath: .status.groupCount
+      name: Groups
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Inventory is the Schema for the inventories API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: InventorySpec defines the desired state of a Forail Inventory.
+            properties:
+              description:
+                type: string
+              groups:
+                description: Groups to ensure exist. Same idempotency semantics as
+                  Hosts.
+                items:
+                  description: InventoryGroup is a group of hosts and/or sub-groups.
+                  properties:
+                    children:
+                      description: |-
+                        Child group names (must also be declared at top level under
+                        spec.groups). Forms group-of-groups hierarchies.
+                      items:
+                        type: string
+                      type: array
+                    description:
+                      type: string
+                    hosts:
+                      description: |-
+                        Hosts that belong to this group (must also be declared at top
+                        level under spec.hosts).
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      type: string
+                    variables:
+                      description: Free-form YAML / JSON group variables.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              hosts:
+                description: |-
+                  Hosts to ensure exist in this inventory. Operator will add new
+                  ones, update changed ones, and remove ones that are no longer
+                  listed (idempotent reconcile).
+                items:
+                  description: InventoryHost is a single host inside the inventory.
+                  properties:
+                    description:
+                      type: string
+                    enabled:
+                      default: true
+                      type: boolean
+                    name:
+                      type: string
+                    variables:
+                      description: Free-form YAML / JSON host variables.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              name:
+                description: Display name in Forail. Defaults to metadata.name.
+                type: string
+              organization:
+                type: string
+              variables:
+                description: Free-form inventory-wide variables (YAML/JSON).
+                type: string
+            required:
+            - organization
+            type: object
+          status:
+            description: InventoryStatus reflects the observed Forail state.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forailId:
+                format: int64
+                type: integer
+              groupCount:
+                format: int32
+                type: integer
+              hostCount:
+                format: int32
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_jobtemplates.yaml
+++ b/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_jobtemplates.yaml
@@ -1,0 +1,212 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: jobtemplates.forail.forail-platform.io
+spec:
+  group: forail.forail-platform.io
+  names:
+    categories:
+    - forail
+    kind: JobTemplate
+    listKind: JobTemplateList
+    plural: jobtemplates
+    shortNames:
+    - jt
+    - jobtmpl
+    singular: jobtemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forailId
+      name: Forail ID
+      type: integer
+    - jsonPath: .spec.inventory
+      name: Inventory
+      type: string
+    - jsonPath: .spec.project
+      name: Project
+      type: string
+    - jsonPath: .spec.playbook
+      name: Playbook
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: JobTemplate is the Schema for the jobtemplates API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              JobTemplateSpec defines the desired state of a Forail JobTemplate.
+
+              Mirrors a subset of the upstream Forail `/api/v2/job_templates/` resource.
+              Reference fields (inventory, project, organization) are by name — the
+              operator resolves them to numeric IDs via the Forail API at reconcile time.
+            properties:
+              askCredentialOnLaunch:
+                type: boolean
+              askInventoryOnLaunch:
+                description: AskInventoryOnLaunch and friends — prompts the user at
+                  launch.
+                type: boolean
+              askLimitOnLaunch:
+                type: boolean
+              askVariablesOnLaunch:
+                type: boolean
+              credentials:
+                description: Names of credentials to attach (looked up by name).
+                items:
+                  type: string
+                type: array
+              description:
+                type: string
+              extraVars:
+                description: Free-form YAML/JSON extra_vars passed to ansible.
+                type: string
+              forks:
+                default: 0
+                description: Forks (parallelism). 0 = use Forail default.
+                format: int32
+                minimum: 0
+                type: integer
+              inventory:
+                description: Inventory name (looked up by name in Forail).
+                type: string
+              jobType:
+                default: run
+                enum:
+                - run
+                - check
+                type: string
+              limit:
+                description: Limit (host pattern), --limit equivalent.
+                type: string
+              name:
+                description: Display name in Forail. Defaults to the metadata.name
+                  of the CR.
+                type: string
+              organization:
+                description: Forail organization name. Required if Forail has multi-tenant
+                  orgs.
+                type: string
+              playbook:
+                description: Playbook file path within the project (e.g. site.yml).
+                type: string
+              project:
+                description: Project name (looked up by name in Forail).
+                type: string
+              verbosity:
+                default: 0
+                description: Verbosity 0..5.
+                format: int32
+                maximum: 5
+                minimum: 0
+                type: integer
+            required:
+            - inventory
+            - playbook
+            - project
+            type: object
+          status:
+            description: JobTemplateStatus reflects the observed state in Forail.
+            properties:
+              conditions:
+                description: Conditions surface Ready and Synced state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forailId:
+                description: Forail JobTemplate numeric ID (assigned on first successful
+                  create).
+                format: int64
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration tracks the last spec generation reconciled.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_organizations.yaml
+++ b/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_organizations.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: organizations.forail.forail-platform.io
+spec:
+  group: forail.forail-platform.io
+  names:
+    categories:
+    - forail
+    kind: Organization
+    listKind: OrganizationList
+    plural: organizations
+    shortNames:
+    - org
+    singular: organization
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forailId
+      name: Forail ID
+      type: integer
+    - jsonPath: .spec.maxHosts
+      name: Max Hosts
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Organization is the Schema for the organizations API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              OrganizationSpec mirrors Forail `/api/v2/organizations/`.
+              Organizations are the top-level tenant container — every other resource
+              (Project, Inventory, JobTemplate, Team) belongs to exactly one.
+            properties:
+              defaultEnvironment:
+                description: Default Execution Environment name for jobs in this org.
+                type: string
+              description:
+                type: string
+              forailInstance:
+                description: Optional ForailInstance reference (for multi-cluster).
+                  Empty = default.
+                type: string
+              maxHosts:
+                default: 0
+                description: Hard cap on hosts visible to this org (0 = unlimited).
+                format: int32
+                minimum: 0
+                type: integer
+              name:
+                description: Display name in Forail. Defaults to metadata.name.
+                type: string
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forailId:
+                format: int64
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_projects.yaml
+++ b/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_projects.yaml
@@ -1,0 +1,208 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: projects.forail.forail-platform.io
+spec:
+  group: forail.forail-platform.io
+  names:
+    categories:
+    - forail
+    kind: Project
+    listKind: ProjectList
+    plural: projects
+    shortNames:
+    - prj
+    singular: project
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forailId
+      name: Forail ID
+      type: integer
+    - jsonPath: .spec.scmType
+      name: SCM
+      type: string
+    - jsonPath: .spec.scmUrl
+      name: URL
+      priority: 1
+      type: string
+    - jsonPath: .spec.scmBranch
+      name: Branch
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Project is the Schema for the projects API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ProjectSpec mirrors a subset of Forail `/api/v2/projects/`.
+              SCM credential (if any) is referenced by name and resolved at reconcile.
+            properties:
+              allowOverride:
+                type: boolean
+              defaultEnvironment:
+                description: Default Execution Environment name. Empty = global default.
+                type: string
+              description:
+                type: string
+              forailInstance:
+                description: Optional ForailInstance reference (for multi-cluster).
+                  Empty = default.
+                type: string
+              name:
+                description: Display name in Forail. Defaults to metadata.name.
+                type: string
+              organization:
+                description: Forail organization name. Required.
+                type: string
+              scmBranch:
+                description: Branch / revision / tag.
+                type: string
+              scmClean:
+                type: boolean
+              scmCredential:
+                description: SCM credential name (looked up in Forail). Empty = public/no
+                  auth.
+                type: string
+              scmDeleteOnUpdate:
+                type: boolean
+              scmRefspec:
+                description: Refspec (git only). Useful for fetching PR refs.
+                type: string
+              scmType:
+                default: git
+                description: SCM type. "manual" means a pre-populated project directory
+                  on disk.
+                enum:
+                - git
+                - hg
+                - svn
+                - insights
+                - archive
+                - manual
+                type: string
+              scmUpdateCacheTimeout:
+                description: SCM update cache TTL in seconds (Forail default 0 = always
+                  update).
+                format: int32
+                minimum: 0
+                type: integer
+              scmUpdateOnLaunch:
+                type: boolean
+              scmUrl:
+                description: Repository URL. Required for non-manual SCM types.
+                type: string
+              timeout:
+                description: Timeout in seconds for SCM update (0 = Forail default).
+                format: int32
+                minimum: 0
+                type: integer
+            required:
+            - organization
+            type: object
+          status:
+            description: ProjectStatus reflects observed state in Forail.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forailId:
+                format: int64
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+              scmRevision:
+                description: Last SCM update status reported by Forail (successful
+                  / failed / never).
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_schedules.yaml
+++ b/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_schedules.yaml
@@ -1,0 +1,179 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: schedules.forail.forail-platform.io
+spec:
+  group: forail.forail-platform.io
+  names:
+    categories:
+    - forail
+    kind: Schedule
+    listKind: ScheduleList
+    plural: schedules
+    shortNames:
+    - sch
+    singular: schedule
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forailId
+      name: Forail ID
+      type: integer
+    - jsonPath: .spec.jobTemplate
+      name: JobTemplate
+      type: string
+    - jsonPath: .spec.enabled
+      name: Enabled
+      type: boolean
+    - jsonPath: .status.nextRun
+      name: Next Run
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Schedule is the Schema for the schedules API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ScheduleSpec defines the desired state of a Forail Schedule.
+
+              Forail schedules attach to a "unified job template" (JobTemplate or
+              WorkflowJobTemplate). MVP supports only JobTemplate references.
+            properties:
+              description:
+                type: string
+              enabled:
+                default: true
+                description: Whether the schedule is active. Defaults to true.
+                type: boolean
+              extraData:
+                description: |-
+                  Free-form YAML/JSON passed as extra_data overrides at launch
+                  time. Same shape as JobTemplate.spec.extraVars.
+                type: string
+              jobTemplate:
+                description: |-
+                  JobTemplate is the name of the JobTemplate (Forail entity) this
+                  schedule fires. Operator resolves it to a numeric ID.
+                type: string
+              name:
+                type: string
+              rrule:
+                description: |-
+                  RRule is an RFC 5545 recurrence rule. Examples:
+                    "DTSTART;TZID=America/New_York:20260101T090000 RRULE:FREQ=DAILY;INTERVAL=1"
+                    "DTSTART:20260101T000000Z RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"
+                type: string
+            required:
+            - jobTemplate
+            - rrule
+            type: object
+          status:
+            description: ScheduleStatus reflects the observed Forail state.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forailId:
+                format: int64
+                type: integer
+              jobTemplateId:
+                description: JobTemplateID is the resolved Forail ID of the referenced
+                  JT.
+                format: int64
+                type: integer
+              nextRun:
+                description: NextRun is the next scheduled execution time as reported
+                  by Forail.
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_teams.yaml
+++ b/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_teams.yaml
@@ -1,0 +1,155 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: teams.forail.forail-platform.io
+spec:
+  group: forail.forail-platform.io
+  names:
+    categories:
+    - forail
+    kind: Team
+    listKind: TeamList
+    plural: teams
+    shortNames:
+    - tm
+    singular: team
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forailId
+      name: Forail ID
+      type: integer
+    - jsonPath: .spec.organization
+      name: Organization
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Team is the Schema for the teams API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              TeamSpec mirrors Forail `/api/v2/teams/`. Team membership is a separate
+              M2M relation handled by the controller (/teams/{id}/users/).
+            properties:
+              description:
+                type: string
+              forailInstance:
+                description: Optional ForailInstance reference (for multi-cluster).
+                  Empty = default.
+                type: string
+              name:
+                description: Display name in Forail. Defaults to metadata.name.
+                type: string
+              organization:
+                description: Owning organization (by name).
+                type: string
+              users:
+                description: |-
+                  Members (Forail usernames). The controller adds/removes users on the
+                  team via /api/v2/teams/{id}/users/ to converge to this list.
+                items:
+                  type: string
+                type: array
+            required:
+            - organization
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forailId:
+                format: int64
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_workflows.yaml
+++ b/operators/forail-operator/2026.6.0/manifests/forail.forail-platform.io_workflows.yaml
@@ -1,0 +1,233 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  name: workflows.forail.forail-platform.io
+spec:
+  group: forail.forail-platform.io
+  names:
+    categories:
+    - forail
+    kind: Workflow
+    listKind: WorkflowList
+    plural: workflows
+    shortNames:
+    - wf
+    - workflow
+    singular: workflow
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.forailId
+      name: Forail ID
+      type: integer
+    - jsonPath: .spec.organization
+      name: Organization
+      type: string
+    - jsonPath: .status.nodeCount
+      name: Nodes
+      type: integer
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Workflow is the Schema for the workflows API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              WorkflowSpec mirrors Forail `/api/v2/workflow_job_templates/` plus a
+              declarative list of nodes that the controller reconciles to/from
+              `/workflow_job_template_nodes/`.
+            properties:
+              allowSimultaneous:
+                type: boolean
+              askInventoryOnLaunch:
+                type: boolean
+              askLimitOnLaunch:
+                type: boolean
+              askVariablesOnLaunch:
+                type: boolean
+              description:
+                type: string
+              extraVars:
+                description: Workflow-level extra_vars (YAML or JSON).
+                type: string
+              forailInstance:
+                description: Optional ForailInstance reference (for multi-cluster).
+                  Empty = default.
+                type: string
+              inventory:
+                description: |-
+                  Optional default inventory name. Each node can override via its
+                  own job template.
+                type: string
+              name:
+                description: Display name in Forail. Defaults to metadata.name.
+                type: string
+              nodes:
+                description: Nodes is the DAG. Order is irrelevant — edges are by
+                  identifier.
+                items:
+                  description: |-
+                    WorkflowNode is one step in a workflow DAG. Each node references a
+                    unified_job_template (typically a JobTemplate, possibly a nested
+                    Workflow) and has three successor lists keyed by upstream outcome.
+                  properties:
+                    alwaysNodes:
+                      description: Identifiers of nodes to run regardless of outcome.
+                      items:
+                        type: string
+                      type: array
+                    extraData:
+                      description: Free-form YAML/JSON extra_data for this node (per-node
+                        vars).
+                      type: string
+                    failureNodes:
+                      description: Identifiers of nodes to run when this node fails.
+                      items:
+                        type: string
+                      type: array
+                    identifier:
+                      description: |-
+                        Identifier is unique within this workflow. Used for graph edges
+                        (other nodes reference this node by identifier in their
+                        success/failure/always lists).
+                      type: string
+                    successNodes:
+                      description: Identifiers of nodes to run when this node finishes
+                        successfully.
+                      items:
+                        type: string
+                      type: array
+                    unifiedJobTemplate:
+                      description: |-
+                        UnifiedJobTemplate is the name of a JobTemplate (preferred) or
+                        nested WorkflowJobTemplate to invoke. The controller resolves
+                        this to a numeric ID at reconcile.
+                      type: string
+                    unifiedJobTemplateKind:
+                      default: job_template
+                      description: |-
+                        Kind of template ref. Default is "job_template". Set to
+                        "workflow_job_template" for nested workflows.
+                      enum:
+                      - job_template
+                      - workflow_job_template
+                      type: string
+                  required:
+                  - identifier
+                  - unifiedJobTemplate
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - identifier
+                x-kubernetes-list-type: map
+              organization:
+                description: Owning organization (by name).
+                type: string
+            required:
+            - organization
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              forailId:
+                format: int64
+                type: integer
+              nodeCount:
+                description: |-
+                  Count of reconciled nodes (helps quickly check graph size from
+                  `kubectl get`).
+                format: int32
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/forail-operator/2026.6.0/metadata/annotations.yaml
+++ b/operators/forail-operator/2026.6.0/metadata/annotations.yaml
@@ -1,0 +1,10 @@
+annotations:
+  # Operator Bundle Format v1
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: forail-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  # Tested against OpenShift 4.13+ / OLM 0.27+
+  com.redhat.openshift.versions: "v4.13"

--- a/operators/forail-operator/ci.yaml
+++ b/operators/forail-operator/ci.yaml
@@ -1,0 +1,5 @@
+---
+# https://github.com/k8s-operatorhub/community-operators/blob/main/docs/operator-ci-yaml.md
+updateGraph: replaces-mode
+reviewers:
+  - krlex


### PR DESCRIPTION
### New operator: forail-operator (2026.6.0)

**Forail Operator** is the Kubernetes operator for the [Forail Platform](https://github.com/forail-platform) — an open-source, Apache-2.0 DevOps automation platform (a modernized fork of Ansible AWX). It declaratively manages Forail resources via **9 CRDs** under the `forail.forail-platform.io` API group: Organization, Team, Project, Inventory, Credential, JobTemplate, Schedule, Workflow, and ForailInstance (multi-cluster backend routing).

- **Image:** `ghcr.io/forail-platform/forail-operator:2026.06.0` (public on ghcr.io, no pull secret required)
- **License:** Apache-2.0
- **Channel:** `alpha`
- **Source / build:** https://github.com/forail-platform/forail-operator
- Validated on k3s v1.30 (CRDs install, controllers reconcile).

#### Note
This supersedes our previously published **`forge-operator`** listing — the
project was renamed `forge` → `forail` to avoid naming collisions with other
"forge" projects. This is a new package name and a new API group, submitted as
a fresh operator.

#### Updates to existing operators
N/A — new operator (does not modify any existing operator).