### PR TITLE
operator ocp-kea-dhcp (0.0.27)

### DIFF
--- a/operators/ocp-kea-dhcp/0.0.27/manifests/kea.openshift.io_keacontrolagents.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/kea.openshift.io_keacontrolagents.yaml
@@ -1,0 +1,1450 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  creationTimestamp: null
+  name: keacontrolagents.kea.openshift.io
+spec:
+  group: kea.openshift.io
+  names:
+    kind: KeaControlAgent
+    listKind: KeaControlAgentList
+    plural: keacontrolagents
+    shortNames:
+    - kca
+    singular: keacontrolagent
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Ready
+      type: string
+    - jsonPath: .spec.http-host
+      name: Host
+      type: string
+    - jsonPath: .spec.http-port
+      name: Port
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KeaControlAgent is the Schema for the keacontrolagents API.
+          It manages a Kea Control Agent deployment that provides a REST API
+          for managing Kea DHCP servers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeaControlAgentSpec defines the desired state of a Kea Control
+              Agent deployment.
+            properties:
+              authentication:
+                description: Authentication configuration for the REST API.
+                properties:
+                  clients:
+                    description: Inline client credentials. Prefer credentialsSecretRef
+                      for production.
+                    items:
+                      description: AuthClient defines a single authentication client
+                        credential.
+                      properties:
+                        passwordSecretKeyRef:
+                          description: Reference to a Secret key containing the password.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          description: Username for authentication.
+                          type: string
+                      required:
+                      - user
+                      type: object
+                    type: array
+                  credentialsSecretRef:
+                    description: |-
+                      Reference to a Secret containing authentication credentials.
+                      The Secret should contain key-value pairs where keys are usernames and values are passwords.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  realm:
+                    description: Authentication realm.
+                    type: string
+                  type:
+                    description: Authentication type. Currently only "basic" is supported.
+                    enum:
+                    - basic
+                    type: string
+                type: object
+              container:
+                description: Container configuration (image, resources, pull policy).
+                properties:
+                  image:
+                    description: |-
+                      Container image override. Defaults to the per-component ISC Kea image
+                      (e.g., kea-dhcp4, kea-dhcp6, kea-ctrl-agent, kea-dhcp-ddns).
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets.
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  resources:
+                    description: CPU and memory resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              control-sockets:
+                description: Control sockets for communicating with managed Kea daemons.
+                properties:
+                  d2:
+                    description: Control socket for the DHCP-DDNS (D2) server.
+                    properties:
+                      socket-address:
+                        description: |-
+                          HTTP socket bind address (for http type). Defaults to "127.0.0.1".
+                          Set to "0.0.0.0" for HA peer communication.
+                        type: string
+                      socket-name:
+                        description: UNIX socket file path (for unix type).
+                        type: string
+                      socket-port:
+                        description: HTTP socket port (for http type).
+                        format: int32
+                        type: integer
+                      socket-type:
+                        description: 'Socket type: "unix" for UNIX domain socket,
+                          "http" for HTTP.'
+                        enum:
+                        - unix
+                        - http
+                        type: string
+                    required:
+                    - socket-type
+                    type: object
+                  dhcp4:
+                    description: Control socket for the DHCPv4 server.
+                    properties:
+                      socket-address:
+                        description: |-
+                          HTTP socket bind address (for http type). Defaults to "127.0.0.1".
+                          Set to "0.0.0.0" for HA peer communication.
+                        type: string
+                      socket-name:
+                        description: UNIX socket file path (for unix type).
+                        type: string
+                      socket-port:
+                        description: HTTP socket port (for http type).
+                        format: int32
+                        type: integer
+                      socket-type:
+                        description: 'Socket type: "unix" for UNIX domain socket,
+                          "http" for HTTP.'
+                        enum:
+                        - unix
+                        - http
+                        type: string
+                    required:
+                    - socket-type
+                    type: object
+                  dhcp6:
+                    description: Control socket for the DHCPv6 server.
+                    properties:
+                      socket-address:
+                        description: |-
+                          HTTP socket bind address (for http type). Defaults to "127.0.0.1".
+                          Set to "0.0.0.0" for HA peer communication.
+                        type: string
+                      socket-name:
+                        description: UNIX socket file path (for unix type).
+                        type: string
+                      socket-port:
+                        description: HTTP socket port (for http type).
+                        format: int32
+                        type: integer
+                      socket-type:
+                        description: 'Socket type: "unix" for UNIX domain socket,
+                          "http" for HTTP.'
+                        enum:
+                        - unix
+                        - http
+                        type: string
+                    required:
+                    - socket-type
+                    type: object
+                type: object
+              hooks-libraries:
+                description: Hook libraries to load.
+                items:
+                  description: HookLibrary defines a Kea hook library to load.
+                  properties:
+                    library:
+                      description: Full path to the hook library .so file inside the
+                        container.
+                      type: string
+                    parameters:
+                      description: Parameters passed to the hook library as arbitrary
+                        JSON.
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - library
+                  type: object
+                type: array
+              http-host:
+                default: 0.0.0.0
+                description: HTTP host address to listen on.
+                type: string
+              http-port:
+                default: 8000
+                description: HTTP port to listen on.
+                format: int32
+                type: integer
+              loggers:
+                description: Logging configuration.
+                items:
+                  description: LoggerConfig defines logging configuration for a Kea
+                    daemon.
+                  properties:
+                    debuglevel:
+                      description: Debug verbosity level (0-99, only used when severity=DEBUG).
+                      format: int32
+                      maximum: 99
+                      minimum: 0
+                      type: integer
+                    name:
+                      description: Logger component name (e.g., "kea-dhcp4", "kea-dhcp6").
+                      type: string
+                    output-options:
+                      description: Output destinations for log messages.
+                      items:
+                        description: LogOutputOption defines where log messages are
+                          written.
+                        properties:
+                          flush:
+                            description: Flush output after each log message.
+                            type: boolean
+                          maxsize:
+                            description: Maximum log file size before rotation in
+                              bytes.
+                            format: int64
+                            type: integer
+                          maxver:
+                            description: Maximum number of rotated log files to keep.
+                            format: int32
+                            type: integer
+                          output:
+                            description: 'Output destination: "stdout", "stderr",
+                              "syslog", "syslog:name", or a file path.'
+                            type: string
+                          pattern:
+                            description: Log message pattern.
+                            type: string
+                        required:
+                        - output
+                        type: object
+                      type: array
+                    severity:
+                      default: INFO
+                      description: Log severity level.
+                      enum:
+                      - FATAL
+                      - ERROR
+                      - WARN
+                      - INFO
+                      - DEBUG
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              placement:
+                description: Pod scheduling constraints.
+                properties:
+                  affinity:
+                    description: Pod affinity rules.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and subtracting
+                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: Node selector key-value pairs.
+                    type: object
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Additional annotations to set on the pod template. Useful for
+                      network attachment definitions (e.g., k8s.v1.cni.cncf.io/networks).
+                    type: object
+                  tolerations:
+                    description: Pod tolerations.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              replicas:
+                default: 1
+                description: Number of replicas.
+                format: int32
+                minimum: 1
+                type: integer
+              tls:
+                description: TLS configuration for the REST API endpoint.
+                properties:
+                  certRequired:
+                    description: Whether client certificates are required.
+                    type: boolean
+                  secretRef:
+                    description: |-
+                      Reference to a kubernetes.io/tls Secret containing TLS certificates.
+                      The Secret must have keys "tls.crt", "tls.key", and optionally "ca.crt".
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - secretRef
+                type: object
+            type: object
+          status:
+            description: KeaControlAgentStatus defines the observed state of KeaControlAgent.
+            properties:
+              conditions:
+                description: Current conditions of the component.
+                items:
+                  description: ConditionStatus mirrors metav1.Condition for embedding
+                    in status.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned.
+                      type: string
+                    message:
+                      description: Human-readable message.
+                      type: string
+                    reason:
+                      description: Machine-readable reason for the condition.
+                      type: string
+                    status:
+                      description: Status of the condition (True, False, Unknown).
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              configHash:
+                description: SHA-256 hash of the current rendered configuration.
+                type: string
+              configMapRef:
+                description: Name of the ConfigMap holding the rendered Kea configuration.
+                type: string
+              observedGeneration:
+                description: The generation last observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Current operational phase.
+                type: string
+              readyReplicas:
+                description: Number of ready replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/kea.openshift.io_keadhcp4servers.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/kea.openshift.io_keadhcp4servers.yaml
@@ -1,0 +1,2961 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  creationTimestamp: null
+  name: keadhcp4servers.kea.openshift.io
+spec:
+  group: kea.openshift.io
+  names:
+    kind: KeaDhcp4Server
+    listKind: KeaDhcp4ServerList
+    plural: keadhcp4servers
+    shortNames:
+    - kd4
+    singular: keadhcp4server
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Ready
+      type: string
+    - jsonPath: .status.readyReplicas
+      name: Replicas
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KeaDhcp4Server is the Schema for the keadhcp4servers API.
+          It manages a Kea DHCPv4 server deployment on Kubernetes or OpenShift.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeaDhcp4ServerSpec defines the desired state of a Kea DHCPv4
+              server deployment.
+            properties:
+              authoritative:
+                description: Whether this server is authoritative for its subnets.
+                type: boolean
+              boot-file-name:
+                description: Boot file name for PXE boot (global).
+                type: string
+              calculate-tee-times:
+                description: Automatically calculate T1 and T2 as percentages of valid-lifetime.
+                type: boolean
+              client-classes:
+                description: Client classification rules.
+                items:
+                  description: ClientClass defines a DHCP client classification rule.
+                  properties:
+                    max-valid-lifetime:
+                      description: Maximum valid lifetime.
+                      format: int32
+                      type: integer
+                    min-valid-lifetime:
+                      description: Minimum valid lifetime.
+                      format: int32
+                      type: integer
+                    name:
+                      description: Unique name of the client class.
+                      type: string
+                    only-if-required:
+                      description: Only use this class when explicitly required by
+                        another class.
+                      type: boolean
+                    option-data:
+                      description: DHCP options specific to this class.
+                      items:
+                        description: OptionData defines a DHCP option value.
+                        properties:
+                          always-send:
+                            description: Always include this option in responses.
+                            type: boolean
+                          code:
+                            description: Numeric option code.
+                            format: int32
+                            type: integer
+                          csv-format:
+                            description: Whether data is in comma-separated format.
+                            type: boolean
+                          data:
+                            description: Option data value as text or hexadecimal.
+                            type: string
+                          name:
+                            description: Option name (e.g., "domain-name-servers",
+                              "routers").
+                            type: string
+                          never-send:
+                            description: Never include this option in responses.
+                            type: boolean
+                          space:
+                            description: 'Option space (default: "dhcp4" or "dhcp6").'
+                            type: string
+                        type: object
+                      type: array
+                    test:
+                      description: Boolean expression for class membership testing.
+                      type: string
+                    valid-lifetime:
+                      description: Valid lifetime for clients in this class.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+              container:
+                description: Container configuration (image, resources, pull policy).
+                properties:
+                  image:
+                    description: |-
+                      Container image override. Defaults to the per-component ISC Kea image
+                      (e.g., kea-dhcp4, kea-dhcp6, kea-ctrl-agent, kea-dhcp-ddns).
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets.
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  resources:
+                    description: CPU and memory resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              control-socket:
+                description: Control socket configuration for management commands.
+                properties:
+                  socket-address:
+                    description: |-
+                      HTTP socket bind address (for http type). Defaults to "127.0.0.1".
+                      Set to "0.0.0.0" for HA peer communication.
+                    type: string
+                  socket-name:
+                    description: UNIX socket file path (for unix type).
+                    type: string
+                  socket-port:
+                    description: HTTP socket port (for http type).
+                    format: int32
+                    type: integer
+                  socket-type:
+                    description: 'Socket type: "unix" for UNIX domain socket, "http"
+                      for HTTP.'
+                    enum:
+                    - unix
+                    - http
+                    type: string
+                required:
+                - socket-type
+                type: object
+              ddns-generated-prefix:
+                description: DDNS generated prefix.
+                type: string
+              ddns-override-client-update:
+                description: DDNS override client update.
+                type: boolean
+              ddns-override-no-update:
+                description: DDNS override no update.
+                type: boolean
+              ddns-qualifying-suffix:
+                description: DDNS qualifying suffix.
+                type: string
+              ddns-replace-client-name:
+                description: DDNS replace client name mode.
+                enum:
+                - never
+                - always
+                - when-present
+                - when-not-present
+                type: string
+              ddns-send-updates:
+                description: DDNS-related parameters.
+                type: boolean
+              ddns-use-conflict-resolution:
+                description: Enable DDNS conflict resolution.
+                type: boolean
+              high-availability:
+                description: |-
+                  High Availability configuration. When set, the operator automatically
+                  configures the HA and lease_cmds hook libraries.
+                properties:
+                  delayed-updates-limit:
+                    description: Delayed updates limit.
+                    format: int32
+                    type: integer
+                  heartbeat-delay:
+                    default: 10000
+                    description: Heartbeat interval in milliseconds.
+                    format: int32
+                    type: integer
+                  max-ack-delay:
+                    default: 10000
+                    description: Maximum time to wait for an acknowledgment in milliseconds.
+                    format: int32
+                    type: integer
+                  max-response-delay:
+                    default: 60000
+                    description: |-
+                      Maximum time to wait for a response from a partner in milliseconds.
+                      Should be greater than heartbeat-delay.
+                    format: int32
+                    type: integer
+                  max-unacked-clients:
+                    default: 10
+                    description: |-
+                      Maximum number of unacknowledged clients before failover.
+                      Set to 0 for immediate failover on connection loss.
+                    format: int32
+                    type: integer
+                  mode:
+                    default: load-balancing
+                    description: HA operating mode.
+                    enum:
+                    - load-balancing
+                    - hot-standby
+                    type: string
+                  multi-threading:
+                    description: Multi-threading configuration.
+                    properties:
+                      enable-multi-threading:
+                        description: Enable multi-threading for HA.
+                        type: boolean
+                      http-client-threads:
+                        description: Number of HTTP client threads.
+                        format: int32
+                        type: integer
+                      http-listener-threads:
+                        description: Number of HTTP listener threads.
+                        format: int32
+                        type: integer
+                    type: object
+                  peers:
+                    description: 'HA peers (at least 2: this server and partner).'
+                    items:
+                      description: HAPeer defines a peer in the Kea HA cluster.
+                      properties:
+                        address:
+                          description: |-
+                            Static IP address to assign to this peer's pod on the NAD interface.
+                            Must be within the subnet but outside the DHCP pool range.
+                            If omitted, the operator auto-assigns an IP based on the pod ordinal
+                            (subnet base + ordinal + 2).
+                          type: string
+                        auto-failover:
+                          default: true
+                          description: Enable automatic failover for this peer.
+                          type: boolean
+                        name:
+                          description: Peer name. Must be unique in the HA cluster.
+                          type: string
+                        role:
+                          description: Peer role in the HA cluster.
+                          enum:
+                          - primary
+                          - secondary
+                          - standby
+                          - backup
+                          type: string
+                        url:
+                          description: |-
+                            URL of the peer's control agent (e.g., "http://peer:8000/").
+                            If omitted, the operator auto-generates it from the StatefulSet headless
+                            Service DNS name: http://<sts>-<ordinal>.<headless>.<ns>.svc.cluster.local:<port>/
+                          type: string
+                      required:
+                      - name
+                      - role
+                      type: object
+                    minItems: 2
+                    type: array
+                  send-lease-updates:
+                    description: Send lease updates to partner.
+                    type: boolean
+                  sync-leases:
+                    description: Sync leases on startup.
+                    type: boolean
+                  sync-page-limit:
+                    description: Sync page limit.
+                    format: int32
+                    type: integer
+                  sync-timeout:
+                    description: Sync timeout in milliseconds.
+                    format: int32
+                    type: integer
+                  this-server-name:
+                    description: Name of this server in the HA cluster. Must match
+                      one of the peer names.
+                    type: string
+                  tls:
+                    description: TLS configuration for HA peer communication.
+                    properties:
+                      certRequired:
+                        description: Whether client certificates are required.
+                        type: boolean
+                      secretRef:
+                        description: |-
+                          Reference to a kubernetes.io/tls Secret containing TLS certificates.
+                          The Secret must have keys "tls.crt", "tls.key", and optionally "ca.crt".
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - secretRef
+                    type: object
+                required:
+                - peers
+                - this-server-name
+                type: object
+              hooks-libraries:
+                description: Hook libraries to load.
+                items:
+                  description: HookLibrary defines a Kea hook library to load.
+                  properties:
+                    library:
+                      description: Full path to the hook library .so file inside the
+                        container.
+                      type: string
+                    parameters:
+                      description: Parameters passed to the hook library as arbitrary
+                        JSON.
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - library
+                  type: object
+                type: array
+              host-reservation-identifiers:
+                description: Host reservation identifier order.
+                items:
+                  type: string
+                type: array
+              hostNetwork:
+                description: Enable host networking. Required for DHCP in some network
+                  topologies.
+                type: boolean
+              hosts-database:
+                description: Host reservations database (single source).
+                properties:
+                  connect-timeout:
+                    description: Connection timeout in seconds.
+                    format: int32
+                    type: integer
+                  credentialsSecretRef:
+                    description: |-
+                      Reference to a Secret containing database credentials.
+                      The Secret must have keys "username" and "password".
+                      Required when type is "mysql" or "postgresql".
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  host:
+                    description: Database host address.
+                    type: string
+                  lfc-interval:
+                    description: Lease File Cleanup interval in seconds (memfile only).
+                    format: int32
+                    type: integer
+                  max-reconnect-tries:
+                    description: Maximum number of reconnect attempts.
+                    format: int32
+                    type: integer
+                  max-row-errors:
+                    description: Maximum acceptable row errors during load.
+                    format: int32
+                    type: integer
+                  name:
+                    description: Database name or memfile path.
+                    type: string
+                  on-fail:
+                    description: Action on database connection failure.
+                    enum:
+                    - stop-retry-exit
+                    - serve-retry-exit
+                    - serve-retry-continue
+                    type: string
+                  persist:
+                    description: Persist leases to disk (memfile only).
+                    type: boolean
+                  port:
+                    description: Database port number.
+                    format: int32
+                    type: integer
+                  read-timeout:
+                    description: Read timeout in seconds (MySQL only).
+                    format: int32
+                    type: integer
+                  readonly:
+                    description: Read-only mode (hosts-database only).
+                    type: boolean
+                  reconnect-wait-time:
+                    description: Wait time between reconnect attempts in milliseconds.
+                    format: int32
+                    type: integer
+                  retry-on-startup:
+                    description: Retry database connection at startup.
+                    type: boolean
+                  tcp-user-timeout:
+                    description: TCP user timeout in seconds (PostgreSQL only).
+                    format: int32
+                    type: integer
+                  type:
+                    description: Type of the database backend.
+                    enum:
+                    - memfile
+                    - mysql
+                    - postgresql
+                    type: string
+                  write-timeout:
+                    description: Write timeout in seconds (MySQL only).
+                    format: int32
+                    type: integer
+                required:
+                - type
+                type: object
+              hosts-databases:
+                description: Host reservations databases (multiple sources).
+                items:
+                  description: DatabaseConfig defines database connection parameters
+                    used by lease-database and hosts-database.
+                  properties:
+                    connect-timeout:
+                      description: Connection timeout in seconds.
+                      format: int32
+                      type: integer
+                    credentialsSecretRef:
+                      description: |-
+                        Reference to a Secret containing database credentials.
+                        The Secret must have keys "username" and "password".
+                        Required when type is "mysql" or "postgresql".
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    host:
+                      description: Database host address.
+                      type: string
+                    lfc-interval:
+                      description: Lease File Cleanup interval in seconds (memfile
+                        only).
+                      format: int32
+                      type: integer
+                    max-reconnect-tries:
+                      description: Maximum number of reconnect attempts.
+                      format: int32
+                      type: integer
+                    max-row-errors:
+                      description: Maximum acceptable row errors during load.
+                      format: int32
+                      type: integer
+                    name:
+                      description: Database name or memfile path.
+                      type: string
+                    on-fail:
+                      description: Action on database connection failure.
+                      enum:
+                      - stop-retry-exit
+                      - serve-retry-exit
+                      - serve-retry-continue
+                      type: string
+                    persist:
+                      description: Persist leases to disk (memfile only).
+                      type: boolean
+                    port:
+                      description: Database port number.
+                      format: int32
+                      type: integer
+                    read-timeout:
+                      description: Read timeout in seconds (MySQL only).
+                      format: int32
+                      type: integer
+                    readonly:
+                      description: Read-only mode (hosts-database only).
+                      type: boolean
+                    reconnect-wait-time:
+                      description: Wait time between reconnect attempts in milliseconds.
+                      format: int32
+                      type: integer
+                    retry-on-startup:
+                      description: Retry database connection at startup.
+                      type: boolean
+                    tcp-user-timeout:
+                      description: TCP user timeout in seconds (PostgreSQL only).
+                      format: int32
+                      type: integer
+                    type:
+                      description: Type of the database backend.
+                      enum:
+                      - memfile
+                      - mysql
+                      - postgresql
+                      type: string
+                    write-timeout:
+                      description: Write timeout in seconds (MySQL only).
+                      format: int32
+                      type: integer
+                  required:
+                  - type
+                  type: object
+                type: array
+              interfaces-config:
+                description: Network interface configuration. Required.
+                properties:
+                  dhcp-socket-type:
+                    description: 'DHCP socket type: "raw" for raw sockets or "udp"
+                      for UDP sockets.'
+                    enum:
+                    - raw
+                    - udp
+                    type: string
+                  interfaces:
+                    description: |-
+                      List of interface names or interface/address pairs to listen on.
+                      Interface names must contain only alphanumeric characters, hyphens, underscores, dots, or slashes.
+                    items:
+                      pattern: ^[a-zA-Z0-9._/-]+$
+                      type: string
+                    minItems: 1
+                    type: array
+                  outbound-interface:
+                    description: Outbound interface selection method.
+                    enum:
+                    - same-as-inbound
+                    - use-routing
+                    type: string
+                  re-detect:
+                    description: Re-detect interfaces on reconfiguration.
+                    type: boolean
+                  service-sockets-max-retries:
+                    description: Maximum number of socket binding retries.
+                    format: int32
+                    type: integer
+                  service-sockets-require-all:
+                    description: Require all interfaces to bind successfully.
+                    type: boolean
+                  service-sockets-retry-wait-time:
+                    description: Milliseconds to wait between socket binding retries.
+                    format: int32
+                    type: integer
+                required:
+                - interfaces
+                type: object
+              lease-database:
+                description: Lease database configuration.
+                properties:
+                  connect-timeout:
+                    description: Connection timeout in seconds.
+                    format: int32
+                    type: integer
+                  credentialsSecretRef:
+                    description: |-
+                      Reference to a Secret containing database credentials.
+                      The Secret must have keys "username" and "password".
+                      Required when type is "mysql" or "postgresql".
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  host:
+                    description: Database host address.
+                    type: string
+                  lfc-interval:
+                    description: Lease File Cleanup interval in seconds (memfile only).
+                    format: int32
+                    type: integer
+                  max-reconnect-tries:
+                    description: Maximum number of reconnect attempts.
+                    format: int32
+                    type: integer
+                  max-row-errors:
+                    description: Maximum acceptable row errors during load.
+                    format: int32
+                    type: integer
+                  name:
+                    description: Database name or memfile path.
+                    type: string
+                  on-fail:
+                    description: Action on database connection failure.
+                    enum:
+                    - stop-retry-exit
+                    - serve-retry-exit
+                    - serve-retry-continue
+                    type: string
+                  persist:
+                    description: Persist leases to disk (memfile only).
+                    type: boolean
+                  port:
+                    description: Database port number.
+                    format: int32
+                    type: integer
+                  read-timeout:
+                    description: Read timeout in seconds (MySQL only).
+                    format: int32
+                    type: integer
+                  readonly:
+                    description: Read-only mode (hosts-database only).
+                    type: boolean
+                  reconnect-wait-time:
+                    description: Wait time between reconnect attempts in milliseconds.
+                    format: int32
+                    type: integer
+                  retry-on-startup:
+                    description: Retry database connection at startup.
+                    type: boolean
+                  tcp-user-timeout:
+                    description: TCP user timeout in seconds (PostgreSQL only).
+                    format: int32
+                    type: integer
+                  type:
+                    description: Type of the database backend.
+                    enum:
+                    - memfile
+                    - mysql
+                    - postgresql
+                    type: string
+                  write-timeout:
+                    description: Write timeout in seconds (MySQL only).
+                    format: int32
+                    type: integer
+                required:
+                - type
+                type: object
+              loggers:
+                description: Logging configuration.
+                items:
+                  description: LoggerConfig defines logging configuration for a Kea
+                    daemon.
+                  properties:
+                    debuglevel:
+                      description: Debug verbosity level (0-99, only used when severity=DEBUG).
+                      format: int32
+                      maximum: 99
+                      minimum: 0
+                      type: integer
+                    name:
+                      description: Logger component name (e.g., "kea-dhcp4", "kea-dhcp6").
+                      type: string
+                    output-options:
+                      description: Output destinations for log messages.
+                      items:
+                        description: LogOutputOption defines where log messages are
+                          written.
+                        properties:
+                          flush:
+                            description: Flush output after each log message.
+                            type: boolean
+                          maxsize:
+                            description: Maximum log file size before rotation in
+                              bytes.
+                            format: int64
+                            type: integer
+                          maxver:
+                            description: Maximum number of rotated log files to keep.
+                            format: int32
+                            type: integer
+                          output:
+                            description: 'Output destination: "stdout", "stderr",
+                              "syslog", "syslog:name", or a file path.'
+                            type: string
+                          pattern:
+                            description: Log message pattern.
+                            type: string
+                        required:
+                        - output
+                        type: object
+                      type: array
+                    severity:
+                      default: INFO
+                      description: Log severity level.
+                      enum:
+                      - FATAL
+                      - ERROR
+                      - WARN
+                      - INFO
+                      - DEBUG
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              match-client-id:
+                description: Match client using client-id option.
+                type: boolean
+              max-valid-lifetime:
+                description: Maximum valid lease lifetime in seconds.
+                format: int32
+                type: integer
+              min-valid-lifetime:
+                description: Minimum valid lease lifetime in seconds.
+                format: int32
+                type: integer
+              multi-threading:
+                description: Enable multi-threading.
+                properties:
+                  enable-multi-threading:
+                    description: Enable multi-threading.
+                    type: boolean
+                  packet-queue-size:
+                    description: Packet queue size.
+                    format: int32
+                    type: integer
+                  thread-pool-size:
+                    description: Thread pool size.
+                    format: int32
+                    type: integer
+                type: object
+              next-server:
+                description: Next server address for PXE boot (global).
+                type: string
+              option-data:
+                description: Global DHCP option data.
+                items:
+                  description: OptionData defines a DHCP option value.
+                  properties:
+                    always-send:
+                      description: Always include this option in responses.
+                      type: boolean
+                    code:
+                      description: Numeric option code.
+                      format: int32
+                      type: integer
+                    csv-format:
+                      description: Whether data is in comma-separated format.
+                      type: boolean
+                    data:
+                      description: Option data value as text or hexadecimal.
+                      type: string
+                    name:
+                      description: Option name (e.g., "domain-name-servers", "routers").
+                      type: string
+                    never-send:
+                      description: Never include this option in responses.
+                      type: boolean
+                    space:
+                      description: 'Option space (default: "dhcp4" or "dhcp6").'
+                      type: string
+                  type: object
+                type: array
+              option-def:
+                description: Custom option definitions.
+                items:
+                  description: OptionDef defines a custom DHCP option definition.
+                  properties:
+                    array:
+                      description: Whether option contains an array of values.
+                      type: boolean
+                    code:
+                      description: Numeric code assignment.
+                      format: int32
+                      type: integer
+                    encapsulate:
+                      description: Encapsulated option space name.
+                      type: string
+                    name:
+                      description: Custom option name.
+                      type: string
+                    record-types:
+                      description: Comma-separated field types for record-type options.
+                      type: string
+                    space:
+                      description: Option space this definition belongs to.
+                      type: string
+                    type:
+                      description: Data type (uint8, uint16, uint32, string, ipv4-address,
+                        boolean, binary, fqdn, record, etc.).
+                      type: string
+                  required:
+                  - code
+                  - name
+                  - type
+                  type: object
+                type: array
+              placement:
+                description: Pod scheduling constraints.
+                properties:
+                  affinity:
+                    description: Pod affinity rules.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and subtracting
+                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: Node selector key-value pairs.
+                    type: object
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Additional annotations to set on the pod template. Useful for
+                      network attachment definitions (e.g., k8s.v1.cni.cncf.io/networks).
+                    type: object
+                  tolerations:
+                    description: Pod tolerations.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              rebind-timer:
+                description: Rebind timer (T2) in seconds.
+                format: int32
+                type: integer
+              renew-timer:
+                description: Renew timer (T1) in seconds.
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Number of replicas. For HA, typically set to 2.
+                format: int32
+                minimum: 1
+                type: integer
+              reservations:
+                description: Global host reservations (outside of subnets).
+                items:
+                  description: Reservation defines a DHCP host reservation.
+                  properties:
+                    boot-file-name:
+                      description: Boot file name (DHCPv4 PXE boot).
+                      type: string
+                    circuit-id:
+                      description: RAI circuit identifier (DHCPv4 only).
+                      type: string
+                    client-classes:
+                      description: Client classes to assign to this host.
+                      items:
+                        type: string
+                      type: array
+                    client-id:
+                      description: DHCP Client Identifier.
+                      type: string
+                    duid:
+                      description: DHCP Unique Identifier.
+                      type: string
+                    flex-id:
+                      description: Flex identifier.
+                      type: string
+                    hostname:
+                      description: Hostname to assign to the client.
+                      type: string
+                    hw-address:
+                      description: Hardware (MAC) address identifier.
+                      type: string
+                    ip-address:
+                      description: IPv4 address to reserve (DHCPv4 only).
+                      type: string
+                    ip-addresses:
+                      description: IPv6 addresses to reserve (DHCPv6 only).
+                      items:
+                        type: string
+                      type: array
+                    next-server:
+                      description: Next server address (DHCPv4 PXE boot).
+                      type: string
+                    option-data:
+                      description: DHCP options for this reservation.
+                      items:
+                        description: OptionData defines a DHCP option value.
+                        properties:
+                          always-send:
+                            description: Always include this option in responses.
+                            type: boolean
+                          code:
+                            description: Numeric option code.
+                            format: int32
+                            type: integer
+                          csv-format:
+                            description: Whether data is in comma-separated format.
+                            type: boolean
+                          data:
+                            description: Option data value as text or hexadecimal.
+                            type: string
+                          name:
+                            description: Option name (e.g., "domain-name-servers",
+                              "routers").
+                            type: string
+                          never-send:
+                            description: Never include this option in responses.
+                            type: boolean
+                          space:
+                            description: 'Option space (default: "dhcp4" or "dhcp6").'
+                            type: string
+                        type: object
+                      type: array
+                    prefixes:
+                      description: Prefix delegation prefixes (DHCPv6 only).
+                      items:
+                        type: string
+                      type: array
+                    server-hostname:
+                      description: Server hostname (DHCPv4).
+                      type: string
+                  type: object
+                type: array
+              server-hostname:
+                description: Server hostname (global).
+                type: string
+              server-tag:
+                description: Server tag for multi-server configuration backend.
+                type: string
+              shared-networks:
+                description: Shared networks grouping related subnets.
+                items:
+                  description: SharedNetwork4 defines a shared network grouping multiple
+                    IPv4 subnets.
+                  properties:
+                    authoritative:
+                      description: Authoritative flag.
+                      type: boolean
+                    client-class:
+                      description: Client class required for this network.
+                      type: string
+                    interface:
+                      description: Shared network interface.
+                      type: string
+                    max-valid-lifetime:
+                      description: Maximum valid lifetime.
+                      format: int32
+                      type: integer
+                    min-valid-lifetime:
+                      description: Minimum valid lifetime.
+                      format: int32
+                      type: integer
+                    name:
+                      description: Shared network name.
+                      type: string
+                    option-data:
+                      description: Network-level DHCP option data.
+                      items:
+                        description: OptionData defines a DHCP option value.
+                        properties:
+                          always-send:
+                            description: Always include this option in responses.
+                            type: boolean
+                          code:
+                            description: Numeric option code.
+                            format: int32
+                            type: integer
+                          csv-format:
+                            description: Whether data is in comma-separated format.
+                            type: boolean
+                          data:
+                            description: Option data value as text or hexadecimal.
+                            type: string
+                          name:
+                            description: Option name (e.g., "domain-name-servers",
+                              "routers").
+                            type: string
+                          never-send:
+                            description: Never include this option in responses.
+                            type: boolean
+                          space:
+                            description: 'Option space (default: "dhcp4" or "dhcp6").'
+                            type: string
+                        type: object
+                      type: array
+                    rebind-timer:
+                      description: Rebind timer in seconds.
+                      format: int32
+                      type: integer
+                    relay:
+                      description: Relay agent configuration.
+                      properties:
+                        ip-addresses:
+                          description: Relay agent IP addresses.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    renew-timer:
+                      description: Renew timer in seconds.
+                      format: int32
+                      type: integer
+                    require-client-classes:
+                      description: Client classes to evaluate.
+                      items:
+                        type: string
+                      type: array
+                    subnet4:
+                      description: Subnets belonging to this shared network.
+                      items:
+                        description: Subnet4 defines a DHCPv4 subnet configuration.
+                        properties:
+                          authoritative:
+                            description: Whether this server is authoritative for
+                              the subnet.
+                            type: boolean
+                          boot-file-name:
+                            description: Boot file name for PXE boot.
+                            type: string
+                          client-class:
+                            description: Client class required to use this subnet.
+                            type: string
+                          id:
+                            description: Unique subnet identifier. Must be positive.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          interface:
+                            description: Network interface to listen on for this subnet.
+                            type: string
+                          match-client-id:
+                            description: Match client by client-id.
+                            type: boolean
+                          max-valid-lifetime:
+                            description: Maximum valid lifetime.
+                            format: int32
+                            type: integer
+                          min-valid-lifetime:
+                            description: Minimum valid lifetime.
+                            format: int32
+                            type: integer
+                          next-server:
+                            description: Next server address for PXE boot.
+                            type: string
+                          option-data:
+                            description: Subnet-level DHCP option data.
+                            items:
+                              description: OptionData defines a DHCP option value.
+                              properties:
+                                always-send:
+                                  description: Always include this option in responses.
+                                  type: boolean
+                                code:
+                                  description: Numeric option code.
+                                  format: int32
+                                  type: integer
+                                csv-format:
+                                  description: Whether data is in comma-separated
+                                    format.
+                                  type: boolean
+                                data:
+                                  description: Option data value as text or hexadecimal.
+                                  type: string
+                                name:
+                                  description: Option name (e.g., "domain-name-servers",
+                                    "routers").
+                                  type: string
+                                never-send:
+                                  description: Never include this option in responses.
+                                  type: boolean
+                                space:
+                                  description: 'Option space (default: "dhcp4" or
+                                    "dhcp6").'
+                                  type: string
+                              type: object
+                            type: array
+                          pools:
+                            description: Address pools for dynamic allocation.
+                            items:
+                              description: Pool4 defines an IPv4 address pool for
+                                dynamic allocation.
+                              properties:
+                                client-class:
+                                  description: Client class required to use this pool.
+                                  type: string
+                                option-data:
+                                  description: Pool-level DHCP option data.
+                                  items:
+                                    description: OptionData defines a DHCP option
+                                      value.
+                                    properties:
+                                      always-send:
+                                        description: Always include this option in
+                                          responses.
+                                        type: boolean
+                                      code:
+                                        description: Numeric option code.
+                                        format: int32
+                                        type: integer
+                                      csv-format:
+                                        description: Whether data is in comma-separated
+                                          format.
+                                        type: boolean
+                                      data:
+                                        description: Option data value as text or
+                                          hexadecimal.
+                                        type: string
+                                      name:
+                                        description: Option name (e.g., "domain-name-servers",
+                                          "routers").
+                                        type: string
+                                      never-send:
+                                        description: Never include this option in
+                                          responses.
+                                        type: boolean
+                                      space:
+                                        description: 'Option space (default: "dhcp4"
+                                          or "dhcp6").'
+                                        type: string
+                                    type: object
+                                  type: array
+                                pool:
+                                  description: Address range (e.g., "192.0.2.1 - 192.0.2.200"
+                                    or "192.0.2.0/26").
+                                  type: string
+                                require-client-classes:
+                                  description: Client classes that must be evaluated
+                                    for this pool.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - pool
+                              type: object
+                            type: array
+                          rebind-timer:
+                            description: Rebind timer (T2) in seconds.
+                            format: int32
+                            type: integer
+                          relay:
+                            description: Relay agent configuration.
+                            properties:
+                              ip-addresses:
+                                description: Relay agent IP addresses.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          renew-timer:
+                            description: Renew timer (T1) in seconds.
+                            format: int32
+                            type: integer
+                          require-client-classes:
+                            description: Client classes to evaluate for this subnet.
+                            items:
+                              type: string
+                            type: array
+                          reservation-mode:
+                            description: Host reservation mode.
+                            enum:
+                            - all
+                            - out-of-pool
+                            - global
+                            - disabled
+                            type: string
+                          reservations:
+                            description: Host reservations within this subnet.
+                            items:
+                              description: Reservation defines a DHCP host reservation.
+                              properties:
+                                boot-file-name:
+                                  description: Boot file name (DHCPv4 PXE boot).
+                                  type: string
+                                circuit-id:
+                                  description: RAI circuit identifier (DHCPv4 only).
+                                  type: string
+                                client-classes:
+                                  description: Client classes to assign to this host.
+                                  items:
+                                    type: string
+                                  type: array
+                                client-id:
+                                  description: DHCP Client Identifier.
+                                  type: string
+                                duid:
+                                  description: DHCP Unique Identifier.
+                                  type: string
+                                flex-id:
+                                  description: Flex identifier.
+                                  type: string
+                                hostname:
+                                  description: Hostname to assign to the client.
+                                  type: string
+                                hw-address:
+                                  description: Hardware (MAC) address identifier.
+                                  type: string
+                                ip-address:
+                                  description: IPv4 address to reserve (DHCPv4 only).
+                                  type: string
+                                ip-addresses:
+                                  description: IPv6 addresses to reserve (DHCPv6 only).
+                                  items:
+                                    type: string
+                                  type: array
+                                next-server:
+                                  description: Next server address (DHCPv4 PXE boot).
+                                  type: string
+                                option-data:
+                                  description: DHCP options for this reservation.
+                                  items:
+                                    description: OptionData defines a DHCP option
+                                      value.
+                                    properties:
+                                      always-send:
+                                        description: Always include this option in
+                                          responses.
+                                        type: boolean
+                                      code:
+                                        description: Numeric option code.
+                                        format: int32
+                                        type: integer
+                                      csv-format:
+                                        description: Whether data is in comma-separated
+                                          format.
+                                        type: boolean
+                                      data:
+                                        description: Option data value as text or
+                                          hexadecimal.
+                                        type: string
+                                      name:
+                                        description: Option name (e.g., "domain-name-servers",
+                                          "routers").
+                                        type: string
+                                      never-send:
+                                        description: Never include this option in
+                                          responses.
+                                        type: boolean
+                                      space:
+                                        description: 'Option space (default: "dhcp4"
+                                          or "dhcp6").'
+                                        type: string
+                                    type: object
+                                  type: array
+                                prefixes:
+                                  description: Prefix delegation prefixes (DHCPv6
+                                    only).
+                                  items:
+                                    type: string
+                                  type: array
+                                server-hostname:
+                                  description: Server hostname (DHCPv4).
+                                  type: string
+                              type: object
+                            type: array
+                          server-hostname:
+                            description: Server hostname for PXE boot.
+                            type: string
+                          subnet:
+                            description: Subnet prefix in CIDR notation (e.g., "192.168.1.0/24").
+                            pattern: ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$
+                            type: string
+                          user-context:
+                            description: Arbitrary user context data.
+                            type: string
+                          valid-lifetime:
+                            description: Valid lease lifetime in seconds for this
+                              subnet.
+                            format: int32
+                            type: integer
+                        required:
+                        - id
+                        - subnet
+                        type: object
+                      type: array
+                    valid-lifetime:
+                      description: Valid lease lifetime in seconds.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+              stork:
+                description: |-
+                  Stork agent sidecar for monitoring and Prometheus metrics.
+                  When enabled, a stork-agent container is injected alongside the Kea daemon.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enable the Stork agent sidecar.
+                    type: boolean
+                  env:
+                    description: Extra environment variables passed to the stork-agent
+                      container.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: |-
+                      Stork agent container image.
+                      Defaults to quay.io/mooyeg/stork-agent:v2.4.0 if not specified.
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy for the stork-agent container.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  port:
+                    default: 8080
+                    description: Port for the Stork agent gRPC listener (stork-server
+                      connects here).
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  prometheusPort:
+                    default: 9547
+                    description: Port for the Prometheus Kea metrics exporter.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  resources:
+                    description: CPU and memory resources for the stork-agent container.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  serverTokenSecretRef:
+                    description: |-
+                      Reference to a Secret containing the Stork server access token.
+                      The Secret must have a key "token". Used for non-interactive agent registration.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  serverURL:
+                    description: |-
+                      URL of the Stork server to register with (e.g., "http://stork-server:8080").
+                      If empty, the agent starts without server registration (Prometheus-only mode).
+                    type: string
+                  storkServerRef:
+                    description: |-
+                      Reference to a KeaStorkServer CR in the same namespace. When set, the operator
+                      auto-discovers the server URL and token, overriding serverURL and serverTokenSecretRef.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - enabled
+                type: object
+              subnet4:
+                description: DHCPv4 subnet definitions.
+                items:
+                  description: Subnet4 defines a DHCPv4 subnet configuration.
+                  properties:
+                    authoritative:
+                      description: Whether this server is authoritative for the subnet.
+                      type: boolean
+                    boot-file-name:
+                      description: Boot file name for PXE boot.
+                      type: string
+                    client-class:
+                      description: Client class required to use this subnet.
+                      type: string
+                    id:
+                      description: Unique subnet identifier. Must be positive.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                    interface:
+                      description: Network interface to listen on for this subnet.
+                      type: string
+                    match-client-id:
+                      description: Match client by client-id.
+                      type: boolean
+                    max-valid-lifetime:
+                      description: Maximum valid lifetime.
+                      format: int32
+                      type: integer
+                    min-valid-lifetime:
+                      description: Minimum valid lifetime.
+                      format: int32
+                      type: integer
+                    next-server:
+                      description: Next server address for PXE boot.
+                      type: string
+                    option-data:
+                      description: Subnet-level DHCP option data.
+                      items:
+                        description: OptionData defines a DHCP option value.
+                        properties:
+                          always-send:
+                            description: Always include this option in responses.
+                            type: boolean
+                          code:
+                            description: Numeric option code.
+                            format: int32
+                            type: integer
+                          csv-format:
+                            description: Whether data is in comma-separated format.
+                            type: boolean
+                          data:
+                            description: Option data value as text or hexadecimal.
+                            type: string
+                          name:
+                            description: Option name (e.g., "domain-name-servers",
+                              "routers").
+                            type: string
+                          never-send:
+                            description: Never include this option in responses.
+                            type: boolean
+                          space:
+                            description: 'Option space (default: "dhcp4" or "dhcp6").'
+                            type: string
+                        type: object
+                      type: array
+                    pools:
+                      description: Address pools for dynamic allocation.
+                      items:
+                        description: Pool4 defines an IPv4 address pool for dynamic
+                          allocation.
+                        properties:
+                          client-class:
+                            description: Client class required to use this pool.
+                            type: string
+                          option-data:
+                            description: Pool-level DHCP option data.
+                            items:
+                              description: OptionData defines a DHCP option value.
+                              properties:
+                                always-send:
+                                  description: Always include this option in responses.
+                                  type: boolean
+                                code:
+                                  description: Numeric option code.
+                                  format: int32
+                                  type: integer
+                                csv-format:
+                                  description: Whether data is in comma-separated
+                                    format.
+                                  type: boolean
+                                data:
+                                  description: Option data value as text or hexadecimal.
+                                  type: string
+                                name:
+                                  description: Option name (e.g., "domain-name-servers",
+                                    "routers").
+                                  type: string
+                                never-send:
+                                  description: Never include this option in responses.
+                                  type: boolean
+                                space:
+                                  description: 'Option space (default: "dhcp4" or
+                                    "dhcp6").'
+                                  type: string
+                              type: object
+                            type: array
+                          pool:
+                            description: Address range (e.g., "192.0.2.1 - 192.0.2.200"
+                              or "192.0.2.0/26").
+                            type: string
+                          require-client-classes:
+                            description: Client classes that must be evaluated for
+                              this pool.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - pool
+                        type: object
+                      type: array
+                    rebind-timer:
+                      description: Rebind timer (T2) in seconds.
+                      format: int32
+                      type: integer
+                    relay:
+                      description: Relay agent configuration.
+                      properties:
+                        ip-addresses:
+                          description: Relay agent IP addresses.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    renew-timer:
+                      description: Renew timer (T1) in seconds.
+                      format: int32
+                      type: integer
+                    require-client-classes:
+                      description: Client classes to evaluate for this subnet.
+                      items:
+                        type: string
+                      type: array
+                    reservation-mode:
+                      description: Host reservation mode.
+                      enum:
+                      - all
+                      - out-of-pool
+                      - global
+                      - disabled
+                      type: string
+                    reservations:
+                      description: Host reservations within this subnet.
+                      items:
+                        description: Reservation defines a DHCP host reservation.
+                        properties:
+                          boot-file-name:
+                            description: Boot file name (DHCPv4 PXE boot).
+                            type: string
+                          circuit-id:
+                            description: RAI circuit identifier (DHCPv4 only).
+                            type: string
+                          client-classes:
+                            description: Client classes to assign to this host.
+                            items:
+                              type: string
+                            type: array
+                          client-id:
+                            description: DHCP Client Identifier.
+                            type: string
+                          duid:
+                            description: DHCP Unique Identifier.
+                            type: string
+                          flex-id:
+                            description: Flex identifier.
+                            type: string
+                          hostname:
+                            description: Hostname to assign to the client.
+                            type: string
+                          hw-address:
+                            description: Hardware (MAC) address identifier.
+                            type: string
+                          ip-address:
+                            description: IPv4 address to reserve (DHCPv4 only).
+                            type: string
+                          ip-addresses:
+                            description: IPv6 addresses to reserve (DHCPv6 only).
+                            items:
+                              type: string
+                            type: array
+                          next-server:
+                            description: Next server address (DHCPv4 PXE boot).
+                            type: string
+                          option-data:
+                            description: DHCP options for this reservation.
+                            items:
+                              description: OptionData defines a DHCP option value.
+                              properties:
+                                always-send:
+                                  description: Always include this option in responses.
+                                  type: boolean
+                                code:
+                                  description: Numeric option code.
+                                  format: int32
+                                  type: integer
+                                csv-format:
+                                  description: Whether data is in comma-separated
+                                    format.
+                                  type: boolean
+                                data:
+                                  description: Option data value as text or hexadecimal.
+                                  type: string
+                                name:
+                                  description: Option name (e.g., "domain-name-servers",
+                                    "routers").
+                                  type: string
+                                never-send:
+                                  description: Never include this option in responses.
+                                  type: boolean
+                                space:
+                                  description: 'Option space (default: "dhcp4" or
+                                    "dhcp6").'
+                                  type: string
+                              type: object
+                            type: array
+                          prefixes:
+                            description: Prefix delegation prefixes (DHCPv6 only).
+                            items:
+                              type: string
+                            type: array
+                          server-hostname:
+                            description: Server hostname (DHCPv4).
+                            type: string
+                        type: object
+                      type: array
+                    server-hostname:
+                      description: Server hostname for PXE boot.
+                      type: string
+                    subnet:
+                      description: Subnet prefix in CIDR notation (e.g., "192.168.1.0/24").
+                      pattern: ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$
+                      type: string
+                    user-context:
+                      description: Arbitrary user context data.
+                      type: string
+                    valid-lifetime:
+                      description: Valid lease lifetime in seconds for this subnet.
+                      format: int32
+                      type: integer
+                  required:
+                  - id
+                  - subnet
+                  type: object
+                type: array
+              t1-percent:
+                description: T1 percentage of valid-lifetime (0.0-1.0). Used when
+                  calculate-tee-times is true.
+                type: string
+              t2-percent:
+                description: T2 percentage of valid-lifetime (0.0-1.0). Used when
+                  calculate-tee-times is true.
+                type: string
+              valid-lifetime:
+                default: 4000
+                description: Default valid lease lifetime in seconds.
+                format: int32
+                type: integer
+            required:
+            - interfaces-config
+            type: object
+          status:
+            description: KeaDhcp4ServerStatus defines the observed state of KeaDhcp4Server.
+            properties:
+              conditions:
+                description: Current conditions of the component.
+                items:
+                  description: ConditionStatus mirrors metav1.Condition for embedding
+                    in status.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned.
+                      type: string
+                    message:
+                      description: Human-readable message.
+                      type: string
+                    reason:
+                      description: Machine-readable reason for the condition.
+                      type: string
+                    status:
+                      description: Status of the condition (True, False, Unknown).
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              configHash:
+                description: SHA-256 hash of the current rendered configuration.
+                type: string
+              configMapRef:
+                description: Name of the ConfigMap holding the rendered Kea configuration.
+                type: string
+              nadAddresses:
+                description: |-
+                  NAD IP addresses assigned to each pod on the secondary network interface.
+                  Indexed by pod ordinal (e.g., ["192.168.50.2", "192.168.50.3"]).
+                  Only populated when a NAD interface and subnet are configured.
+                items:
+                  type: string
+                type: array
+              observedGeneration:
+                description: The generation last observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Current operational phase.
+                type: string
+              readyReplicas:
+                description: Number of ready replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/kea.openshift.io_keadhcp6servers.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/kea.openshift.io_keadhcp6servers.yaml
@@ -1,0 +1,3033 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  creationTimestamp: null
+  name: keadhcp6servers.kea.openshift.io
+spec:
+  group: kea.openshift.io
+  names:
+    kind: KeaDhcp6Server
+    listKind: KeaDhcp6ServerList
+    plural: keadhcp6servers
+    shortNames:
+    - kd6
+    singular: keadhcp6server
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Ready
+      type: string
+    - jsonPath: .status.readyReplicas
+      name: Replicas
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeaDhcp6Server is the Schema for the keadhcp6servers API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeaDhcp6ServerSpec defines the desired state of a Kea DHCPv6
+              server deployment.
+            properties:
+              calculate-tee-times:
+                description: Automatically calculate T1 and T2.
+                type: boolean
+              client-classes:
+                description: Client classification rules.
+                items:
+                  description: ClientClass defines a DHCP client classification rule.
+                  properties:
+                    max-valid-lifetime:
+                      description: Maximum valid lifetime.
+                      format: int32
+                      type: integer
+                    min-valid-lifetime:
+                      description: Minimum valid lifetime.
+                      format: int32
+                      type: integer
+                    name:
+                      description: Unique name of the client class.
+                      type: string
+                    only-if-required:
+                      description: Only use this class when explicitly required by
+                        another class.
+                      type: boolean
+                    option-data:
+                      description: DHCP options specific to this class.
+                      items:
+                        description: OptionData defines a DHCP option value.
+                        properties:
+                          always-send:
+                            description: Always include this option in responses.
+                            type: boolean
+                          code:
+                            description: Numeric option code.
+                            format: int32
+                            type: integer
+                          csv-format:
+                            description: Whether data is in comma-separated format.
+                            type: boolean
+                          data:
+                            description: Option data value as text or hexadecimal.
+                            type: string
+                          name:
+                            description: Option name (e.g., "domain-name-servers",
+                              "routers").
+                            type: string
+                          never-send:
+                            description: Never include this option in responses.
+                            type: boolean
+                          space:
+                            description: 'Option space (default: "dhcp4" or "dhcp6").'
+                            type: string
+                        type: object
+                      type: array
+                    test:
+                      description: Boolean expression for class membership testing.
+                      type: string
+                    valid-lifetime:
+                      description: Valid lifetime for clients in this class.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+              container:
+                description: Container configuration (image, resources, pull policy).
+                properties:
+                  image:
+                    description: |-
+                      Container image override. Defaults to the per-component ISC Kea image
+                      (e.g., kea-dhcp4, kea-dhcp6, kea-ctrl-agent, kea-dhcp-ddns).
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets.
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  resources:
+                    description: CPU and memory resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              control-socket:
+                description: Control socket configuration.
+                properties:
+                  socket-address:
+                    description: |-
+                      HTTP socket bind address (for http type). Defaults to "127.0.0.1".
+                      Set to "0.0.0.0" for HA peer communication.
+                    type: string
+                  socket-name:
+                    description: UNIX socket file path (for unix type).
+                    type: string
+                  socket-port:
+                    description: HTTP socket port (for http type).
+                    format: int32
+                    type: integer
+                  socket-type:
+                    description: 'Socket type: "unix" for UNIX domain socket, "http"
+                      for HTTP.'
+                    enum:
+                    - unix
+                    - http
+                    type: string
+                required:
+                - socket-type
+                type: object
+              ddns-qualifying-suffix:
+                description: DDNS qualifying suffix.
+                type: string
+              ddns-send-updates:
+                description: DDNS send updates.
+                type: boolean
+              high-availability:
+                description: High Availability configuration.
+                properties:
+                  delayed-updates-limit:
+                    description: Delayed updates limit.
+                    format: int32
+                    type: integer
+                  heartbeat-delay:
+                    default: 10000
+                    description: Heartbeat interval in milliseconds.
+                    format: int32
+                    type: integer
+                  max-ack-delay:
+                    default: 10000
+                    description: Maximum time to wait for an acknowledgment in milliseconds.
+                    format: int32
+                    type: integer
+                  max-response-delay:
+                    default: 60000
+                    description: |-
+                      Maximum time to wait for a response from a partner in milliseconds.
+                      Should be greater than heartbeat-delay.
+                    format: int32
+                    type: integer
+                  max-unacked-clients:
+                    default: 10
+                    description: |-
+                      Maximum number of unacknowledged clients before failover.
+                      Set to 0 for immediate failover on connection loss.
+                    format: int32
+                    type: integer
+                  mode:
+                    default: load-balancing
+                    description: HA operating mode.
+                    enum:
+                    - load-balancing
+                    - hot-standby
+                    type: string
+                  multi-threading:
+                    description: Multi-threading configuration.
+                    properties:
+                      enable-multi-threading:
+                        description: Enable multi-threading for HA.
+                        type: boolean
+                      http-client-threads:
+                        description: Number of HTTP client threads.
+                        format: int32
+                        type: integer
+                      http-listener-threads:
+                        description: Number of HTTP listener threads.
+                        format: int32
+                        type: integer
+                    type: object
+                  peers:
+                    description: 'HA peers (at least 2: this server and partner).'
+                    items:
+                      description: HAPeer defines a peer in the Kea HA cluster.
+                      properties:
+                        address:
+                          description: |-
+                            Static IP address to assign to this peer's pod on the NAD interface.
+                            Must be within the subnet but outside the DHCP pool range.
+                            If omitted, the operator auto-assigns an IP based on the pod ordinal
+                            (subnet base + ordinal + 2).
+                          type: string
+                        auto-failover:
+                          default: true
+                          description: Enable automatic failover for this peer.
+                          type: boolean
+                        name:
+                          description: Peer name. Must be unique in the HA cluster.
+                          type: string
+                        role:
+                          description: Peer role in the HA cluster.
+                          enum:
+                          - primary
+                          - secondary
+                          - standby
+                          - backup
+                          type: string
+                        url:
+                          description: |-
+                            URL of the peer's control agent (e.g., "http://peer:8000/").
+                            If omitted, the operator auto-generates it from the StatefulSet headless
+                            Service DNS name: http://<sts>-<ordinal>.<headless>.<ns>.svc.cluster.local:<port>/
+                          type: string
+                      required:
+                      - name
+                      - role
+                      type: object
+                    minItems: 2
+                    type: array
+                  send-lease-updates:
+                    description: Send lease updates to partner.
+                    type: boolean
+                  sync-leases:
+                    description: Sync leases on startup.
+                    type: boolean
+                  sync-page-limit:
+                    description: Sync page limit.
+                    format: int32
+                    type: integer
+                  sync-timeout:
+                    description: Sync timeout in milliseconds.
+                    format: int32
+                    type: integer
+                  this-server-name:
+                    description: Name of this server in the HA cluster. Must match
+                      one of the peer names.
+                    type: string
+                  tls:
+                    description: TLS configuration for HA peer communication.
+                    properties:
+                      certRequired:
+                        description: Whether client certificates are required.
+                        type: boolean
+                      secretRef:
+                        description: |-
+                          Reference to a kubernetes.io/tls Secret containing TLS certificates.
+                          The Secret must have keys "tls.crt", "tls.key", and optionally "ca.crt".
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - secretRef
+                    type: object
+                required:
+                - peers
+                - this-server-name
+                type: object
+              hooks-libraries:
+                description: Hook libraries to load.
+                items:
+                  description: HookLibrary defines a Kea hook library to load.
+                  properties:
+                    library:
+                      description: Full path to the hook library .so file inside the
+                        container.
+                      type: string
+                    parameters:
+                      description: Parameters passed to the hook library as arbitrary
+                        JSON.
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - library
+                  type: object
+                type: array
+              host-reservation-identifiers:
+                description: Host reservation identifier order.
+                items:
+                  type: string
+                type: array
+              hostNetwork:
+                description: Enable host networking.
+                type: boolean
+              hosts-database:
+                description: Host reservations database (single source).
+                properties:
+                  connect-timeout:
+                    description: Connection timeout in seconds.
+                    format: int32
+                    type: integer
+                  credentialsSecretRef:
+                    description: |-
+                      Reference to a Secret containing database credentials.
+                      The Secret must have keys "username" and "password".
+                      Required when type is "mysql" or "postgresql".
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  host:
+                    description: Database host address.
+                    type: string
+                  lfc-interval:
+                    description: Lease File Cleanup interval in seconds (memfile only).
+                    format: int32
+                    type: integer
+                  max-reconnect-tries:
+                    description: Maximum number of reconnect attempts.
+                    format: int32
+                    type: integer
+                  max-row-errors:
+                    description: Maximum acceptable row errors during load.
+                    format: int32
+                    type: integer
+                  name:
+                    description: Database name or memfile path.
+                    type: string
+                  on-fail:
+                    description: Action on database connection failure.
+                    enum:
+                    - stop-retry-exit
+                    - serve-retry-exit
+                    - serve-retry-continue
+                    type: string
+                  persist:
+                    description: Persist leases to disk (memfile only).
+                    type: boolean
+                  port:
+                    description: Database port number.
+                    format: int32
+                    type: integer
+                  read-timeout:
+                    description: Read timeout in seconds (MySQL only).
+                    format: int32
+                    type: integer
+                  readonly:
+                    description: Read-only mode (hosts-database only).
+                    type: boolean
+                  reconnect-wait-time:
+                    description: Wait time between reconnect attempts in milliseconds.
+                    format: int32
+                    type: integer
+                  retry-on-startup:
+                    description: Retry database connection at startup.
+                    type: boolean
+                  tcp-user-timeout:
+                    description: TCP user timeout in seconds (PostgreSQL only).
+                    format: int32
+                    type: integer
+                  type:
+                    description: Type of the database backend.
+                    enum:
+                    - memfile
+                    - mysql
+                    - postgresql
+                    type: string
+                  write-timeout:
+                    description: Write timeout in seconds (MySQL only).
+                    format: int32
+                    type: integer
+                required:
+                - type
+                type: object
+              hosts-databases:
+                description: Host reservations databases (multiple sources).
+                items:
+                  description: DatabaseConfig defines database connection parameters
+                    used by lease-database and hosts-database.
+                  properties:
+                    connect-timeout:
+                      description: Connection timeout in seconds.
+                      format: int32
+                      type: integer
+                    credentialsSecretRef:
+                      description: |-
+                        Reference to a Secret containing database credentials.
+                        The Secret must have keys "username" and "password".
+                        Required when type is "mysql" or "postgresql".
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    host:
+                      description: Database host address.
+                      type: string
+                    lfc-interval:
+                      description: Lease File Cleanup interval in seconds (memfile
+                        only).
+                      format: int32
+                      type: integer
+                    max-reconnect-tries:
+                      description: Maximum number of reconnect attempts.
+                      format: int32
+                      type: integer
+                    max-row-errors:
+                      description: Maximum acceptable row errors during load.
+                      format: int32
+                      type: integer
+                    name:
+                      description: Database name or memfile path.
+                      type: string
+                    on-fail:
+                      description: Action on database connection failure.
+                      enum:
+                      - stop-retry-exit
+                      - serve-retry-exit
+                      - serve-retry-continue
+                      type: string
+                    persist:
+                      description: Persist leases to disk (memfile only).
+                      type: boolean
+                    port:
+                      description: Database port number.
+                      format: int32
+                      type: integer
+                    read-timeout:
+                      description: Read timeout in seconds (MySQL only).
+                      format: int32
+                      type: integer
+                    readonly:
+                      description: Read-only mode (hosts-database only).
+                      type: boolean
+                    reconnect-wait-time:
+                      description: Wait time between reconnect attempts in milliseconds.
+                      format: int32
+                      type: integer
+                    retry-on-startup:
+                      description: Retry database connection at startup.
+                      type: boolean
+                    tcp-user-timeout:
+                      description: TCP user timeout in seconds (PostgreSQL only).
+                      format: int32
+                      type: integer
+                    type:
+                      description: Type of the database backend.
+                      enum:
+                      - memfile
+                      - mysql
+                      - postgresql
+                      type: string
+                    write-timeout:
+                      description: Write timeout in seconds (MySQL only).
+                      format: int32
+                      type: integer
+                  required:
+                  - type
+                  type: object
+                type: array
+              interfaces-config:
+                description: Network interface configuration.
+                properties:
+                  dhcp-socket-type:
+                    description: 'DHCP socket type: "raw" for raw sockets or "udp"
+                      for UDP sockets.'
+                    enum:
+                    - raw
+                    - udp
+                    type: string
+                  interfaces:
+                    description: |-
+                      List of interface names or interface/address pairs to listen on.
+                      Interface names must contain only alphanumeric characters, hyphens, underscores, dots, or slashes.
+                    items:
+                      pattern: ^[a-zA-Z0-9._/-]+$
+                      type: string
+                    minItems: 1
+                    type: array
+                  outbound-interface:
+                    description: Outbound interface selection method.
+                    enum:
+                    - same-as-inbound
+                    - use-routing
+                    type: string
+                  re-detect:
+                    description: Re-detect interfaces on reconfiguration.
+                    type: boolean
+                  service-sockets-max-retries:
+                    description: Maximum number of socket binding retries.
+                    format: int32
+                    type: integer
+                  service-sockets-require-all:
+                    description: Require all interfaces to bind successfully.
+                    type: boolean
+                  service-sockets-retry-wait-time:
+                    description: Milliseconds to wait between socket binding retries.
+                    format: int32
+                    type: integer
+                required:
+                - interfaces
+                type: object
+              lease-database:
+                description: Lease database configuration.
+                properties:
+                  connect-timeout:
+                    description: Connection timeout in seconds.
+                    format: int32
+                    type: integer
+                  credentialsSecretRef:
+                    description: |-
+                      Reference to a Secret containing database credentials.
+                      The Secret must have keys "username" and "password".
+                      Required when type is "mysql" or "postgresql".
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  host:
+                    description: Database host address.
+                    type: string
+                  lfc-interval:
+                    description: Lease File Cleanup interval in seconds (memfile only).
+                    format: int32
+                    type: integer
+                  max-reconnect-tries:
+                    description: Maximum number of reconnect attempts.
+                    format: int32
+                    type: integer
+                  max-row-errors:
+                    description: Maximum acceptable row errors during load.
+                    format: int32
+                    type: integer
+                  name:
+                    description: Database name or memfile path.
+                    type: string
+                  on-fail:
+                    description: Action on database connection failure.
+                    enum:
+                    - stop-retry-exit
+                    - serve-retry-exit
+                    - serve-retry-continue
+                    type: string
+                  persist:
+                    description: Persist leases to disk (memfile only).
+                    type: boolean
+                  port:
+                    description: Database port number.
+                    format: int32
+                    type: integer
+                  read-timeout:
+                    description: Read timeout in seconds (MySQL only).
+                    format: int32
+                    type: integer
+                  readonly:
+                    description: Read-only mode (hosts-database only).
+                    type: boolean
+                  reconnect-wait-time:
+                    description: Wait time between reconnect attempts in milliseconds.
+                    format: int32
+                    type: integer
+                  retry-on-startup:
+                    description: Retry database connection at startup.
+                    type: boolean
+                  tcp-user-timeout:
+                    description: TCP user timeout in seconds (PostgreSQL only).
+                    format: int32
+                    type: integer
+                  type:
+                    description: Type of the database backend.
+                    enum:
+                    - memfile
+                    - mysql
+                    - postgresql
+                    type: string
+                  write-timeout:
+                    description: Write timeout in seconds (MySQL only).
+                    format: int32
+                    type: integer
+                required:
+                - type
+                type: object
+              loggers:
+                description: Logging configuration.
+                items:
+                  description: LoggerConfig defines logging configuration for a Kea
+                    daemon.
+                  properties:
+                    debuglevel:
+                      description: Debug verbosity level (0-99, only used when severity=DEBUG).
+                      format: int32
+                      maximum: 99
+                      minimum: 0
+                      type: integer
+                    name:
+                      description: Logger component name (e.g., "kea-dhcp4", "kea-dhcp6").
+                      type: string
+                    output-options:
+                      description: Output destinations for log messages.
+                      items:
+                        description: LogOutputOption defines where log messages are
+                          written.
+                        properties:
+                          flush:
+                            description: Flush output after each log message.
+                            type: boolean
+                          maxsize:
+                            description: Maximum log file size before rotation in
+                              bytes.
+                            format: int64
+                            type: integer
+                          maxver:
+                            description: Maximum number of rotated log files to keep.
+                            format: int32
+                            type: integer
+                          output:
+                            description: 'Output destination: "stdout", "stderr",
+                              "syslog", "syslog:name", or a file path.'
+                            type: string
+                          pattern:
+                            description: Log message pattern.
+                            type: string
+                        required:
+                        - output
+                        type: object
+                      type: array
+                    severity:
+                      default: INFO
+                      description: Log severity level.
+                      enum:
+                      - FATAL
+                      - ERROR
+                      - WARN
+                      - INFO
+                      - DEBUG
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              max-valid-lifetime:
+                description: Maximum valid lifetime.
+                format: int32
+                type: integer
+              min-valid-lifetime:
+                description: Minimum valid lifetime.
+                format: int32
+                type: integer
+              multi-threading:
+                description: Multi-threading configuration.
+                properties:
+                  enable-multi-threading:
+                    description: Enable multi-threading.
+                    type: boolean
+                  packet-queue-size:
+                    description: Packet queue size.
+                    format: int32
+                    type: integer
+                  thread-pool-size:
+                    description: Thread pool size.
+                    format: int32
+                    type: integer
+                type: object
+              option-data:
+                description: Global DHCP option data.
+                items:
+                  description: OptionData defines a DHCP option value.
+                  properties:
+                    always-send:
+                      description: Always include this option in responses.
+                      type: boolean
+                    code:
+                      description: Numeric option code.
+                      format: int32
+                      type: integer
+                    csv-format:
+                      description: Whether data is in comma-separated format.
+                      type: boolean
+                    data:
+                      description: Option data value as text or hexadecimal.
+                      type: string
+                    name:
+                      description: Option name (e.g., "domain-name-servers", "routers").
+                      type: string
+                    never-send:
+                      description: Never include this option in responses.
+                      type: boolean
+                    space:
+                      description: 'Option space (default: "dhcp4" or "dhcp6").'
+                      type: string
+                  type: object
+                type: array
+              option-def:
+                description: Custom option definitions.
+                items:
+                  description: OptionDef defines a custom DHCP option definition.
+                  properties:
+                    array:
+                      description: Whether option contains an array of values.
+                      type: boolean
+                    code:
+                      description: Numeric code assignment.
+                      format: int32
+                      type: integer
+                    encapsulate:
+                      description: Encapsulated option space name.
+                      type: string
+                    name:
+                      description: Custom option name.
+                      type: string
+                    record-types:
+                      description: Comma-separated field types for record-type options.
+                      type: string
+                    space:
+                      description: Option space this definition belongs to.
+                      type: string
+                    type:
+                      description: Data type (uint8, uint16, uint32, string, ipv4-address,
+                        boolean, binary, fqdn, record, etc.).
+                      type: string
+                  required:
+                  - code
+                  - name
+                  - type
+                  type: object
+                type: array
+              placement:
+                description: Pod scheduling constraints.
+                properties:
+                  affinity:
+                    description: Pod affinity rules.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and subtracting
+                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: Node selector key-value pairs.
+                    type: object
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Additional annotations to set on the pod template. Useful for
+                      network attachment definitions (e.g., k8s.v1.cni.cncf.io/networks).
+                    type: object
+                  tolerations:
+                    description: Pod tolerations.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              preferred-lifetime:
+                description: Default preferred lifetime in seconds.
+                format: int32
+                type: integer
+              rapid-commit:
+                description: Enable rapid commit (2-message exchange).
+                type: boolean
+              rebind-timer:
+                description: Rebind timer (T2) in seconds.
+                format: int32
+                type: integer
+              renew-timer:
+                description: Renew timer (T1) in seconds.
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Number of replicas.
+                format: int32
+                minimum: 1
+                type: integer
+              reservations:
+                description: Global host reservations.
+                items:
+                  description: Reservation defines a DHCP host reservation.
+                  properties:
+                    boot-file-name:
+                      description: Boot file name (DHCPv4 PXE boot).
+                      type: string
+                    circuit-id:
+                      description: RAI circuit identifier (DHCPv4 only).
+                      type: string
+                    client-classes:
+                      description: Client classes to assign to this host.
+                      items:
+                        type: string
+                      type: array
+                    client-id:
+                      description: DHCP Client Identifier.
+                      type: string
+                    duid:
+                      description: DHCP Unique Identifier.
+                      type: string
+                    flex-id:
+                      description: Flex identifier.
+                      type: string
+                    hostname:
+                      description: Hostname to assign to the client.
+                      type: string
+                    hw-address:
+                      description: Hardware (MAC) address identifier.
+                      type: string
+                    ip-address:
+                      description: IPv4 address to reserve (DHCPv4 only).
+                      type: string
+                    ip-addresses:
+                      description: IPv6 addresses to reserve (DHCPv6 only).
+                      items:
+                        type: string
+                      type: array
+                    next-server:
+                      description: Next server address (DHCPv4 PXE boot).
+                      type: string
+                    option-data:
+                      description: DHCP options for this reservation.
+                      items:
+                        description: OptionData defines a DHCP option value.
+                        properties:
+                          always-send:
+                            description: Always include this option in responses.
+                            type: boolean
+                          code:
+                            description: Numeric option code.
+                            format: int32
+                            type: integer
+                          csv-format:
+                            description: Whether data is in comma-separated format.
+                            type: boolean
+                          data:
+                            description: Option data value as text or hexadecimal.
+                            type: string
+                          name:
+                            description: Option name (e.g., "domain-name-servers",
+                              "routers").
+                            type: string
+                          never-send:
+                            description: Never include this option in responses.
+                            type: boolean
+                          space:
+                            description: 'Option space (default: "dhcp4" or "dhcp6").'
+                            type: string
+                        type: object
+                      type: array
+                    prefixes:
+                      description: Prefix delegation prefixes (DHCPv6 only).
+                      items:
+                        type: string
+                      type: array
+                    server-hostname:
+                      description: Server hostname (DHCPv4).
+                      type: string
+                  type: object
+                type: array
+              server-tag:
+                description: Server tag for config backend.
+                type: string
+              shared-networks:
+                description: Shared networks.
+                items:
+                  description: SharedNetwork6 defines a shared network grouping multiple
+                    IPv6 subnets.
+                  properties:
+                    client-class:
+                      description: Client class required for this network.
+                      type: string
+                    interface:
+                      description: Network interface.
+                      type: string
+                    interface-id:
+                      description: Interface ID.
+                      type: string
+                    name:
+                      description: Shared network name.
+                      type: string
+                    option-data:
+                      description: Network-level DHCP option data.
+                      items:
+                        description: OptionData defines a DHCP option value.
+                        properties:
+                          always-send:
+                            description: Always include this option in responses.
+                            type: boolean
+                          code:
+                            description: Numeric option code.
+                            format: int32
+                            type: integer
+                          csv-format:
+                            description: Whether data is in comma-separated format.
+                            type: boolean
+                          data:
+                            description: Option data value as text or hexadecimal.
+                            type: string
+                          name:
+                            description: Option name (e.g., "domain-name-servers",
+                              "routers").
+                            type: string
+                          never-send:
+                            description: Never include this option in responses.
+                            type: boolean
+                          space:
+                            description: 'Option space (default: "dhcp4" or "dhcp6").'
+                            type: string
+                        type: object
+                      type: array
+                    preferred-lifetime:
+                      description: Preferred lifetime in seconds.
+                      format: int32
+                      type: integer
+                    rapid-commit:
+                      description: Enable rapid commit.
+                      type: boolean
+                    rebind-timer:
+                      description: Rebind timer in seconds.
+                      format: int32
+                      type: integer
+                    relay:
+                      description: Relay agent configuration.
+                      properties:
+                        ip-addresses:
+                          description: Relay agent IP addresses.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    renew-timer:
+                      description: Renew timer in seconds.
+                      format: int32
+                      type: integer
+                    subnet6:
+                      description: Subnets belonging to this shared network.
+                      items:
+                        description: Subnet6 defines a DHCPv6 subnet configuration.
+                        properties:
+                          client-class:
+                            description: Client class required for this subnet.
+                            type: string
+                          id:
+                            description: Unique subnet identifier.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          interface:
+                            description: Network interface to listen on.
+                            type: string
+                          interface-id:
+                            description: Interface ID for relay-supplied interface
+                              identification.
+                            type: string
+                          max-valid-lifetime:
+                            description: Maximum valid lifetime.
+                            format: int32
+                            type: integer
+                          min-valid-lifetime:
+                            description: Minimum valid lifetime.
+                            format: int32
+                            type: integer
+                          option-data:
+                            description: Subnet-level DHCP option data.
+                            items:
+                              description: OptionData defines a DHCP option value.
+                              properties:
+                                always-send:
+                                  description: Always include this option in responses.
+                                  type: boolean
+                                code:
+                                  description: Numeric option code.
+                                  format: int32
+                                  type: integer
+                                csv-format:
+                                  description: Whether data is in comma-separated
+                                    format.
+                                  type: boolean
+                                data:
+                                  description: Option data value as text or hexadecimal.
+                                  type: string
+                                name:
+                                  description: Option name (e.g., "domain-name-servers",
+                                    "routers").
+                                  type: string
+                                never-send:
+                                  description: Never include this option in responses.
+                                  type: boolean
+                                space:
+                                  description: 'Option space (default: "dhcp4" or
+                                    "dhcp6").'
+                                  type: string
+                              type: object
+                            type: array
+                          pd-pools:
+                            description: Prefix delegation pools.
+                            items:
+                              description: PDPool defines a prefix delegation pool
+                                (IPv6-specific).
+                              properties:
+                                client-class:
+                                  description: Client class required to use this pool.
+                                  type: string
+                                delegated-len:
+                                  description: Length of the delegated prefix in bits.
+                                  format: int32
+                                  maximum: 128
+                                  minimum: 1
+                                  type: integer
+                                excluded-prefix:
+                                  description: Excluded prefix.
+                                  type: string
+                                excluded-prefix-len:
+                                  description: Excluded prefix length.
+                                  format: int32
+                                  type: integer
+                                option-data:
+                                  description: Pool-level DHCP option data.
+                                  items:
+                                    description: OptionData defines a DHCP option
+                                      value.
+                                    properties:
+                                      always-send:
+                                        description: Always include this option in
+                                          responses.
+                                        type: boolean
+                                      code:
+                                        description: Numeric option code.
+                                        format: int32
+                                        type: integer
+                                      csv-format:
+                                        description: Whether data is in comma-separated
+                                          format.
+                                        type: boolean
+                                      data:
+                                        description: Option data value as text or
+                                          hexadecimal.
+                                        type: string
+                                      name:
+                                        description: Option name (e.g., "domain-name-servers",
+                                          "routers").
+                                        type: string
+                                      never-send:
+                                        description: Never include this option in
+                                          responses.
+                                        type: boolean
+                                      space:
+                                        description: 'Option space (default: "dhcp4"
+                                          or "dhcp6").'
+                                        type: string
+                                    type: object
+                                  type: array
+                                prefix:
+                                  description: Delegated prefix (e.g., "2001:db8:8::").
+                                  type: string
+                                prefix-len:
+                                  description: Length of the prefix in bits.
+                                  format: int32
+                                  maximum: 128
+                                  minimum: 1
+                                  type: integer
+                              required:
+                              - delegated-len
+                              - prefix
+                              - prefix-len
+                              type: object
+                            type: array
+                          pools:
+                            description: Address pools for dynamic allocation.
+                            items:
+                              description: Pool6 defines an IPv6 address pool for
+                                dynamic allocation.
+                              properties:
+                                client-class:
+                                  description: Client class required to use this pool.
+                                  type: string
+                                option-data:
+                                  description: Pool-level DHCP option data.
+                                  items:
+                                    description: OptionData defines a DHCP option
+                                      value.
+                                    properties:
+                                      always-send:
+                                        description: Always include this option in
+                                          responses.
+                                        type: boolean
+                                      code:
+                                        description: Numeric option code.
+                                        format: int32
+                                        type: integer
+                                      csv-format:
+                                        description: Whether data is in comma-separated
+                                          format.
+                                        type: boolean
+                                      data:
+                                        description: Option data value as text or
+                                          hexadecimal.
+                                        type: string
+                                      name:
+                                        description: Option name (e.g., "domain-name-servers",
+                                          "routers").
+                                        type: string
+                                      never-send:
+                                        description: Never include this option in
+                                          responses.
+                                        type: boolean
+                                      space:
+                                        description: 'Option space (default: "dhcp4"
+                                          or "dhcp6").'
+                                        type: string
+                                    type: object
+                                  type: array
+                                pool:
+                                  description: Address range (e.g., "2001:db8:1::1
+                                    - 2001:db8:1::ffff").
+                                  type: string
+                                require-client-classes:
+                                  description: Client classes that must be evaluated.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - pool
+                              type: object
+                            type: array
+                          preferred-lifetime:
+                            description: Preferred lifetime in seconds (T_pref).
+                            format: int32
+                            type: integer
+                          rapid-commit:
+                            description: Enable rapid commit (2-message exchange).
+                            type: boolean
+                          rebind-timer:
+                            description: Rebind timer (T2) in seconds.
+                            format: int32
+                            type: integer
+                          relay:
+                            description: Relay agent configuration.
+                            properties:
+                              ip-addresses:
+                                description: Relay agent IP addresses.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          renew-timer:
+                            description: Renew timer (T1) in seconds.
+                            format: int32
+                            type: integer
+                          require-client-classes:
+                            description: Client classes to evaluate.
+                            items:
+                              type: string
+                            type: array
+                          reservation-mode:
+                            description: Host reservation mode.
+                            enum:
+                            - all
+                            - out-of-pool
+                            - global
+                            - disabled
+                            type: string
+                          reservations:
+                            description: Host reservations within this subnet.
+                            items:
+                              description: Reservation defines a DHCP host reservation.
+                              properties:
+                                boot-file-name:
+                                  description: Boot file name (DHCPv4 PXE boot).
+                                  type: string
+                                circuit-id:
+                                  description: RAI circuit identifier (DHCPv4 only).
+                                  type: string
+                                client-classes:
+                                  description: Client classes to assign to this host.
+                                  items:
+                                    type: string
+                                  type: array
+                                client-id:
+                                  description: DHCP Client Identifier.
+                                  type: string
+                                duid:
+                                  description: DHCP Unique Identifier.
+                                  type: string
+                                flex-id:
+                                  description: Flex identifier.
+                                  type: string
+                                hostname:
+                                  description: Hostname to assign to the client.
+                                  type: string
+                                hw-address:
+                                  description: Hardware (MAC) address identifier.
+                                  type: string
+                                ip-address:
+                                  description: IPv4 address to reserve (DHCPv4 only).
+                                  type: string
+                                ip-addresses:
+                                  description: IPv6 addresses to reserve (DHCPv6 only).
+                                  items:
+                                    type: string
+                                  type: array
+                                next-server:
+                                  description: Next server address (DHCPv4 PXE boot).
+                                  type: string
+                                option-data:
+                                  description: DHCP options for this reservation.
+                                  items:
+                                    description: OptionData defines a DHCP option
+                                      value.
+                                    properties:
+                                      always-send:
+                                        description: Always include this option in
+                                          responses.
+                                        type: boolean
+                                      code:
+                                        description: Numeric option code.
+                                        format: int32
+                                        type: integer
+                                      csv-format:
+                                        description: Whether data is in comma-separated
+                                          format.
+                                        type: boolean
+                                      data:
+                                        description: Option data value as text or
+                                          hexadecimal.
+                                        type: string
+                                      name:
+                                        description: Option name (e.g., "domain-name-servers",
+                                          "routers").
+                                        type: string
+                                      never-send:
+                                        description: Never include this option in
+                                          responses.
+                                        type: boolean
+                                      space:
+                                        description: 'Option space (default: "dhcp4"
+                                          or "dhcp6").'
+                                        type: string
+                                    type: object
+                                  type: array
+                                prefixes:
+                                  description: Prefix delegation prefixes (DHCPv6
+                                    only).
+                                  items:
+                                    type: string
+                                  type: array
+                                server-hostname:
+                                  description: Server hostname (DHCPv4).
+                                  type: string
+                              type: object
+                            type: array
+                          subnet:
+                            description: Subnet prefix in CIDR notation (e.g., "2001:db8:1::/64").
+                            pattern: ^[a-fA-F0-9:]+/[0-9]{1,3}$
+                            type: string
+                          valid-lifetime:
+                            description: Valid lease lifetime in seconds.
+                            format: int32
+                            type: integer
+                        required:
+                        - id
+                        - subnet
+                        type: object
+                      type: array
+                    valid-lifetime:
+                      description: Valid lease lifetime in seconds.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  type: object
+                type: array
+              stork:
+                description: |-
+                  Stork agent sidecar for monitoring and Prometheus metrics.
+                  When enabled, a stork-agent container is injected alongside the Kea daemon.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enable the Stork agent sidecar.
+                    type: boolean
+                  env:
+                    description: Extra environment variables passed to the stork-agent
+                      container.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: |-
+                      Stork agent container image.
+                      Defaults to quay.io/mooyeg/stork-agent:v2.4.0 if not specified.
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy for the stork-agent container.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  port:
+                    default: 8080
+                    description: Port for the Stork agent gRPC listener (stork-server
+                      connects here).
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  prometheusPort:
+                    default: 9547
+                    description: Port for the Prometheus Kea metrics exporter.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  resources:
+                    description: CPU and memory resources for the stork-agent container.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                  serverTokenSecretRef:
+                    description: |-
+                      Reference to a Secret containing the Stork server access token.
+                      The Secret must have a key "token". Used for non-interactive agent registration.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  serverURL:
+                    description: |-
+                      URL of the Stork server to register with (e.g., "http://stork-server:8080").
+                      If empty, the agent starts without server registration (Prometheus-only mode).
+                    type: string
+                  storkServerRef:
+                    description: |-
+                      Reference to a KeaStorkServer CR in the same namespace. When set, the operator
+                      auto-discovers the server URL and token, overriding serverURL and serverTokenSecretRef.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - enabled
+                type: object
+              subnet6:
+                description: DHCPv6 subnet definitions.
+                items:
+                  description: Subnet6 defines a DHCPv6 subnet configuration.
+                  properties:
+                    client-class:
+                      description: Client class required for this subnet.
+                      type: string
+                    id:
+                      description: Unique subnet identifier.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                    interface:
+                      description: Network interface to listen on.
+                      type: string
+                    interface-id:
+                      description: Interface ID for relay-supplied interface identification.
+                      type: string
+                    max-valid-lifetime:
+                      description: Maximum valid lifetime.
+                      format: int32
+                      type: integer
+                    min-valid-lifetime:
+                      description: Minimum valid lifetime.
+                      format: int32
+                      type: integer
+                    option-data:
+                      description: Subnet-level DHCP option data.
+                      items:
+                        description: OptionData defines a DHCP option value.
+                        properties:
+                          always-send:
+                            description: Always include this option in responses.
+                            type: boolean
+                          code:
+                            description: Numeric option code.
+                            format: int32
+                            type: integer
+                          csv-format:
+                            description: Whether data is in comma-separated format.
+                            type: boolean
+                          data:
+                            description: Option data value as text or hexadecimal.
+                            type: string
+                          name:
+                            description: Option name (e.g., "domain-name-servers",
+                              "routers").
+                            type: string
+                          never-send:
+                            description: Never include this option in responses.
+                            type: boolean
+                          space:
+                            description: 'Option space (default: "dhcp4" or "dhcp6").'
+                            type: string
+                        type: object
+                      type: array
+                    pd-pools:
+                      description: Prefix delegation pools.
+                      items:
+                        description: PDPool defines a prefix delegation pool (IPv6-specific).
+                        properties:
+                          client-class:
+                            description: Client class required to use this pool.
+                            type: string
+                          delegated-len:
+                            description: Length of the delegated prefix in bits.
+                            format: int32
+                            maximum: 128
+                            minimum: 1
+                            type: integer
+                          excluded-prefix:
+                            description: Excluded prefix.
+                            type: string
+                          excluded-prefix-len:
+                            description: Excluded prefix length.
+                            format: int32
+                            type: integer
+                          option-data:
+                            description: Pool-level DHCP option data.
+                            items:
+                              description: OptionData defines a DHCP option value.
+                              properties:
+                                always-send:
+                                  description: Always include this option in responses.
+                                  type: boolean
+                                code:
+                                  description: Numeric option code.
+                                  format: int32
+                                  type: integer
+                                csv-format:
+                                  description: Whether data is in comma-separated
+                                    format.
+                                  type: boolean
+                                data:
+                                  description: Option data value as text or hexadecimal.
+                                  type: string
+                                name:
+                                  description: Option name (e.g., "domain-name-servers",
+                                    "routers").
+                                  type: string
+                                never-send:
+                                  description: Never include this option in responses.
+                                  type: boolean
+                                space:
+                                  description: 'Option space (default: "dhcp4" or
+                                    "dhcp6").'
+                                  type: string
+                              type: object
+                            type: array
+                          prefix:
+                            description: Delegated prefix (e.g., "2001:db8:8::").
+                            type: string
+                          prefix-len:
+                            description: Length of the prefix in bits.
+                            format: int32
+                            maximum: 128
+                            minimum: 1
+                            type: integer
+                        required:
+                        - delegated-len
+                        - prefix
+                        - prefix-len
+                        type: object
+                      type: array
+                    pools:
+                      description: Address pools for dynamic allocation.
+                      items:
+                        description: Pool6 defines an IPv6 address pool for dynamic
+                          allocation.
+                        properties:
+                          client-class:
+                            description: Client class required to use this pool.
+                            type: string
+                          option-data:
+                            description: Pool-level DHCP option data.
+                            items:
+                              description: OptionData defines a DHCP option value.
+                              properties:
+                                always-send:
+                                  description: Always include this option in responses.
+                                  type: boolean
+                                code:
+                                  description: Numeric option code.
+                                  format: int32
+                                  type: integer
+                                csv-format:
+                                  description: Whether data is in comma-separated
+                                    format.
+                                  type: boolean
+                                data:
+                                  description: Option data value as text or hexadecimal.
+                                  type: string
+                                name:
+                                  description: Option name (e.g., "domain-name-servers",
+                                    "routers").
+                                  type: string
+                                never-send:
+                                  description: Never include this option in responses.
+                                  type: boolean
+                                space:
+                                  description: 'Option space (default: "dhcp4" or
+                                    "dhcp6").'
+                                  type: string
+                              type: object
+                            type: array
+                          pool:
+                            description: Address range (e.g., "2001:db8:1::1 - 2001:db8:1::ffff").
+                            type: string
+                          require-client-classes:
+                            description: Client classes that must be evaluated.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - pool
+                        type: object
+                      type: array
+                    preferred-lifetime:
+                      description: Preferred lifetime in seconds (T_pref).
+                      format: int32
+                      type: integer
+                    rapid-commit:
+                      description: Enable rapid commit (2-message exchange).
+                      type: boolean
+                    rebind-timer:
+                      description: Rebind timer (T2) in seconds.
+                      format: int32
+                      type: integer
+                    relay:
+                      description: Relay agent configuration.
+                      properties:
+                        ip-addresses:
+                          description: Relay agent IP addresses.
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    renew-timer:
+                      description: Renew timer (T1) in seconds.
+                      format: int32
+                      type: integer
+                    require-client-classes:
+                      description: Client classes to evaluate.
+                      items:
+                        type: string
+                      type: array
+                    reservation-mode:
+                      description: Host reservation mode.
+                      enum:
+                      - all
+                      - out-of-pool
+                      - global
+                      - disabled
+                      type: string
+                    reservations:
+                      description: Host reservations within this subnet.
+                      items:
+                        description: Reservation defines a DHCP host reservation.
+                        properties:
+                          boot-file-name:
+                            description: Boot file name (DHCPv4 PXE boot).
+                            type: string
+                          circuit-id:
+                            description: RAI circuit identifier (DHCPv4 only).
+                            type: string
+                          client-classes:
+                            description: Client classes to assign to this host.
+                            items:
+                              type: string
+                            type: array
+                          client-id:
+                            description: DHCP Client Identifier.
+                            type: string
+                          duid:
+                            description: DHCP Unique Identifier.
+                            type: string
+                          flex-id:
+                            description: Flex identifier.
+                            type: string
+                          hostname:
+                            description: Hostname to assign to the client.
+                            type: string
+                          hw-address:
+                            description: Hardware (MAC) address identifier.
+                            type: string
+                          ip-address:
+                            description: IPv4 address to reserve (DHCPv4 only).
+                            type: string
+                          ip-addresses:
+                            description: IPv6 addresses to reserve (DHCPv6 only).
+                            items:
+                              type: string
+                            type: array
+                          next-server:
+                            description: Next server address (DHCPv4 PXE boot).
+                            type: string
+                          option-data:
+                            description: DHCP options for this reservation.
+                            items:
+                              description: OptionData defines a DHCP option value.
+                              properties:
+                                always-send:
+                                  description: Always include this option in responses.
+                                  type: boolean
+                                code:
+                                  description: Numeric option code.
+                                  format: int32
+                                  type: integer
+                                csv-format:
+                                  description: Whether data is in comma-separated
+                                    format.
+                                  type: boolean
+                                data:
+                                  description: Option data value as text or hexadecimal.
+                                  type: string
+                                name:
+                                  description: Option name (e.g., "domain-name-servers",
+                                    "routers").
+                                  type: string
+                                never-send:
+                                  description: Never include this option in responses.
+                                  type: boolean
+                                space:
+                                  description: 'Option space (default: "dhcp4" or
+                                    "dhcp6").'
+                                  type: string
+                              type: object
+                            type: array
+                          prefixes:
+                            description: Prefix delegation prefixes (DHCPv6 only).
+                            items:
+                              type: string
+                            type: array
+                          server-hostname:
+                            description: Server hostname (DHCPv4).
+                            type: string
+                        type: object
+                      type: array
+                    subnet:
+                      description: Subnet prefix in CIDR notation (e.g., "2001:db8:1::/64").
+                      pattern: ^[a-fA-F0-9:]+/[0-9]{1,3}$
+                      type: string
+                    valid-lifetime:
+                      description: Valid lease lifetime in seconds.
+                      format: int32
+                      type: integer
+                  required:
+                  - id
+                  - subnet
+                  type: object
+                type: array
+              t1-percent:
+                description: T1 percentage (0.0-1.0).
+                type: string
+              t2-percent:
+                description: T2 percentage (0.0-1.0).
+                type: string
+              valid-lifetime:
+                default: 4000
+                description: Default valid lease lifetime in seconds.
+                format: int32
+                type: integer
+            required:
+            - interfaces-config
+            type: object
+          status:
+            description: KeaDhcp6ServerStatus defines the observed state of KeaDhcp6Server.
+            properties:
+              conditions:
+                description: Current conditions of the component.
+                items:
+                  description: ConditionStatus mirrors metav1.Condition for embedding
+                    in status.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned.
+                      type: string
+                    message:
+                      description: Human-readable message.
+                      type: string
+                    reason:
+                      description: Machine-readable reason for the condition.
+                      type: string
+                    status:
+                      description: Status of the condition (True, False, Unknown).
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              configHash:
+                description: SHA-256 hash of the current rendered configuration.
+                type: string
+              configMapRef:
+                description: Name of the ConfigMap holding the rendered Kea configuration.
+                type: string
+              observedGeneration:
+                description: The generation last observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Current operational phase.
+                type: string
+              readyReplicas:
+                description: Number of ready replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/kea.openshift.io_keadhcpddns.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/kea.openshift.io_keadhcpddns.yaml
@@ -1,0 +1,1439 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  creationTimestamp: null
+  name: keadhcpddns.kea.openshift.io
+spec:
+  group: kea.openshift.io
+  names:
+    kind: KeaDhcpDdns
+    listKind: KeaDhcpDdnsList
+    plural: keadhcpddns
+    shortNames:
+    - kdd
+    singular: keadhcpddns
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KeaDhcpDdns is the Schema for the keadhcpddns API.
+          It manages a Kea DHCP-DDNS (D2) server that performs dynamic DNS updates
+          on behalf of the DHCP servers.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeaDhcpDdnsSpec defines the desired state of a Kea DHCP-DDNS
+              (D2) server deployment.
+            properties:
+              container:
+                description: Container configuration (image, resources, pull policy).
+                properties:
+                  image:
+                    description: |-
+                      Container image override. Defaults to the per-component ISC Kea image
+                      (e.g., kea-dhcp4, kea-dhcp6, kea-ctrl-agent, kea-dhcp-ddns).
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets.
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  resources:
+                    description: CPU and memory resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              control-socket:
+                description: Control socket configuration for management commands.
+                properties:
+                  socket-address:
+                    description: |-
+                      HTTP socket bind address (for http type). Defaults to "127.0.0.1".
+                      Set to "0.0.0.0" for HA peer communication.
+                    type: string
+                  socket-name:
+                    description: UNIX socket file path (for unix type).
+                    type: string
+                  socket-port:
+                    description: HTTP socket port (for http type).
+                    format: int32
+                    type: integer
+                  socket-type:
+                    description: 'Socket type: "unix" for UNIX domain socket, "http"
+                      for HTTP.'
+                    enum:
+                    - unix
+                    - http
+                    type: string
+                required:
+                - socket-type
+                type: object
+              dns-server-timeout:
+                default: 500
+                description: DNS server timeout in milliseconds.
+                format: int32
+                type: integer
+              forward-ddns:
+                description: Forward DDNS domain configuration.
+                properties:
+                  ddns-domains:
+                    description: List of DDNS domains.
+                    items:
+                      description: DDNSDomain defines a DNS domain for dynamic updates.
+                      properties:
+                        dns-servers:
+                          description: DNS servers to send updates to.
+                          items:
+                            description: DNSServer defines a DNS server endpoint for
+                              DDNS updates.
+                            properties:
+                              ip-address:
+                                description: IP address of the DNS server.
+                                type: string
+                              port:
+                                description: Port of the DNS server. Defaults to 53.
+                                format: int32
+                                type: integer
+                            required:
+                            - ip-address
+                            type: object
+                          type: array
+                        key-name:
+                          description: Name of the TSIG key to use for this domain.
+                          type: string
+                        name:
+                          description: DNS domain name (e.g., "example.com." — note
+                            trailing dot).
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              hooks-libraries:
+                description: Hook libraries to load.
+                items:
+                  description: HookLibrary defines a Kea hook library to load.
+                  properties:
+                    library:
+                      description: Full path to the hook library .so file inside the
+                        container.
+                      type: string
+                    parameters:
+                      description: Parameters passed to the hook library as arbitrary
+                        JSON.
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - library
+                  type: object
+                type: array
+              ip-address:
+                default: 127.0.0.1
+                description: IP address to listen on for NCR messages from DHCP servers.
+                type: string
+              loggers:
+                description: Logging configuration.
+                items:
+                  description: LoggerConfig defines logging configuration for a Kea
+                    daemon.
+                  properties:
+                    debuglevel:
+                      description: Debug verbosity level (0-99, only used when severity=DEBUG).
+                      format: int32
+                      maximum: 99
+                      minimum: 0
+                      type: integer
+                    name:
+                      description: Logger component name (e.g., "kea-dhcp4", "kea-dhcp6").
+                      type: string
+                    output-options:
+                      description: Output destinations for log messages.
+                      items:
+                        description: LogOutputOption defines where log messages are
+                          written.
+                        properties:
+                          flush:
+                            description: Flush output after each log message.
+                            type: boolean
+                          maxsize:
+                            description: Maximum log file size before rotation in
+                              bytes.
+                            format: int64
+                            type: integer
+                          maxver:
+                            description: Maximum number of rotated log files to keep.
+                            format: int32
+                            type: integer
+                          output:
+                            description: 'Output destination: "stdout", "stderr",
+                              "syslog", "syslog:name", or a file path.'
+                            type: string
+                          pattern:
+                            description: Log message pattern.
+                            type: string
+                        required:
+                        - output
+                        type: object
+                      type: array
+                    severity:
+                      default: INFO
+                      description: Log severity level.
+                      enum:
+                      - FATAL
+                      - ERROR
+                      - WARN
+                      - INFO
+                      - DEBUG
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              ncr-format:
+                default: JSON
+                description: NCR format. Only "JSON" is currently supported by Kea.
+                enum:
+                - JSON
+                type: string
+              ncr-protocol:
+                default: UDP
+                description: NCR protocol. Only "UDP" is currently supported by Kea.
+                enum:
+                - UDP
+                - TCP
+                type: string
+              placement:
+                description: Pod scheduling constraints.
+                properties:
+                  affinity:
+                    description: Pod affinity rules.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and subtracting
+                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: Node selector key-value pairs.
+                    type: object
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Additional annotations to set on the pod template. Useful for
+                      network attachment definitions (e.g., k8s.v1.cni.cncf.io/networks).
+                    type: object
+                  tolerations:
+                    description: Pod tolerations.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              port:
+                default: 53001
+                description: Port to listen on for NCR messages.
+                format: int32
+                type: integer
+              replicas:
+                default: 1
+                description: Number of replicas.
+                format: int32
+                minimum: 1
+                type: integer
+              reverse-ddns:
+                description: Reverse DDNS domain configuration.
+                properties:
+                  ddns-domains:
+                    description: List of DDNS domains.
+                    items:
+                      description: DDNSDomain defines a DNS domain for dynamic updates.
+                      properties:
+                        dns-servers:
+                          description: DNS servers to send updates to.
+                          items:
+                            description: DNSServer defines a DNS server endpoint for
+                              DDNS updates.
+                            properties:
+                              ip-address:
+                                description: IP address of the DNS server.
+                                type: string
+                              port:
+                                description: Port of the DNS server. Defaults to 53.
+                                format: int32
+                                type: integer
+                            required:
+                            - ip-address
+                            type: object
+                          type: array
+                        key-name:
+                          description: Name of the TSIG key to use for this domain.
+                          type: string
+                        name:
+                          description: DNS domain name (e.g., "example.com." — note
+                            trailing dot).
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              tsig-keys:
+                description: TSIG keys for authenticated DNS updates.
+                items:
+                  description: TSIGKey defines a TSIG key for authenticated DNS updates
+                    (RFC 2845).
+                  properties:
+                    algorithm:
+                      description: TSIG algorithm (e.g., "HMAC-MD5", "HMAC-SHA256",
+                        "HMAC-SHA512").
+                      type: string
+                    digest-bits:
+                      description: Number of bits for digest truncation. 0 means no
+                        truncation.
+                      format: int32
+                      type: integer
+                    name:
+                      description: TSIG key name.
+                      type: string
+                    secretRef:
+                      description: Reference to a Secret key containing the base64-encoded
+                        TSIG secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - algorithm
+                  - name
+                  type: object
+                type: array
+            type: object
+          status:
+            description: KeaDhcpDdnsStatus defines the observed state of KeaDhcpDdns.
+            properties:
+              conditions:
+                description: Current conditions of the component.
+                items:
+                  description: ConditionStatus mirrors metav1.Condition for embedding
+                    in status.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned.
+                      type: string
+                    message:
+                      description: Human-readable message.
+                      type: string
+                    reason:
+                      description: Machine-readable reason for the condition.
+                      type: string
+                    status:
+                      description: Status of the condition (True, False, Unknown).
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              configHash:
+                description: SHA-256 hash of the current rendered configuration.
+                type: string
+              configMapRef:
+                description: Name of the ConfigMap holding the rendered Kea configuration.
+                type: string
+              observedGeneration:
+                description: The generation last observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Current operational phase.
+                type: string
+              readyReplicas:
+                description: Number of ready replicas.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/kea.openshift.io_keaservers.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/kea.openshift.io_keaservers.yaml
@@ -1,0 +1,9770 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  creationTimestamp: null
+  name: keaservers.kea.openshift.io
+spec:
+  group: kea.openshift.io
+  names:
+    kind: KeaServer
+    listKind: KeaServerList
+    plural: keaservers
+    shortNames:
+    - ks
+    singular: keaserver
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.dhcp4Ready
+      name: DHCPv4
+      type: boolean
+    - jsonPath: .status.dhcp6Ready
+      name: DHCPv6
+      type: boolean
+    - jsonPath: .status.controlAgentReady
+      name: Agent
+      type: boolean
+    - jsonPath: .status.dhcpDdnsReady
+      name: DDNS
+      type: boolean
+    - jsonPath: .status.storkServerReady
+      name: Stork
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KeaServer is the Schema for the keaservers API.
+          It is a convenience umbrella resource that deploys any combination
+          of Kea DHCP components (DHCPv4, DHCPv6, Control Agent, DDNS).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              KeaServerSpec is a convenience resource that deploys multiple Kea components
+              via a single custom resource. Each non-nil component section causes the
+              operator to create the corresponding component CRD.
+            properties:
+              controlAgent:
+                description: Control Agent configuration. When set, creates a KeaControlAgent.
+                properties:
+                  authentication:
+                    description: Authentication configuration for the REST API.
+                    properties:
+                      clients:
+                        description: Inline client credentials. Prefer credentialsSecretRef
+                          for production.
+                        items:
+                          description: AuthClient defines a single authentication
+                            client credential.
+                          properties:
+                            passwordSecretKeyRef:
+                              description: Reference to a Secret key containing the
+                                password.
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            user:
+                              description: Username for authentication.
+                              type: string
+                          required:
+                          - user
+                          type: object
+                        type: array
+                      credentialsSecretRef:
+                        description: |-
+                          Reference to a Secret containing authentication credentials.
+                          The Secret should contain key-value pairs where keys are usernames and values are passwords.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      realm:
+                        description: Authentication realm.
+                        type: string
+                      type:
+                        description: Authentication type. Currently only "basic" is
+                          supported.
+                        enum:
+                        - basic
+                        type: string
+                    type: object
+                  container:
+                    description: Container configuration (image, resources, pull policy).
+                    properties:
+                      image:
+                        description: |-
+                          Container image override. Defaults to the per-component ISC Kea image
+                          (e.g., kea-dhcp4, kea-dhcp6, kea-ctrl-agent, kea-dhcp-ddns).
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets.
+                        items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      resources:
+                        description: CPU and memory resource requirements.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    type: object
+                  control-sockets:
+                    description: Control sockets for communicating with managed Kea
+                      daemons.
+                    properties:
+                      d2:
+                        description: Control socket for the DHCP-DDNS (D2) server.
+                        properties:
+                          socket-address:
+                            description: |-
+                              HTTP socket bind address (for http type). Defaults to "127.0.0.1".
+                              Set to "0.0.0.0" for HA peer communication.
+                            type: string
+                          socket-name:
+                            description: UNIX socket file path (for unix type).
+                            type: string
+                          socket-port:
+                            description: HTTP socket port (for http type).
+                            format: int32
+                            type: integer
+                          socket-type:
+                            description: 'Socket type: "unix" for UNIX domain socket,
+                              "http" for HTTP.'
+                            enum:
+                            - unix
+                            - http
+                            type: string
+                        required:
+                        - socket-type
+                        type: object
+                      dhcp4:
+                        description: Control socket for the DHCPv4 server.
+                        properties:
+                          socket-address:
+                            description: |-
+                              HTTP socket bind address (for http type). Defaults to "127.0.0.1".
+                              Set to "0.0.0.0" for HA peer communication.
+                            type: string
+                          socket-name:
+                            description: UNIX socket file path (for unix type).
+                            type: string
+                          socket-port:
+                            description: HTTP socket port (for http type).
+                            format: int32
+                            type: integer
+                          socket-type:
+                            description: 'Socket type: "unix" for UNIX domain socket,
+                              "http" for HTTP.'
+                            enum:
+                            - unix
+                            - http
+                            type: string
+                        required:
+                        - socket-type
+                        type: object
+                      dhcp6:
+                        description: Control socket for the DHCPv6 server.
+                        properties:
+                          socket-address:
+                            description: |-
+                              HTTP socket bind address (for http type). Defaults to "127.0.0.1".
+                              Set to "0.0.0.0" for HA peer communication.
+                            type: string
+                          socket-name:
+                            description: UNIX socket file path (for unix type).
+                            type: string
+                          socket-port:
+                            description: HTTP socket port (for http type).
+                            format: int32
+                            type: integer
+                          socket-type:
+                            description: 'Socket type: "unix" for UNIX domain socket,
+                              "http" for HTTP.'
+                            enum:
+                            - unix
+                            - http
+                            type: string
+                        required:
+                        - socket-type
+                        type: object
+                    type: object
+                  hooks-libraries:
+                    description: Hook libraries to load.
+                    items:
+                      description: HookLibrary defines a Kea hook library to load.
+                      properties:
+                        library:
+                          description: Full path to the hook library .so file inside
+                            the container.
+                          type: string
+                        parameters:
+                          description: Parameters passed to the hook library as arbitrary
+                            JSON.
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - library
+                      type: object
+                    type: array
+                  http-host:
+                    default: 0.0.0.0
+                    description: HTTP host address to listen on.
+                    type: string
+                  http-port:
+                    default: 8000
+                    description: HTTP port to listen on.
+                    format: int32
+                    type: integer
+                  loggers:
+                    description: Logging configuration.
+                    items:
+                      description: LoggerConfig defines logging configuration for
+                        a Kea daemon.
+                      properties:
+                        debuglevel:
+                          description: Debug verbosity level (0-99, only used when
+                            severity=DEBUG).
+                          format: int32
+                          maximum: 99
+                          minimum: 0
+                          type: integer
+                        name:
+                          description: Logger component name (e.g., "kea-dhcp4", "kea-dhcp6").
+                          type: string
+                        output-options:
+                          description: Output destinations for log messages.
+                          items:
+                            description: LogOutputOption defines where log messages
+                              are written.
+                            properties:
+                              flush:
+                                description: Flush output after each log message.
+                                type: boolean
+                              maxsize:
+                                description: Maximum log file size before rotation
+                                  in bytes.
+                                format: int64
+                                type: integer
+                              maxver:
+                                description: Maximum number of rotated log files to
+                                  keep.
+                                format: int32
+                                type: integer
+                              output:
+                                description: 'Output destination: "stdout", "stderr",
+                                  "syslog", "syslog:name", or a file path.'
+                                type: string
+                              pattern:
+                                description: Log message pattern.
+                                type: string
+                            required:
+                            - output
+                            type: object
+                          type: array
+                        severity:
+                          default: INFO
+                          description: Log severity level.
+                          enum:
+                          - FATAL
+                          - ERROR
+                          - WARN
+                          - INFO
+                          - DEBUG
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  placement:
+                    description: Pod scheduling constraints.
+                    properties:
+                      affinity:
+                        description: Pod affinity rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and subtracting
+                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Node selector key-value pairs.
+                        type: object
+                      podAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Additional annotations to set on the pod template. Useful for
+                          network attachment definitions (e.g., k8s.v1.cni.cncf.io/networks).
+                        type: object
+                      tolerations:
+                        description: Pod tolerations.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  replicas:
+                    default: 1
+                    description: Number of replicas.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  tls:
+                    description: TLS configuration for the REST API endpoint.
+                    properties:
+                      certRequired:
+                        description: Whether client certificates are required.
+                        type: boolean
+                      secretRef:
+                        description: |-
+                          Reference to a kubernetes.io/tls Secret containing TLS certificates.
+                          The Secret must have keys "tls.crt", "tls.key", and optionally "ca.crt".
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - secretRef
+                    type: object
+                type: object
+              dhcp4:
+                description: DHCPv4 server configuration. When set, creates a KeaDhcp4Server.
+                properties:
+                  authoritative:
+                    description: Whether this server is authoritative for its subnets.
+                    type: boolean
+                  boot-file-name:
+                    description: Boot file name for PXE boot (global).
+                    type: string
+                  calculate-tee-times:
+                    description: Automatically calculate T1 and T2 as percentages
+                      of valid-lifetime.
+                    type: boolean
+                  client-classes:
+                    description: Client classification rules.
+                    items:
+                      description: ClientClass defines a DHCP client classification
+                        rule.
+                      properties:
+                        max-valid-lifetime:
+                          description: Maximum valid lifetime.
+                          format: int32
+                          type: integer
+                        min-valid-lifetime:
+                          description: Minimum valid lifetime.
+                          format: int32
+                          type: integer
+                        name:
+                          description: Unique name of the client class.
+                          type: string
+                        only-if-required:
+                          description: Only use this class when explicitly required
+                            by another class.
+                          type: boolean
+                        option-data:
+                          description: DHCP options specific to this class.
+                          items:
+                            description: OptionData defines a DHCP option value.
+                            properties:
+                              always-send:
+                                description: Always include this option in responses.
+                                type: boolean
+                              code:
+                                description: Numeric option code.
+                                format: int32
+                                type: integer
+                              csv-format:
+                                description: Whether data is in comma-separated format.
+                                type: boolean
+                              data:
+                                description: Option data value as text or hexadecimal.
+                                type: string
+                              name:
+                                description: Option name (e.g., "domain-name-servers",
+                                  "routers").
+                                type: string
+                              never-send:
+                                description: Never include this option in responses.
+                                type: boolean
+                              space:
+                                description: 'Option space (default: "dhcp4" or "dhcp6").'
+                                type: string
+                            type: object
+                          type: array
+                        test:
+                          description: Boolean expression for class membership testing.
+                          type: string
+                        valid-lifetime:
+                          description: Valid lifetime for clients in this class.
+                          format: int32
+                          type: integer
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  container:
+                    description: Container configuration (image, resources, pull policy).
+                    properties:
+                      image:
+                        description: |-
+                          Container image override. Defaults to the per-component ISC Kea image
+                          (e.g., kea-dhcp4, kea-dhcp6, kea-ctrl-agent, kea-dhcp-ddns).
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets.
+                        items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      resources:
+                        description: CPU and memory resource requirements.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    type: object
+                  control-socket:
+                    description: Control socket configuration for management commands.
+                    properties:
+                      socket-address:
+                        description: |-
+                          HTTP socket bind address (for http type). Defaults to "127.0.0.1".
+                          Set to "0.0.0.0" for HA peer communication.
+                        type: string
+                      socket-name:
+                        description: UNIX socket file path (for unix type).
+                        type: string
+                      socket-port:
+                        description: HTTP socket port (for http type).
+                        format: int32
+                        type: integer
+                      socket-type:
+                        description: 'Socket type: "unix" for UNIX domain socket,
+                          "http" for HTTP.'
+                        enum:
+                        - unix
+                        - http
+                        type: string
+                    required:
+                    - socket-type
+                    type: object
+                  ddns-generated-prefix:
+                    description: DDNS generated prefix.
+                    type: string
+                  ddns-override-client-update:
+                    description: DDNS override client update.
+                    type: boolean
+                  ddns-override-no-update:
+                    description: DDNS override no update.
+                    type: boolean
+                  ddns-qualifying-suffix:
+                    description: DDNS qualifying suffix.
+                    type: string
+                  ddns-replace-client-name:
+                    description: DDNS replace client name mode.
+                    enum:
+                    - never
+                    - always
+                    - when-present
+                    - when-not-present
+                    type: string
+                  ddns-send-updates:
+                    description: DDNS-related parameters.
+                    type: boolean
+                  ddns-use-conflict-resolution:
+                    description: Enable DDNS conflict resolution.
+                    type: boolean
+                  high-availability:
+                    description: |-
+                      High Availability configuration. When set, the operator automatically
+                      configures the HA and lease_cmds hook libraries.
+                    properties:
+                      delayed-updates-limit:
+                        description: Delayed updates limit.
+                        format: int32
+                        type: integer
+                      heartbeat-delay:
+                        default: 10000
+                        description: Heartbeat interval in milliseconds.
+                        format: int32
+                        type: integer
+                      max-ack-delay:
+                        default: 10000
+                        description: Maximum time to wait for an acknowledgment in
+                          milliseconds.
+                        format: int32
+                        type: integer
+                      max-response-delay:
+                        default: 60000
+                        description: |-
+                          Maximum time to wait for a response from a partner in milliseconds.
+                          Should be greater than heartbeat-delay.
+                        format: int32
+                        type: integer
+                      max-unacked-clients:
+                        default: 10
+                        description: |-
+                          Maximum number of unacknowledged clients before failover.
+                          Set to 0 for immediate failover on connection loss.
+                        format: int32
+                        type: integer
+                      mode:
+                        default: load-balancing
+                        description: HA operating mode.
+                        enum:
+                        - load-balancing
+                        - hot-standby
+                        type: string
+                      multi-threading:
+                        description: Multi-threading configuration.
+                        properties:
+                          enable-multi-threading:
+                            description: Enable multi-threading for HA.
+                            type: boolean
+                          http-client-threads:
+                            description: Number of HTTP client threads.
+                            format: int32
+                            type: integer
+                          http-listener-threads:
+                            description: Number of HTTP listener threads.
+                            format: int32
+                            type: integer
+                        type: object
+                      peers:
+                        description: 'HA peers (at least 2: this server and partner).'
+                        items:
+                          description: HAPeer defines a peer in the Kea HA cluster.
+                          properties:
+                            address:
+                              description: |-
+                                Static IP address to assign to this peer's pod on the NAD interface.
+                                Must be within the subnet but outside the DHCP pool range.
+                                If omitted, the operator auto-assigns an IP based on the pod ordinal
+                                (subnet base + ordinal + 2).
+                              type: string
+                            auto-failover:
+                              default: true
+                              description: Enable automatic failover for this peer.
+                              type: boolean
+                            name:
+                              description: Peer name. Must be unique in the HA cluster.
+                              type: string
+                            role:
+                              description: Peer role in the HA cluster.
+                              enum:
+                              - primary
+                              - secondary
+                              - standby
+                              - backup
+                              type: string
+                            url:
+                              description: |-
+                                URL of the peer's control agent (e.g., "http://peer:8000/").
+                                If omitted, the operator auto-generates it from the StatefulSet headless
+                                Service DNS name: http://<sts>-<ordinal>.<headless>.<ns>.svc.cluster.local:<port>/
+                              type: string
+                          required:
+                          - name
+                          - role
+                          type: object
+                        minItems: 2
+                        type: array
+                      send-lease-updates:
+                        description: Send lease updates to partner.
+                        type: boolean
+                      sync-leases:
+                        description: Sync leases on startup.
+                        type: boolean
+                      sync-page-limit:
+                        description: Sync page limit.
+                        format: int32
+                        type: integer
+                      sync-timeout:
+                        description: Sync timeout in milliseconds.
+                        format: int32
+                        type: integer
+                      this-server-name:
+                        description: Name of this server in the HA cluster. Must match
+                          one of the peer names.
+                        type: string
+                      tls:
+                        description: TLS configuration for HA peer communication.
+                        properties:
+                          certRequired:
+                            description: Whether client certificates are required.
+                            type: boolean
+                          secretRef:
+                            description: |-
+                              Reference to a kubernetes.io/tls Secret containing TLS certificates.
+                              The Secret must have keys "tls.crt", "tls.key", and optionally "ca.crt".
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                        - secretRef
+                        type: object
+                    required:
+                    - peers
+                    - this-server-name
+                    type: object
+                  hooks-libraries:
+                    description: Hook libraries to load.
+                    items:
+                      description: HookLibrary defines a Kea hook library to load.
+                      properties:
+                        library:
+                          description: Full path to the hook library .so file inside
+                            the container.
+                          type: string
+                        parameters:
+                          description: Parameters passed to the hook library as arbitrary
+                            JSON.
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - library
+                      type: object
+                    type: array
+                  host-reservation-identifiers:
+                    description: Host reservation identifier order.
+                    items:
+                      type: string
+                    type: array
+                  hostNetwork:
+                    description: Enable host networking. Required for DHCP in some
+                      network topologies.
+                    type: boolean
+                  hosts-database:
+                    description: Host reservations database (single source).
+                    properties:
+                      connect-timeout:
+                        description: Connection timeout in seconds.
+                        format: int32
+                        type: integer
+                      credentialsSecretRef:
+                        description: |-
+                          Reference to a Secret containing database credentials.
+                          The Secret must have keys "username" and "password".
+                          Required when type is "mysql" or "postgresql".
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      host:
+                        description: Database host address.
+                        type: string
+                      lfc-interval:
+                        description: Lease File Cleanup interval in seconds (memfile
+                          only).
+                        format: int32
+                        type: integer
+                      max-reconnect-tries:
+                        description: Maximum number of reconnect attempts.
+                        format: int32
+                        type: integer
+                      max-row-errors:
+                        description: Maximum acceptable row errors during load.
+                        format: int32
+                        type: integer
+                      name:
+                        description: Database name or memfile path.
+                        type: string
+                      on-fail:
+                        description: Action on database connection failure.
+                        enum:
+                        - stop-retry-exit
+                        - serve-retry-exit
+                        - serve-retry-continue
+                        type: string
+                      persist:
+                        description: Persist leases to disk (memfile only).
+                        type: boolean
+                      port:
+                        description: Database port number.
+                        format: int32
+                        type: integer
+                      read-timeout:
+                        description: Read timeout in seconds (MySQL only).
+                        format: int32
+                        type: integer
+                      readonly:
+                        description: Read-only mode (hosts-database only).
+                        type: boolean
+                      reconnect-wait-time:
+                        description: Wait time between reconnect attempts in milliseconds.
+                        format: int32
+                        type: integer
+                      retry-on-startup:
+                        description: Retry database connection at startup.
+                        type: boolean
+                      tcp-user-timeout:
+                        description: TCP user timeout in seconds (PostgreSQL only).
+                        format: int32
+                        type: integer
+                      type:
+                        description: Type of the database backend.
+                        enum:
+                        - memfile
+                        - mysql
+                        - postgresql
+                        type: string
+                      write-timeout:
+                        description: Write timeout in seconds (MySQL only).
+                        format: int32
+                        type: integer
+                    required:
+                    - type
+                    type: object
+                  hosts-databases:
+                    description: Host reservations databases (multiple sources).
+                    items:
+                      description: DatabaseConfig defines database connection parameters
+                        used by lease-database and hosts-database.
+                      properties:
+                        connect-timeout:
+                          description: Connection timeout in seconds.
+                          format: int32
+                          type: integer
+                        credentialsSecretRef:
+                          description: |-
+                            Reference to a Secret containing database credentials.
+                            The Secret must have keys "username" and "password".
+                            Required when type is "mysql" or "postgresql".
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        host:
+                          description: Database host address.
+                          type: string
+                        lfc-interval:
+                          description: Lease File Cleanup interval in seconds (memfile
+                            only).
+                          format: int32
+                          type: integer
+                        max-reconnect-tries:
+                          description: Maximum number of reconnect attempts.
+                          format: int32
+                          type: integer
+                        max-row-errors:
+                          description: Maximum acceptable row errors during load.
+                          format: int32
+                          type: integer
+                        name:
+                          description: Database name or memfile path.
+                          type: string
+                        on-fail:
+                          description: Action on database connection failure.
+                          enum:
+                          - stop-retry-exit
+                          - serve-retry-exit
+                          - serve-retry-continue
+                          type: string
+                        persist:
+                          description: Persist leases to disk (memfile only).
+                          type: boolean
+                        port:
+                          description: Database port number.
+                          format: int32
+                          type: integer
+                        read-timeout:
+                          description: Read timeout in seconds (MySQL only).
+                          format: int32
+                          type: integer
+                        readonly:
+                          description: Read-only mode (hosts-database only).
+                          type: boolean
+                        reconnect-wait-time:
+                          description: Wait time between reconnect attempts in milliseconds.
+                          format: int32
+                          type: integer
+                        retry-on-startup:
+                          description: Retry database connection at startup.
+                          type: boolean
+                        tcp-user-timeout:
+                          description: TCP user timeout in seconds (PostgreSQL only).
+                          format: int32
+                          type: integer
+                        type:
+                          description: Type of the database backend.
+                          enum:
+                          - memfile
+                          - mysql
+                          - postgresql
+                          type: string
+                        write-timeout:
+                          description: Write timeout in seconds (MySQL only).
+                          format: int32
+                          type: integer
+                      required:
+                      - type
+                      type: object
+                    type: array
+                  interfaces-config:
+                    description: Network interface configuration. Required.
+                    properties:
+                      dhcp-socket-type:
+                        description: 'DHCP socket type: "raw" for raw sockets or "udp"
+                          for UDP sockets.'
+                        enum:
+                        - raw
+                        - udp
+                        type: string
+                      interfaces:
+                        description: |-
+                          List of interface names or interface/address pairs to listen on.
+                          Interface names must contain only alphanumeric characters, hyphens, underscores, dots, or slashes.
+                        items:
+                          pattern: ^[a-zA-Z0-9._/-]+$
+                          type: string
+                        minItems: 1
+                        type: array
+                      outbound-interface:
+                        description: Outbound interface selection method.
+                        enum:
+                        - same-as-inbound
+                        - use-routing
+                        type: string
+                      re-detect:
+                        description: Re-detect interfaces on reconfiguration.
+                        type: boolean
+                      service-sockets-max-retries:
+                        description: Maximum number of socket binding retries.
+                        format: int32
+                        type: integer
+                      service-sockets-require-all:
+                        description: Require all interfaces to bind successfully.
+                        type: boolean
+                      service-sockets-retry-wait-time:
+                        description: Milliseconds to wait between socket binding retries.
+                        format: int32
+                        type: integer
+                    required:
+                    - interfaces
+                    type: object
+                  lease-database:
+                    description: Lease database configuration.
+                    properties:
+                      connect-timeout:
+                        description: Connection timeout in seconds.
+                        format: int32
+                        type: integer
+                      credentialsSecretRef:
+                        description: |-
+                          Reference to a Secret containing database credentials.
+                          The Secret must have keys "username" and "password".
+                          Required when type is "mysql" or "postgresql".
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      host:
+                        description: Database host address.
+                        type: string
+                      lfc-interval:
+                        description: Lease File Cleanup interval in seconds (memfile
+                          only).
+                        format: int32
+                        type: integer
+                      max-reconnect-tries:
+                        description: Maximum number of reconnect attempts.
+                        format: int32
+                        type: integer
+                      max-row-errors:
+                        description: Maximum acceptable row errors during load.
+                        format: int32
+                        type: integer
+                      name:
+                        description: Database name or memfile path.
+                        type: string
+                      on-fail:
+                        description: Action on database connection failure.
+                        enum:
+                        - stop-retry-exit
+                        - serve-retry-exit
+                        - serve-retry-continue
+                        type: string
+                      persist:
+                        description: Persist leases to disk (memfile only).
+                        type: boolean
+                      port:
+                        description: Database port number.
+                        format: int32
+                        type: integer
+                      read-timeout:
+                        description: Read timeout in seconds (MySQL only).
+                        format: int32
+                        type: integer
+                      readonly:
+                        description: Read-only mode (hosts-database only).
+                        type: boolean
+                      reconnect-wait-time:
+                        description: Wait time between reconnect attempts in milliseconds.
+                        format: int32
+                        type: integer
+                      retry-on-startup:
+                        description: Retry database connection at startup.
+                        type: boolean
+                      tcp-user-timeout:
+                        description: TCP user timeout in seconds (PostgreSQL only).
+                        format: int32
+                        type: integer
+                      type:
+                        description: Type of the database backend.
+                        enum:
+                        - memfile
+                        - mysql
+                        - postgresql
+                        type: string
+                      write-timeout:
+                        description: Write timeout in seconds (MySQL only).
+                        format: int32
+                        type: integer
+                    required:
+                    - type
+                    type: object
+                  loggers:
+                    description: Logging configuration.
+                    items:
+                      description: LoggerConfig defines logging configuration for
+                        a Kea daemon.
+                      properties:
+                        debuglevel:
+                          description: Debug verbosity level (0-99, only used when
+                            severity=DEBUG).
+                          format: int32
+                          maximum: 99
+                          minimum: 0
+                          type: integer
+                        name:
+                          description: Logger component name (e.g., "kea-dhcp4", "kea-dhcp6").
+                          type: string
+                        output-options:
+                          description: Output destinations for log messages.
+                          items:
+                            description: LogOutputOption defines where log messages
+                              are written.
+                            properties:
+                              flush:
+                                description: Flush output after each log message.
+                                type: boolean
+                              maxsize:
+                                description: Maximum log file size before rotation
+                                  in bytes.
+                                format: int64
+                                type: integer
+                              maxver:
+                                description: Maximum number of rotated log files to
+                                  keep.
+                                format: int32
+                                type: integer
+                              output:
+                                description: 'Output destination: "stdout", "stderr",
+                                  "syslog", "syslog:name", or a file path.'
+                                type: string
+                              pattern:
+                                description: Log message pattern.
+                                type: string
+                            required:
+                            - output
+                            type: object
+                          type: array
+                        severity:
+                          default: INFO
+                          description: Log severity level.
+                          enum:
+                          - FATAL
+                          - ERROR
+                          - WARN
+                          - INFO
+                          - DEBUG
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  match-client-id:
+                    description: Match client using client-id option.
+                    type: boolean
+                  max-valid-lifetime:
+                    description: Maximum valid lease lifetime in seconds.
+                    format: int32
+                    type: integer
+                  min-valid-lifetime:
+                    description: Minimum valid lease lifetime in seconds.
+                    format: int32
+                    type: integer
+                  multi-threading:
+                    description: Enable multi-threading.
+                    properties:
+                      enable-multi-threading:
+                        description: Enable multi-threading.
+                        type: boolean
+                      packet-queue-size:
+                        description: Packet queue size.
+                        format: int32
+                        type: integer
+                      thread-pool-size:
+                        description: Thread pool size.
+                        format: int32
+                        type: integer
+                    type: object
+                  next-server:
+                    description: Next server address for PXE boot (global).
+                    type: string
+                  option-data:
+                    description: Global DHCP option data.
+                    items:
+                      description: OptionData defines a DHCP option value.
+                      properties:
+                        always-send:
+                          description: Always include this option in responses.
+                          type: boolean
+                        code:
+                          description: Numeric option code.
+                          format: int32
+                          type: integer
+                        csv-format:
+                          description: Whether data is in comma-separated format.
+                          type: boolean
+                        data:
+                          description: Option data value as text or hexadecimal.
+                          type: string
+                        name:
+                          description: Option name (e.g., "domain-name-servers", "routers").
+                          type: string
+                        never-send:
+                          description: Never include this option in responses.
+                          type: boolean
+                        space:
+                          description: 'Option space (default: "dhcp4" or "dhcp6").'
+                          type: string
+                      type: object
+                    type: array
+                  option-def:
+                    description: Custom option definitions.
+                    items:
+                      description: OptionDef defines a custom DHCP option definition.
+                      properties:
+                        array:
+                          description: Whether option contains an array of values.
+                          type: boolean
+                        code:
+                          description: Numeric code assignment.
+                          format: int32
+                          type: integer
+                        encapsulate:
+                          description: Encapsulated option space name.
+                          type: string
+                        name:
+                          description: Custom option name.
+                          type: string
+                        record-types:
+                          description: Comma-separated field types for record-type
+                            options.
+                          type: string
+                        space:
+                          description: Option space this definition belongs to.
+                          type: string
+                        type:
+                          description: Data type (uint8, uint16, uint32, string, ipv4-address,
+                            boolean, binary, fqdn, record, etc.).
+                          type: string
+                      required:
+                      - code
+                      - name
+                      - type
+                      type: object
+                    type: array
+                  placement:
+                    description: Pod scheduling constraints.
+                    properties:
+                      affinity:
+                        description: Pod affinity rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and subtracting
+                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Node selector key-value pairs.
+                        type: object
+                      podAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Additional annotations to set on the pod template. Useful for
+                          network attachment definitions (e.g., k8s.v1.cni.cncf.io/networks).
+                        type: object
+                      tolerations:
+                        description: Pod tolerations.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  rebind-timer:
+                    description: Rebind timer (T2) in seconds.
+                    format: int32
+                    type: integer
+                  renew-timer:
+                    description: Renew timer (T1) in seconds.
+                    format: int32
+                    type: integer
+                  replicas:
+                    default: 1
+                    description: Number of replicas. For HA, typically set to 2.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  reservations:
+                    description: Global host reservations (outside of subnets).
+                    items:
+                      description: Reservation defines a DHCP host reservation.
+                      properties:
+                        boot-file-name:
+                          description: Boot file name (DHCPv4 PXE boot).
+                          type: string
+                        circuit-id:
+                          description: RAI circuit identifier (DHCPv4 only).
+                          type: string
+                        client-classes:
+                          description: Client classes to assign to this host.
+                          items:
+                            type: string
+                          type: array
+                        client-id:
+                          description: DHCP Client Identifier.
+                          type: string
+                        duid:
+                          description: DHCP Unique Identifier.
+                          type: string
+                        flex-id:
+                          description: Flex identifier.
+                          type: string
+                        hostname:
+                          description: Hostname to assign to the client.
+                          type: string
+                        hw-address:
+                          description: Hardware (MAC) address identifier.
+                          type: string
+                        ip-address:
+                          description: IPv4 address to reserve (DHCPv4 only).
+                          type: string
+                        ip-addresses:
+                          description: IPv6 addresses to reserve (DHCPv6 only).
+                          items:
+                            type: string
+                          type: array
+                        next-server:
+                          description: Next server address (DHCPv4 PXE boot).
+                          type: string
+                        option-data:
+                          description: DHCP options for this reservation.
+                          items:
+                            description: OptionData defines a DHCP option value.
+                            properties:
+                              always-send:
+                                description: Always include this option in responses.
+                                type: boolean
+                              code:
+                                description: Numeric option code.
+                                format: int32
+                                type: integer
+                              csv-format:
+                                description: Whether data is in comma-separated format.
+                                type: boolean
+                              data:
+                                description: Option data value as text or hexadecimal.
+                                type: string
+                              name:
+                                description: Option name (e.g., "domain-name-servers",
+                                  "routers").
+                                type: string
+                              never-send:
+                                description: Never include this option in responses.
+                                type: boolean
+                              space:
+                                description: 'Option space (default: "dhcp4" or "dhcp6").'
+                                type: string
+                            type: object
+                          type: array
+                        prefixes:
+                          description: Prefix delegation prefixes (DHCPv6 only).
+                          items:
+                            type: string
+                          type: array
+                        server-hostname:
+                          description: Server hostname (DHCPv4).
+                          type: string
+                      type: object
+                    type: array
+                  server-hostname:
+                    description: Server hostname (global).
+                    type: string
+                  server-tag:
+                    description: Server tag for multi-server configuration backend.
+                    type: string
+                  shared-networks:
+                    description: Shared networks grouping related subnets.
+                    items:
+                      description: SharedNetwork4 defines a shared network grouping
+                        multiple IPv4 subnets.
+                      properties:
+                        authoritative:
+                          description: Authoritative flag.
+                          type: boolean
+                        client-class:
+                          description: Client class required for this network.
+                          type: string
+                        interface:
+                          description: Shared network interface.
+                          type: string
+                        max-valid-lifetime:
+                          description: Maximum valid lifetime.
+                          format: int32
+                          type: integer
+                        min-valid-lifetime:
+                          description: Minimum valid lifetime.
+                          format: int32
+                          type: integer
+                        name:
+                          description: Shared network name.
+                          type: string
+                        option-data:
+                          description: Network-level DHCP option data.
+                          items:
+                            description: OptionData defines a DHCP option value.
+                            properties:
+                              always-send:
+                                description: Always include this option in responses.
+                                type: boolean
+                              code:
+                                description: Numeric option code.
+                                format: int32
+                                type: integer
+                              csv-format:
+                                description: Whether data is in comma-separated format.
+                                type: boolean
+                              data:
+                                description: Option data value as text or hexadecimal.
+                                type: string
+                              name:
+                                description: Option name (e.g., "domain-name-servers",
+                                  "routers").
+                                type: string
+                              never-send:
+                                description: Never include this option in responses.
+                                type: boolean
+                              space:
+                                description: 'Option space (default: "dhcp4" or "dhcp6").'
+                                type: string
+                            type: object
+                          type: array
+                        rebind-timer:
+                          description: Rebind timer in seconds.
+                          format: int32
+                          type: integer
+                        relay:
+                          description: Relay agent configuration.
+                          properties:
+                            ip-addresses:
+                              description: Relay agent IP addresses.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        renew-timer:
+                          description: Renew timer in seconds.
+                          format: int32
+                          type: integer
+                        require-client-classes:
+                          description: Client classes to evaluate.
+                          items:
+                            type: string
+                          type: array
+                        subnet4:
+                          description: Subnets belonging to this shared network.
+                          items:
+                            description: Subnet4 defines a DHCPv4 subnet configuration.
+                            properties:
+                              authoritative:
+                                description: Whether this server is authoritative
+                                  for the subnet.
+                                type: boolean
+                              boot-file-name:
+                                description: Boot file name for PXE boot.
+                                type: string
+                              client-class:
+                                description: Client class required to use this subnet.
+                                type: string
+                              id:
+                                description: Unique subnet identifier. Must be positive.
+                                format: int32
+                                minimum: 1
+                                type: integer
+                              interface:
+                                description: Network interface to listen on for this
+                                  subnet.
+                                type: string
+                              match-client-id:
+                                description: Match client by client-id.
+                                type: boolean
+                              max-valid-lifetime:
+                                description: Maximum valid lifetime.
+                                format: int32
+                                type: integer
+                              min-valid-lifetime:
+                                description: Minimum valid lifetime.
+                                format: int32
+                                type: integer
+                              next-server:
+                                description: Next server address for PXE boot.
+                                type: string
+                              option-data:
+                                description: Subnet-level DHCP option data.
+                                items:
+                                  description: OptionData defines a DHCP option value.
+                                  properties:
+                                    always-send:
+                                      description: Always include this option in responses.
+                                      type: boolean
+                                    code:
+                                      description: Numeric option code.
+                                      format: int32
+                                      type: integer
+                                    csv-format:
+                                      description: Whether data is in comma-separated
+                                        format.
+                                      type: boolean
+                                    data:
+                                      description: Option data value as text or hexadecimal.
+                                      type: string
+                                    name:
+                                      description: Option name (e.g., "domain-name-servers",
+                                        "routers").
+                                      type: string
+                                    never-send:
+                                      description: Never include this option in responses.
+                                      type: boolean
+                                    space:
+                                      description: 'Option space (default: "dhcp4"
+                                        or "dhcp6").'
+                                      type: string
+                                  type: object
+                                type: array
+                              pools:
+                                description: Address pools for dynamic allocation.
+                                items:
+                                  description: Pool4 defines an IPv4 address pool
+                                    for dynamic allocation.
+                                  properties:
+                                    client-class:
+                                      description: Client class required to use this
+                                        pool.
+                                      type: string
+                                    option-data:
+                                      description: Pool-level DHCP option data.
+                                      items:
+                                        description: OptionData defines a DHCP option
+                                          value.
+                                        properties:
+                                          always-send:
+                                            description: Always include this option
+                                              in responses.
+                                            type: boolean
+                                          code:
+                                            description: Numeric option code.
+                                            format: int32
+                                            type: integer
+                                          csv-format:
+                                            description: Whether data is in comma-separated
+                                              format.
+                                            type: boolean
+                                          data:
+                                            description: Option data value as text
+                                              or hexadecimal.
+                                            type: string
+                                          name:
+                                            description: Option name (e.g., "domain-name-servers",
+                                              "routers").
+                                            type: string
+                                          never-send:
+                                            description: Never include this option
+                                              in responses.
+                                            type: boolean
+                                          space:
+                                            description: 'Option space (default: "dhcp4"
+                                              or "dhcp6").'
+                                            type: string
+                                        type: object
+                                      type: array
+                                    pool:
+                                      description: Address range (e.g., "192.0.2.1
+                                        - 192.0.2.200" or "192.0.2.0/26").
+                                      type: string
+                                    require-client-classes:
+                                      description: Client classes that must be evaluated
+                                        for this pool.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - pool
+                                  type: object
+                                type: array
+                              rebind-timer:
+                                description: Rebind timer (T2) in seconds.
+                                format: int32
+                                type: integer
+                              relay:
+                                description: Relay agent configuration.
+                                properties:
+                                  ip-addresses:
+                                    description: Relay agent IP addresses.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              renew-timer:
+                                description: Renew timer (T1) in seconds.
+                                format: int32
+                                type: integer
+                              require-client-classes:
+                                description: Client classes to evaluate for this subnet.
+                                items:
+                                  type: string
+                                type: array
+                              reservation-mode:
+                                description: Host reservation mode.
+                                enum:
+                                - all
+                                - out-of-pool
+                                - global
+                                - disabled
+                                type: string
+                              reservations:
+                                description: Host reservations within this subnet.
+                                items:
+                                  description: Reservation defines a DHCP host reservation.
+                                  properties:
+                                    boot-file-name:
+                                      description: Boot file name (DHCPv4 PXE boot).
+                                      type: string
+                                    circuit-id:
+                                      description: RAI circuit identifier (DHCPv4
+                                        only).
+                                      type: string
+                                    client-classes:
+                                      description: Client classes to assign to this
+                                        host.
+                                      items:
+                                        type: string
+                                      type: array
+                                    client-id:
+                                      description: DHCP Client Identifier.
+                                      type: string
+                                    duid:
+                                      description: DHCP Unique Identifier.
+                                      type: string
+                                    flex-id:
+                                      description: Flex identifier.
+                                      type: string
+                                    hostname:
+                                      description: Hostname to assign to the client.
+                                      type: string
+                                    hw-address:
+                                      description: Hardware (MAC) address identifier.
+                                      type: string
+                                    ip-address:
+                                      description: IPv4 address to reserve (DHCPv4
+                                        only).
+                                      type: string
+                                    ip-addresses:
+                                      description: IPv6 addresses to reserve (DHCPv6
+                                        only).
+                                      items:
+                                        type: string
+                                      type: array
+                                    next-server:
+                                      description: Next server address (DHCPv4 PXE
+                                        boot).
+                                      type: string
+                                    option-data:
+                                      description: DHCP options for this reservation.
+                                      items:
+                                        description: OptionData defines a DHCP option
+                                          value.
+                                        properties:
+                                          always-send:
+                                            description: Always include this option
+                                              in responses.
+                                            type: boolean
+                                          code:
+                                            description: Numeric option code.
+                                            format: int32
+                                            type: integer
+                                          csv-format:
+                                            description: Whether data is in comma-separated
+                                              format.
+                                            type: boolean
+                                          data:
+                                            description: Option data value as text
+                                              or hexadecimal.
+                                            type: string
+                                          name:
+                                            description: Option name (e.g., "domain-name-servers",
+                                              "routers").
+                                            type: string
+                                          never-send:
+                                            description: Never include this option
+                                              in responses.
+                                            type: boolean
+                                          space:
+                                            description: 'Option space (default: "dhcp4"
+                                              or "dhcp6").'
+                                            type: string
+                                        type: object
+                                      type: array
+                                    prefixes:
+                                      description: Prefix delegation prefixes (DHCPv6
+                                        only).
+                                      items:
+                                        type: string
+                                      type: array
+                                    server-hostname:
+                                      description: Server hostname (DHCPv4).
+                                      type: string
+                                  type: object
+                                type: array
+                              server-hostname:
+                                description: Server hostname for PXE boot.
+                                type: string
+                              subnet:
+                                description: Subnet prefix in CIDR notation (e.g.,
+                                  "192.168.1.0/24").
+                                pattern: ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$
+                                type: string
+                              user-context:
+                                description: Arbitrary user context data.
+                                type: string
+                              valid-lifetime:
+                                description: Valid lease lifetime in seconds for this
+                                  subnet.
+                                format: int32
+                                type: integer
+                            required:
+                            - id
+                            - subnet
+                            type: object
+                          type: array
+                        valid-lifetime:
+                          description: Valid lease lifetime in seconds.
+                          format: int32
+                          type: integer
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  stork:
+                    description: |-
+                      Stork agent sidecar for monitoring and Prometheus metrics.
+                      When enabled, a stork-agent container is injected alongside the Kea daemon.
+                    properties:
+                      enabled:
+                        default: false
+                        description: Enable the Stork agent sidecar.
+                        type: boolean
+                      env:
+                        description: Extra environment variables passed to the stork-agent
+                          container.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: |-
+                          Stork agent container image.
+                          Defaults to quay.io/mooyeg/stork-agent:v2.4.0 if not specified.
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy for the stork-agent container.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      port:
+                        default: 8080
+                        description: Port for the Stork agent gRPC listener (stork-server
+                          connects here).
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      prometheusPort:
+                        default: 9547
+                        description: Port for the Prometheus Kea metrics exporter.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      resources:
+                        description: CPU and memory resources for the stork-agent
+                          container.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      serverTokenSecretRef:
+                        description: |-
+                          Reference to a Secret containing the Stork server access token.
+                          The Secret must have a key "token". Used for non-interactive agent registration.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      serverURL:
+                        description: |-
+                          URL of the Stork server to register with (e.g., "http://stork-server:8080").
+                          If empty, the agent starts without server registration (Prometheus-only mode).
+                        type: string
+                      storkServerRef:
+                        description: |-
+                          Reference to a KeaStorkServer CR in the same namespace. When set, the operator
+                          auto-discovers the server URL and token, overriding serverURL and serverTokenSecretRef.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - enabled
+                    type: object
+                  subnet4:
+                    description: DHCPv4 subnet definitions.
+                    items:
+                      description: Subnet4 defines a DHCPv4 subnet configuration.
+                      properties:
+                        authoritative:
+                          description: Whether this server is authoritative for the
+                            subnet.
+                          type: boolean
+                        boot-file-name:
+                          description: Boot file name for PXE boot.
+                          type: string
+                        client-class:
+                          description: Client class required to use this subnet.
+                          type: string
+                        id:
+                          description: Unique subnet identifier. Must be positive.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        interface:
+                          description: Network interface to listen on for this subnet.
+                          type: string
+                        match-client-id:
+                          description: Match client by client-id.
+                          type: boolean
+                        max-valid-lifetime:
+                          description: Maximum valid lifetime.
+                          format: int32
+                          type: integer
+                        min-valid-lifetime:
+                          description: Minimum valid lifetime.
+                          format: int32
+                          type: integer
+                        next-server:
+                          description: Next server address for PXE boot.
+                          type: string
+                        option-data:
+                          description: Subnet-level DHCP option data.
+                          items:
+                            description: OptionData defines a DHCP option value.
+                            properties:
+                              always-send:
+                                description: Always include this option in responses.
+                                type: boolean
+                              code:
+                                description: Numeric option code.
+                                format: int32
+                                type: integer
+                              csv-format:
+                                description: Whether data is in comma-separated format.
+                                type: boolean
+                              data:
+                                description: Option data value as text or hexadecimal.
+                                type: string
+                              name:
+                                description: Option name (e.g., "domain-name-servers",
+                                  "routers").
+                                type: string
+                              never-send:
+                                description: Never include this option in responses.
+                                type: boolean
+                              space:
+                                description: 'Option space (default: "dhcp4" or "dhcp6").'
+                                type: string
+                            type: object
+                          type: array
+                        pools:
+                          description: Address pools for dynamic allocation.
+                          items:
+                            description: Pool4 defines an IPv4 address pool for dynamic
+                              allocation.
+                            properties:
+                              client-class:
+                                description: Client class required to use this pool.
+                                type: string
+                              option-data:
+                                description: Pool-level DHCP option data.
+                                items:
+                                  description: OptionData defines a DHCP option value.
+                                  properties:
+                                    always-send:
+                                      description: Always include this option in responses.
+                                      type: boolean
+                                    code:
+                                      description: Numeric option code.
+                                      format: int32
+                                      type: integer
+                                    csv-format:
+                                      description: Whether data is in comma-separated
+                                        format.
+                                      type: boolean
+                                    data:
+                                      description: Option data value as text or hexadecimal.
+                                      type: string
+                                    name:
+                                      description: Option name (e.g., "domain-name-servers",
+                                        "routers").
+                                      type: string
+                                    never-send:
+                                      description: Never include this option in responses.
+                                      type: boolean
+                                    space:
+                                      description: 'Option space (default: "dhcp4"
+                                        or "dhcp6").'
+                                      type: string
+                                  type: object
+                                type: array
+                              pool:
+                                description: Address range (e.g., "192.0.2.1 - 192.0.2.200"
+                                  or "192.0.2.0/26").
+                                type: string
+                              require-client-classes:
+                                description: Client classes that must be evaluated
+                                  for this pool.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - pool
+                            type: object
+                          type: array
+                        rebind-timer:
+                          description: Rebind timer (T2) in seconds.
+                          format: int32
+                          type: integer
+                        relay:
+                          description: Relay agent configuration.
+                          properties:
+                            ip-addresses:
+                              description: Relay agent IP addresses.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        renew-timer:
+                          description: Renew timer (T1) in seconds.
+                          format: int32
+                          type: integer
+                        require-client-classes:
+                          description: Client classes to evaluate for this subnet.
+                          items:
+                            type: string
+                          type: array
+                        reservation-mode:
+                          description: Host reservation mode.
+                          enum:
+                          - all
+                          - out-of-pool
+                          - global
+                          - disabled
+                          type: string
+                        reservations:
+                          description: Host reservations within this subnet.
+                          items:
+                            description: Reservation defines a DHCP host reservation.
+                            properties:
+                              boot-file-name:
+                                description: Boot file name (DHCPv4 PXE boot).
+                                type: string
+                              circuit-id:
+                                description: RAI circuit identifier (DHCPv4 only).
+                                type: string
+                              client-classes:
+                                description: Client classes to assign to this host.
+                                items:
+                                  type: string
+                                type: array
+                              client-id:
+                                description: DHCP Client Identifier.
+                                type: string
+                              duid:
+                                description: DHCP Unique Identifier.
+                                type: string
+                              flex-id:
+                                description: Flex identifier.
+                                type: string
+                              hostname:
+                                description: Hostname to assign to the client.
+                                type: string
+                              hw-address:
+                                description: Hardware (MAC) address identifier.
+                                type: string
+                              ip-address:
+                                description: IPv4 address to reserve (DHCPv4 only).
+                                type: string
+                              ip-addresses:
+                                description: IPv6 addresses to reserve (DHCPv6 only).
+                                items:
+                                  type: string
+                                type: array
+                              next-server:
+                                description: Next server address (DHCPv4 PXE boot).
+                                type: string
+                              option-data:
+                                description: DHCP options for this reservation.
+                                items:
+                                  description: OptionData defines a DHCP option value.
+                                  properties:
+                                    always-send:
+                                      description: Always include this option in responses.
+                                      type: boolean
+                                    code:
+                                      description: Numeric option code.
+                                      format: int32
+                                      type: integer
+                                    csv-format:
+                                      description: Whether data is in comma-separated
+                                        format.
+                                      type: boolean
+                                    data:
+                                      description: Option data value as text or hexadecimal.
+                                      type: string
+                                    name:
+                                      description: Option name (e.g., "domain-name-servers",
+                                        "routers").
+                                      type: string
+                                    never-send:
+                                      description: Never include this option in responses.
+                                      type: boolean
+                                    space:
+                                      description: 'Option space (default: "dhcp4"
+                                        or "dhcp6").'
+                                      type: string
+                                  type: object
+                                type: array
+                              prefixes:
+                                description: Prefix delegation prefixes (DHCPv6 only).
+                                items:
+                                  type: string
+                                type: array
+                              server-hostname:
+                                description: Server hostname (DHCPv4).
+                                type: string
+                            type: object
+                          type: array
+                        server-hostname:
+                          description: Server hostname for PXE boot.
+                          type: string
+                        subnet:
+                          description: Subnet prefix in CIDR notation (e.g., "192.168.1.0/24").
+                          pattern: ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$
+                          type: string
+                        user-context:
+                          description: Arbitrary user context data.
+                          type: string
+                        valid-lifetime:
+                          description: Valid lease lifetime in seconds for this subnet.
+                          format: int32
+                          type: integer
+                      required:
+                      - id
+                      - subnet
+                      type: object
+                    type: array
+                  t1-percent:
+                    description: T1 percentage of valid-lifetime (0.0-1.0). Used when
+                      calculate-tee-times is true.
+                    type: string
+                  t2-percent:
+                    description: T2 percentage of valid-lifetime (0.0-1.0). Used when
+                      calculate-tee-times is true.
+                    type: string
+                  valid-lifetime:
+                    default: 4000
+                    description: Default valid lease lifetime in seconds.
+                    format: int32
+                    type: integer
+                required:
+                - interfaces-config
+                type: object
+              dhcp6:
+                description: DHCPv6 server configuration. When set, creates a KeaDhcp6Server.
+                properties:
+                  calculate-tee-times:
+                    description: Automatically calculate T1 and T2.
+                    type: boolean
+                  client-classes:
+                    description: Client classification rules.
+                    items:
+                      description: ClientClass defines a DHCP client classification
+                        rule.
+                      properties:
+                        max-valid-lifetime:
+                          description: Maximum valid lifetime.
+                          format: int32
+                          type: integer
+                        min-valid-lifetime:
+                          description: Minimum valid lifetime.
+                          format: int32
+                          type: integer
+                        name:
+                          description: Unique name of the client class.
+                          type: string
+                        only-if-required:
+                          description: Only use this class when explicitly required
+                            by another class.
+                          type: boolean
+                        option-data:
+                          description: DHCP options specific to this class.
+                          items:
+                            description: OptionData defines a DHCP option value.
+                            properties:
+                              always-send:
+                                description: Always include this option in responses.
+                                type: boolean
+                              code:
+                                description: Numeric option code.
+                                format: int32
+                                type: integer
+                              csv-format:
+                                description: Whether data is in comma-separated format.
+                                type: boolean
+                              data:
+                                description: Option data value as text or hexadecimal.
+                                type: string
+                              name:
+                                description: Option name (e.g., "domain-name-servers",
+                                  "routers").
+                                type: string
+                              never-send:
+                                description: Never include this option in responses.
+                                type: boolean
+                              space:
+                                description: 'Option space (default: "dhcp4" or "dhcp6").'
+                                type: string
+                            type: object
+                          type: array
+                        test:
+                          description: Boolean expression for class membership testing.
+                          type: string
+                        valid-lifetime:
+                          description: Valid lifetime for clients in this class.
+                          format: int32
+                          type: integer
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  container:
+                    description: Container configuration (image, resources, pull policy).
+                    properties:
+                      image:
+                        description: |-
+                          Container image override. Defaults to the per-component ISC Kea image
+                          (e.g., kea-dhcp4, kea-dhcp6, kea-ctrl-agent, kea-dhcp-ddns).
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets.
+                        items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      resources:
+                        description: CPU and memory resource requirements.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    type: object
+                  control-socket:
+                    description: Control socket configuration.
+                    properties:
+                      socket-address:
+                        description: |-
+                          HTTP socket bind address (for http type). Defaults to "127.0.0.1".
+                          Set to "0.0.0.0" for HA peer communication.
+                        type: string
+                      socket-name:
+                        description: UNIX socket file path (for unix type).
+                        type: string
+                      socket-port:
+                        description: HTTP socket port (for http type).
+                        format: int32
+                        type: integer
+                      socket-type:
+                        description: 'Socket type: "unix" for UNIX domain socket,
+                          "http" for HTTP.'
+                        enum:
+                        - unix
+                        - http
+                        type: string
+                    required:
+                    - socket-type
+                    type: object
+                  ddns-qualifying-suffix:
+                    description: DDNS qualifying suffix.
+                    type: string
+                  ddns-send-updates:
+                    description: DDNS send updates.
+                    type: boolean
+                  high-availability:
+                    description: High Availability configuration.
+                    properties:
+                      delayed-updates-limit:
+                        description: Delayed updates limit.
+                        format: int32
+                        type: integer
+                      heartbeat-delay:
+                        default: 10000
+                        description: Heartbeat interval in milliseconds.
+                        format: int32
+                        type: integer
+                      max-ack-delay:
+                        default: 10000
+                        description: Maximum time to wait for an acknowledgment in
+                          milliseconds.
+                        format: int32
+                        type: integer
+                      max-response-delay:
+                        default: 60000
+                        description: |-
+                          Maximum time to wait for a response from a partner in milliseconds.
+                          Should be greater than heartbeat-delay.
+                        format: int32
+                        type: integer
+                      max-unacked-clients:
+                        default: 10
+                        description: |-
+                          Maximum number of unacknowledged clients before failover.
+                          Set to 0 for immediate failover on connection loss.
+                        format: int32
+                        type: integer
+                      mode:
+                        default: load-balancing
+                        description: HA operating mode.
+                        enum:
+                        - load-balancing
+                        - hot-standby
+                        type: string
+                      multi-threading:
+                        description: Multi-threading configuration.
+                        properties:
+                          enable-multi-threading:
+                            description: Enable multi-threading for HA.
+                            type: boolean
+                          http-client-threads:
+                            description: Number of HTTP client threads.
+                            format: int32
+                            type: integer
+                          http-listener-threads:
+                            description: Number of HTTP listener threads.
+                            format: int32
+                            type: integer
+                        type: object
+                      peers:
+                        description: 'HA peers (at least 2: this server and partner).'
+                        items:
+                          description: HAPeer defines a peer in the Kea HA cluster.
+                          properties:
+                            address:
+                              description: |-
+                                Static IP address to assign to this peer's pod on the NAD interface.
+                                Must be within the subnet but outside the DHCP pool range.
+                                If omitted, the operator auto-assigns an IP based on the pod ordinal
+                                (subnet base + ordinal + 2).
+                              type: string
+                            auto-failover:
+                              default: true
+                              description: Enable automatic failover for this peer.
+                              type: boolean
+                            name:
+                              description: Peer name. Must be unique in the HA cluster.
+                              type: string
+                            role:
+                              description: Peer role in the HA cluster.
+                              enum:
+                              - primary
+                              - secondary
+                              - standby
+                              - backup
+                              type: string
+                            url:
+                              description: |-
+                                URL of the peer's control agent (e.g., "http://peer:8000/").
+                                If omitted, the operator auto-generates it from the StatefulSet headless
+                                Service DNS name: http://<sts>-<ordinal>.<headless>.<ns>.svc.cluster.local:<port>/
+                              type: string
+                          required:
+                          - name
+                          - role
+                          type: object
+                        minItems: 2
+                        type: array
+                      send-lease-updates:
+                        description: Send lease updates to partner.
+                        type: boolean
+                      sync-leases:
+                        description: Sync leases on startup.
+                        type: boolean
+                      sync-page-limit:
+                        description: Sync page limit.
+                        format: int32
+                        type: integer
+                      sync-timeout:
+                        description: Sync timeout in milliseconds.
+                        format: int32
+                        type: integer
+                      this-server-name:
+                        description: Name of this server in the HA cluster. Must match
+                          one of the peer names.
+                        type: string
+                      tls:
+                        description: TLS configuration for HA peer communication.
+                        properties:
+                          certRequired:
+                            description: Whether client certificates are required.
+                            type: boolean
+                          secretRef:
+                            description: |-
+                              Reference to a kubernetes.io/tls Secret containing TLS certificates.
+                              The Secret must have keys "tls.crt", "tls.key", and optionally "ca.crt".
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        required:
+                        - secretRef
+                        type: object
+                    required:
+                    - peers
+                    - this-server-name
+                    type: object
+                  hooks-libraries:
+                    description: Hook libraries to load.
+                    items:
+                      description: HookLibrary defines a Kea hook library to load.
+                      properties:
+                        library:
+                          description: Full path to the hook library .so file inside
+                            the container.
+                          type: string
+                        parameters:
+                          description: Parameters passed to the hook library as arbitrary
+                            JSON.
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - library
+                      type: object
+                    type: array
+                  host-reservation-identifiers:
+                    description: Host reservation identifier order.
+                    items:
+                      type: string
+                    type: array
+                  hostNetwork:
+                    description: Enable host networking.
+                    type: boolean
+                  hosts-database:
+                    description: Host reservations database (single source).
+                    properties:
+                      connect-timeout:
+                        description: Connection timeout in seconds.
+                        format: int32
+                        type: integer
+                      credentialsSecretRef:
+                        description: |-
+                          Reference to a Secret containing database credentials.
+                          The Secret must have keys "username" and "password".
+                          Required when type is "mysql" or "postgresql".
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      host:
+                        description: Database host address.
+                        type: string
+                      lfc-interval:
+                        description: Lease File Cleanup interval in seconds (memfile
+                          only).
+                        format: int32
+                        type: integer
+                      max-reconnect-tries:
+                        description: Maximum number of reconnect attempts.
+                        format: int32
+                        type: integer
+                      max-row-errors:
+                        description: Maximum acceptable row errors during load.
+                        format: int32
+                        type: integer
+                      name:
+                        description: Database name or memfile path.
+                        type: string
+                      on-fail:
+                        description: Action on database connection failure.
+                        enum:
+                        - stop-retry-exit
+                        - serve-retry-exit
+                        - serve-retry-continue
+                        type: string
+                      persist:
+                        description: Persist leases to disk (memfile only).
+                        type: boolean
+                      port:
+                        description: Database port number.
+                        format: int32
+                        type: integer
+                      read-timeout:
+                        description: Read timeout in seconds (MySQL only).
+                        format: int32
+                        type: integer
+                      readonly:
+                        description: Read-only mode (hosts-database only).
+                        type: boolean
+                      reconnect-wait-time:
+                        description: Wait time between reconnect attempts in milliseconds.
+                        format: int32
+                        type: integer
+                      retry-on-startup:
+                        description: Retry database connection at startup.
+                        type: boolean
+                      tcp-user-timeout:
+                        description: TCP user timeout in seconds (PostgreSQL only).
+                        format: int32
+                        type: integer
+                      type:
+                        description: Type of the database backend.
+                        enum:
+                        - memfile
+                        - mysql
+                        - postgresql
+                        type: string
+                      write-timeout:
+                        description: Write timeout in seconds (MySQL only).
+                        format: int32
+                        type: integer
+                    required:
+                    - type
+                    type: object
+                  hosts-databases:
+                    description: Host reservations databases (multiple sources).
+                    items:
+                      description: DatabaseConfig defines database connection parameters
+                        used by lease-database and hosts-database.
+                      properties:
+                        connect-timeout:
+                          description: Connection timeout in seconds.
+                          format: int32
+                          type: integer
+                        credentialsSecretRef:
+                          description: |-
+                            Reference to a Secret containing database credentials.
+                            The Secret must have keys "username" and "password".
+                            Required when type is "mysql" or "postgresql".
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        host:
+                          description: Database host address.
+                          type: string
+                        lfc-interval:
+                          description: Lease File Cleanup interval in seconds (memfile
+                            only).
+                          format: int32
+                          type: integer
+                        max-reconnect-tries:
+                          description: Maximum number of reconnect attempts.
+                          format: int32
+                          type: integer
+                        max-row-errors:
+                          description: Maximum acceptable row errors during load.
+                          format: int32
+                          type: integer
+                        name:
+                          description: Database name or memfile path.
+                          type: string
+                        on-fail:
+                          description: Action on database connection failure.
+                          enum:
+                          - stop-retry-exit
+                          - serve-retry-exit
+                          - serve-retry-continue
+                          type: string
+                        persist:
+                          description: Persist leases to disk (memfile only).
+                          type: boolean
+                        port:
+                          description: Database port number.
+                          format: int32
+                          type: integer
+                        read-timeout:
+                          description: Read timeout in seconds (MySQL only).
+                          format: int32
+                          type: integer
+                        readonly:
+                          description: Read-only mode (hosts-database only).
+                          type: boolean
+                        reconnect-wait-time:
+                          description: Wait time between reconnect attempts in milliseconds.
+                          format: int32
+                          type: integer
+                        retry-on-startup:
+                          description: Retry database connection at startup.
+                          type: boolean
+                        tcp-user-timeout:
+                          description: TCP user timeout in seconds (PostgreSQL only).
+                          format: int32
+                          type: integer
+                        type:
+                          description: Type of the database backend.
+                          enum:
+                          - memfile
+                          - mysql
+                          - postgresql
+                          type: string
+                        write-timeout:
+                          description: Write timeout in seconds (MySQL only).
+                          format: int32
+                          type: integer
+                      required:
+                      - type
+                      type: object
+                    type: array
+                  interfaces-config:
+                    description: Network interface configuration.
+                    properties:
+                      dhcp-socket-type:
+                        description: 'DHCP socket type: "raw" for raw sockets or "udp"
+                          for UDP sockets.'
+                        enum:
+                        - raw
+                        - udp
+                        type: string
+                      interfaces:
+                        description: |-
+                          List of interface names or interface/address pairs to listen on.
+                          Interface names must contain only alphanumeric characters, hyphens, underscores, dots, or slashes.
+                        items:
+                          pattern: ^[a-zA-Z0-9._/-]+$
+                          type: string
+                        minItems: 1
+                        type: array
+                      outbound-interface:
+                        description: Outbound interface selection method.
+                        enum:
+                        - same-as-inbound
+                        - use-routing
+                        type: string
+                      re-detect:
+                        description: Re-detect interfaces on reconfiguration.
+                        type: boolean
+                      service-sockets-max-retries:
+                        description: Maximum number of socket binding retries.
+                        format: int32
+                        type: integer
+                      service-sockets-require-all:
+                        description: Require all interfaces to bind successfully.
+                        type: boolean
+                      service-sockets-retry-wait-time:
+                        description: Milliseconds to wait between socket binding retries.
+                        format: int32
+                        type: integer
+                    required:
+                    - interfaces
+                    type: object
+                  lease-database:
+                    description: Lease database configuration.
+                    properties:
+                      connect-timeout:
+                        description: Connection timeout in seconds.
+                        format: int32
+                        type: integer
+                      credentialsSecretRef:
+                        description: |-
+                          Reference to a Secret containing database credentials.
+                          The Secret must have keys "username" and "password".
+                          Required when type is "mysql" or "postgresql".
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      host:
+                        description: Database host address.
+                        type: string
+                      lfc-interval:
+                        description: Lease File Cleanup interval in seconds (memfile
+                          only).
+                        format: int32
+                        type: integer
+                      max-reconnect-tries:
+                        description: Maximum number of reconnect attempts.
+                        format: int32
+                        type: integer
+                      max-row-errors:
+                        description: Maximum acceptable row errors during load.
+                        format: int32
+                        type: integer
+                      name:
+                        description: Database name or memfile path.
+                        type: string
+                      on-fail:
+                        description: Action on database connection failure.
+                        enum:
+                        - stop-retry-exit
+                        - serve-retry-exit
+                        - serve-retry-continue
+                        type: string
+                      persist:
+                        description: Persist leases to disk (memfile only).
+                        type: boolean
+                      port:
+                        description: Database port number.
+                        format: int32
+                        type: integer
+                      read-timeout:
+                        description: Read timeout in seconds (MySQL only).
+                        format: int32
+                        type: integer
+                      readonly:
+                        description: Read-only mode (hosts-database only).
+                        type: boolean
+                      reconnect-wait-time:
+                        description: Wait time between reconnect attempts in milliseconds.
+                        format: int32
+                        type: integer
+                      retry-on-startup:
+                        description: Retry database connection at startup.
+                        type: boolean
+                      tcp-user-timeout:
+                        description: TCP user timeout in seconds (PostgreSQL only).
+                        format: int32
+                        type: integer
+                      type:
+                        description: Type of the database backend.
+                        enum:
+                        - memfile
+                        - mysql
+                        - postgresql
+                        type: string
+                      write-timeout:
+                        description: Write timeout in seconds (MySQL only).
+                        format: int32
+                        type: integer
+                    required:
+                    - type
+                    type: object
+                  loggers:
+                    description: Logging configuration.
+                    items:
+                      description: LoggerConfig defines logging configuration for
+                        a Kea daemon.
+                      properties:
+                        debuglevel:
+                          description: Debug verbosity level (0-99, only used when
+                            severity=DEBUG).
+                          format: int32
+                          maximum: 99
+                          minimum: 0
+                          type: integer
+                        name:
+                          description: Logger component name (e.g., "kea-dhcp4", "kea-dhcp6").
+                          type: string
+                        output-options:
+                          description: Output destinations for log messages.
+                          items:
+                            description: LogOutputOption defines where log messages
+                              are written.
+                            properties:
+                              flush:
+                                description: Flush output after each log message.
+                                type: boolean
+                              maxsize:
+                                description: Maximum log file size before rotation
+                                  in bytes.
+                                format: int64
+                                type: integer
+                              maxver:
+                                description: Maximum number of rotated log files to
+                                  keep.
+                                format: int32
+                                type: integer
+                              output:
+                                description: 'Output destination: "stdout", "stderr",
+                                  "syslog", "syslog:name", or a file path.'
+                                type: string
+                              pattern:
+                                description: Log message pattern.
+                                type: string
+                            required:
+                            - output
+                            type: object
+                          type: array
+                        severity:
+                          default: INFO
+                          description: Log severity level.
+                          enum:
+                          - FATAL
+                          - ERROR
+                          - WARN
+                          - INFO
+                          - DEBUG
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  max-valid-lifetime:
+                    description: Maximum valid lifetime.
+                    format: int32
+                    type: integer
+                  min-valid-lifetime:
+                    description: Minimum valid lifetime.
+                    format: int32
+                    type: integer
+                  multi-threading:
+                    description: Multi-threading configuration.
+                    properties:
+                      enable-multi-threading:
+                        description: Enable multi-threading.
+                        type: boolean
+                      packet-queue-size:
+                        description: Packet queue size.
+                        format: int32
+                        type: integer
+                      thread-pool-size:
+                        description: Thread pool size.
+                        format: int32
+                        type: integer
+                    type: object
+                  option-data:
+                    description: Global DHCP option data.
+                    items:
+                      description: OptionData defines a DHCP option value.
+                      properties:
+                        always-send:
+                          description: Always include this option in responses.
+                          type: boolean
+                        code:
+                          description: Numeric option code.
+                          format: int32
+                          type: integer
+                        csv-format:
+                          description: Whether data is in comma-separated format.
+                          type: boolean
+                        data:
+                          description: Option data value as text or hexadecimal.
+                          type: string
+                        name:
+                          description: Option name (e.g., "domain-name-servers", "routers").
+                          type: string
+                        never-send:
+                          description: Never include this option in responses.
+                          type: boolean
+                        space:
+                          description: 'Option space (default: "dhcp4" or "dhcp6").'
+                          type: string
+                      type: object
+                    type: array
+                  option-def:
+                    description: Custom option definitions.
+                    items:
+                      description: OptionDef defines a custom DHCP option definition.
+                      properties:
+                        array:
+                          description: Whether option contains an array of values.
+                          type: boolean
+                        code:
+                          description: Numeric code assignment.
+                          format: int32
+                          type: integer
+                        encapsulate:
+                          description: Encapsulated option space name.
+                          type: string
+                        name:
+                          description: Custom option name.
+                          type: string
+                        record-types:
+                          description: Comma-separated field types for record-type
+                            options.
+                          type: string
+                        space:
+                          description: Option space this definition belongs to.
+                          type: string
+                        type:
+                          description: Data type (uint8, uint16, uint32, string, ipv4-address,
+                            boolean, binary, fqdn, record, etc.).
+                          type: string
+                      required:
+                      - code
+                      - name
+                      - type
+                      type: object
+                    type: array
+                  placement:
+                    description: Pod scheduling constraints.
+                    properties:
+                      affinity:
+                        description: Pod affinity rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and subtracting
+                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Node selector key-value pairs.
+                        type: object
+                      podAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Additional annotations to set on the pod template. Useful for
+                          network attachment definitions (e.g., k8s.v1.cni.cncf.io/networks).
+                        type: object
+                      tolerations:
+                        description: Pod tolerations.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  preferred-lifetime:
+                    description: Default preferred lifetime in seconds.
+                    format: int32
+                    type: integer
+                  rapid-commit:
+                    description: Enable rapid commit (2-message exchange).
+                    type: boolean
+                  rebind-timer:
+                    description: Rebind timer (T2) in seconds.
+                    format: int32
+                    type: integer
+                  renew-timer:
+                    description: Renew timer (T1) in seconds.
+                    format: int32
+                    type: integer
+                  replicas:
+                    default: 1
+                    description: Number of replicas.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  reservations:
+                    description: Global host reservations.
+                    items:
+                      description: Reservation defines a DHCP host reservation.
+                      properties:
+                        boot-file-name:
+                          description: Boot file name (DHCPv4 PXE boot).
+                          type: string
+                        circuit-id:
+                          description: RAI circuit identifier (DHCPv4 only).
+                          type: string
+                        client-classes:
+                          description: Client classes to assign to this host.
+                          items:
+                            type: string
+                          type: array
+                        client-id:
+                          description: DHCP Client Identifier.
+                          type: string
+                        duid:
+                          description: DHCP Unique Identifier.
+                          type: string
+                        flex-id:
+                          description: Flex identifier.
+                          type: string
+                        hostname:
+                          description: Hostname to assign to the client.
+                          type: string
+                        hw-address:
+                          description: Hardware (MAC) address identifier.
+                          type: string
+                        ip-address:
+                          description: IPv4 address to reserve (DHCPv4 only).
+                          type: string
+                        ip-addresses:
+                          description: IPv6 addresses to reserve (DHCPv6 only).
+                          items:
+                            type: string
+                          type: array
+                        next-server:
+                          description: Next server address (DHCPv4 PXE boot).
+                          type: string
+                        option-data:
+                          description: DHCP options for this reservation.
+                          items:
+                            description: OptionData defines a DHCP option value.
+                            properties:
+                              always-send:
+                                description: Always include this option in responses.
+                                type: boolean
+                              code:
+                                description: Numeric option code.
+                                format: int32
+                                type: integer
+                              csv-format:
+                                description: Whether data is in comma-separated format.
+                                type: boolean
+                              data:
+                                description: Option data value as text or hexadecimal.
+                                type: string
+                              name:
+                                description: Option name (e.g., "domain-name-servers",
+                                  "routers").
+                                type: string
+                              never-send:
+                                description: Never include this option in responses.
+                                type: boolean
+                              space:
+                                description: 'Option space (default: "dhcp4" or "dhcp6").'
+                                type: string
+                            type: object
+                          type: array
+                        prefixes:
+                          description: Prefix delegation prefixes (DHCPv6 only).
+                          items:
+                            type: string
+                          type: array
+                        server-hostname:
+                          description: Server hostname (DHCPv4).
+                          type: string
+                      type: object
+                    type: array
+                  server-tag:
+                    description: Server tag for config backend.
+                    type: string
+                  shared-networks:
+                    description: Shared networks.
+                    items:
+                      description: SharedNetwork6 defines a shared network grouping
+                        multiple IPv6 subnets.
+                      properties:
+                        client-class:
+                          description: Client class required for this network.
+                          type: string
+                        interface:
+                          description: Network interface.
+                          type: string
+                        interface-id:
+                          description: Interface ID.
+                          type: string
+                        name:
+                          description: Shared network name.
+                          type: string
+                        option-data:
+                          description: Network-level DHCP option data.
+                          items:
+                            description: OptionData defines a DHCP option value.
+                            properties:
+                              always-send:
+                                description: Always include this option in responses.
+                                type: boolean
+                              code:
+                                description: Numeric option code.
+                                format: int32
+                                type: integer
+                              csv-format:
+                                description: Whether data is in comma-separated format.
+                                type: boolean
+                              data:
+                                description: Option data value as text or hexadecimal.
+                                type: string
+                              name:
+                                description: Option name (e.g., "domain-name-servers",
+                                  "routers").
+                                type: string
+                              never-send:
+                                description: Never include this option in responses.
+                                type: boolean
+                              space:
+                                description: 'Option space (default: "dhcp4" or "dhcp6").'
+                                type: string
+                            type: object
+                          type: array
+                        preferred-lifetime:
+                          description: Preferred lifetime in seconds.
+                          format: int32
+                          type: integer
+                        rapid-commit:
+                          description: Enable rapid commit.
+                          type: boolean
+                        rebind-timer:
+                          description: Rebind timer in seconds.
+                          format: int32
+                          type: integer
+                        relay:
+                          description: Relay agent configuration.
+                          properties:
+                            ip-addresses:
+                              description: Relay agent IP addresses.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        renew-timer:
+                          description: Renew timer in seconds.
+                          format: int32
+                          type: integer
+                        subnet6:
+                          description: Subnets belonging to this shared network.
+                          items:
+                            description: Subnet6 defines a DHCPv6 subnet configuration.
+                            properties:
+                              client-class:
+                                description: Client class required for this subnet.
+                                type: string
+                              id:
+                                description: Unique subnet identifier.
+                                format: int32
+                                minimum: 1
+                                type: integer
+                              interface:
+                                description: Network interface to listen on.
+                                type: string
+                              interface-id:
+                                description: Interface ID for relay-supplied interface
+                                  identification.
+                                type: string
+                              max-valid-lifetime:
+                                description: Maximum valid lifetime.
+                                format: int32
+                                type: integer
+                              min-valid-lifetime:
+                                description: Minimum valid lifetime.
+                                format: int32
+                                type: integer
+                              option-data:
+                                description: Subnet-level DHCP option data.
+                                items:
+                                  description: OptionData defines a DHCP option value.
+                                  properties:
+                                    always-send:
+                                      description: Always include this option in responses.
+                                      type: boolean
+                                    code:
+                                      description: Numeric option code.
+                                      format: int32
+                                      type: integer
+                                    csv-format:
+                                      description: Whether data is in comma-separated
+                                        format.
+                                      type: boolean
+                                    data:
+                                      description: Option data value as text or hexadecimal.
+                                      type: string
+                                    name:
+                                      description: Option name (e.g., "domain-name-servers",
+                                        "routers").
+                                      type: string
+                                    never-send:
+                                      description: Never include this option in responses.
+                                      type: boolean
+                                    space:
+                                      description: 'Option space (default: "dhcp4"
+                                        or "dhcp6").'
+                                      type: string
+                                  type: object
+                                type: array
+                              pd-pools:
+                                description: Prefix delegation pools.
+                                items:
+                                  description: PDPool defines a prefix delegation
+                                    pool (IPv6-specific).
+                                  properties:
+                                    client-class:
+                                      description: Client class required to use this
+                                        pool.
+                                      type: string
+                                    delegated-len:
+                                      description: Length of the delegated prefix
+                                        in bits.
+                                      format: int32
+                                      maximum: 128
+                                      minimum: 1
+                                      type: integer
+                                    excluded-prefix:
+                                      description: Excluded prefix.
+                                      type: string
+                                    excluded-prefix-len:
+                                      description: Excluded prefix length.
+                                      format: int32
+                                      type: integer
+                                    option-data:
+                                      description: Pool-level DHCP option data.
+                                      items:
+                                        description: OptionData defines a DHCP option
+                                          value.
+                                        properties:
+                                          always-send:
+                                            description: Always include this option
+                                              in responses.
+                                            type: boolean
+                                          code:
+                                            description: Numeric option code.
+                                            format: int32
+                                            type: integer
+                                          csv-format:
+                                            description: Whether data is in comma-separated
+                                              format.
+                                            type: boolean
+                                          data:
+                                            description: Option data value as text
+                                              or hexadecimal.
+                                            type: string
+                                          name:
+                                            description: Option name (e.g., "domain-name-servers",
+                                              "routers").
+                                            type: string
+                                          never-send:
+                                            description: Never include this option
+                                              in responses.
+                                            type: boolean
+                                          space:
+                                            description: 'Option space (default: "dhcp4"
+                                              or "dhcp6").'
+                                            type: string
+                                        type: object
+                                      type: array
+                                    prefix:
+                                      description: Delegated prefix (e.g., "2001:db8:8::").
+                                      type: string
+                                    prefix-len:
+                                      description: Length of the prefix in bits.
+                                      format: int32
+                                      maximum: 128
+                                      minimum: 1
+                                      type: integer
+                                  required:
+                                  - delegated-len
+                                  - prefix
+                                  - prefix-len
+                                  type: object
+                                type: array
+                              pools:
+                                description: Address pools for dynamic allocation.
+                                items:
+                                  description: Pool6 defines an IPv6 address pool
+                                    for dynamic allocation.
+                                  properties:
+                                    client-class:
+                                      description: Client class required to use this
+                                        pool.
+                                      type: string
+                                    option-data:
+                                      description: Pool-level DHCP option data.
+                                      items:
+                                        description: OptionData defines a DHCP option
+                                          value.
+                                        properties:
+                                          always-send:
+                                            description: Always include this option
+                                              in responses.
+                                            type: boolean
+                                          code:
+                                            description: Numeric option code.
+                                            format: int32
+                                            type: integer
+                                          csv-format:
+                                            description: Whether data is in comma-separated
+                                              format.
+                                            type: boolean
+                                          data:
+                                            description: Option data value as text
+                                              or hexadecimal.
+                                            type: string
+                                          name:
+                                            description: Option name (e.g., "domain-name-servers",
+                                              "routers").
+                                            type: string
+                                          never-send:
+                                            description: Never include this option
+                                              in responses.
+                                            type: boolean
+                                          space:
+                                            description: 'Option space (default: "dhcp4"
+                                              or "dhcp6").'
+                                            type: string
+                                        type: object
+                                      type: array
+                                    pool:
+                                      description: Address range (e.g., "2001:db8:1::1
+                                        - 2001:db8:1::ffff").
+                                      type: string
+                                    require-client-classes:
+                                      description: Client classes that must be evaluated.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - pool
+                                  type: object
+                                type: array
+                              preferred-lifetime:
+                                description: Preferred lifetime in seconds (T_pref).
+                                format: int32
+                                type: integer
+                              rapid-commit:
+                                description: Enable rapid commit (2-message exchange).
+                                type: boolean
+                              rebind-timer:
+                                description: Rebind timer (T2) in seconds.
+                                format: int32
+                                type: integer
+                              relay:
+                                description: Relay agent configuration.
+                                properties:
+                                  ip-addresses:
+                                    description: Relay agent IP addresses.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              renew-timer:
+                                description: Renew timer (T1) in seconds.
+                                format: int32
+                                type: integer
+                              require-client-classes:
+                                description: Client classes to evaluate.
+                                items:
+                                  type: string
+                                type: array
+                              reservation-mode:
+                                description: Host reservation mode.
+                                enum:
+                                - all
+                                - out-of-pool
+                                - global
+                                - disabled
+                                type: string
+                              reservations:
+                                description: Host reservations within this subnet.
+                                items:
+                                  description: Reservation defines a DHCP host reservation.
+                                  properties:
+                                    boot-file-name:
+                                      description: Boot file name (DHCPv4 PXE boot).
+                                      type: string
+                                    circuit-id:
+                                      description: RAI circuit identifier (DHCPv4
+                                        only).
+                                      type: string
+                                    client-classes:
+                                      description: Client classes to assign to this
+                                        host.
+                                      items:
+                                        type: string
+                                      type: array
+                                    client-id:
+                                      description: DHCP Client Identifier.
+                                      type: string
+                                    duid:
+                                      description: DHCP Unique Identifier.
+                                      type: string
+                                    flex-id:
+                                      description: Flex identifier.
+                                      type: string
+                                    hostname:
+                                      description: Hostname to assign to the client.
+                                      type: string
+                                    hw-address:
+                                      description: Hardware (MAC) address identifier.
+                                      type: string
+                                    ip-address:
+                                      description: IPv4 address to reserve (DHCPv4
+                                        only).
+                                      type: string
+                                    ip-addresses:
+                                      description: IPv6 addresses to reserve (DHCPv6
+                                        only).
+                                      items:
+                                        type: string
+                                      type: array
+                                    next-server:
+                                      description: Next server address (DHCPv4 PXE
+                                        boot).
+                                      type: string
+                                    option-data:
+                                      description: DHCP options for this reservation.
+                                      items:
+                                        description: OptionData defines a DHCP option
+                                          value.
+                                        properties:
+                                          always-send:
+                                            description: Always include this option
+                                              in responses.
+                                            type: boolean
+                                          code:
+                                            description: Numeric option code.
+                                            format: int32
+                                            type: integer
+                                          csv-format:
+                                            description: Whether data is in comma-separated
+                                              format.
+                                            type: boolean
+                                          data:
+                                            description: Option data value as text
+                                              or hexadecimal.
+                                            type: string
+                                          name:
+                                            description: Option name (e.g., "domain-name-servers",
+                                              "routers").
+                                            type: string
+                                          never-send:
+                                            description: Never include this option
+                                              in responses.
+                                            type: boolean
+                                          space:
+                                            description: 'Option space (default: "dhcp4"
+                                              or "dhcp6").'
+                                            type: string
+                                        type: object
+                                      type: array
+                                    prefixes:
+                                      description: Prefix delegation prefixes (DHCPv6
+                                        only).
+                                      items:
+                                        type: string
+                                      type: array
+                                    server-hostname:
+                                      description: Server hostname (DHCPv4).
+                                      type: string
+                                  type: object
+                                type: array
+                              subnet:
+                                description: Subnet prefix in CIDR notation (e.g.,
+                                  "2001:db8:1::/64").
+                                pattern: ^[a-fA-F0-9:]+/[0-9]{1,3}$
+                                type: string
+                              valid-lifetime:
+                                description: Valid lease lifetime in seconds.
+                                format: int32
+                                type: integer
+                            required:
+                            - id
+                            - subnet
+                            type: object
+                          type: array
+                        valid-lifetime:
+                          description: Valid lease lifetime in seconds.
+                          format: int32
+                          type: integer
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  stork:
+                    description: |-
+                      Stork agent sidecar for monitoring and Prometheus metrics.
+                      When enabled, a stork-agent container is injected alongside the Kea daemon.
+                    properties:
+                      enabled:
+                        default: false
+                        description: Enable the Stork agent sidecar.
+                        type: boolean
+                      env:
+                        description: Extra environment variables passed to the stork-agent
+                          container.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the environment variable.
+                                May consist of any printable ASCII characters except '='.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  description: |-
+                                    FileKeyRef selects a key of the env file.
+                                    Requires the EnvFiles feature gate to be enabled.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        The key within the env file. An invalid key will prevent the pod from starting.
+                                        The keys defined within a source may consist of any printable ASCII characters except '='.
+                                        During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                      type: string
+                                    optional:
+                                      default: false
+                                      description: |-
+                                        Specify whether the file or its key must be defined. If the file or key
+                                        does not exist, then the env var is not published.
+                                        If optional is set to true and the specified key does not exist,
+                                        the environment variable will not be set in the Pod's containers.
+
+                                        If optional is set to false and the specified key does not exist,
+                                        an error will be returned during Pod creation.
+                                      type: boolean
+                                    path:
+                                      description: |-
+                                        The path within the volume from which to select the file.
+                                        Must be relative and may not contain the '..' path or start with '..'.
+                                      type: string
+                                    volumeName:
+                                      description: The name of the volume mount containing
+                                        the env file.
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: |-
+                          Stork agent container image.
+                          Defaults to quay.io/mooyeg/stork-agent:v2.4.0 if not specified.
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy for the stork-agent container.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      port:
+                        default: 8080
+                        description: Port for the Stork agent gRPC listener (stork-server
+                          connects here).
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      prometheusPort:
+                        default: 9547
+                        description: Port for the Prometheus Kea metrics exporter.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      resources:
+                        description: CPU and memory resources for the stork-agent
+                          container.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      serverTokenSecretRef:
+                        description: |-
+                          Reference to a Secret containing the Stork server access token.
+                          The Secret must have a key "token". Used for non-interactive agent registration.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      serverURL:
+                        description: |-
+                          URL of the Stork server to register with (e.g., "http://stork-server:8080").
+                          If empty, the agent starts without server registration (Prometheus-only mode).
+                        type: string
+                      storkServerRef:
+                        description: |-
+                          Reference to a KeaStorkServer CR in the same namespace. When set, the operator
+                          auto-discovers the server URL and token, overriding serverURL and serverTokenSecretRef.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - enabled
+                    type: object
+                  subnet6:
+                    description: DHCPv6 subnet definitions.
+                    items:
+                      description: Subnet6 defines a DHCPv6 subnet configuration.
+                      properties:
+                        client-class:
+                          description: Client class required for this subnet.
+                          type: string
+                        id:
+                          description: Unique subnet identifier.
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        interface:
+                          description: Network interface to listen on.
+                          type: string
+                        interface-id:
+                          description: Interface ID for relay-supplied interface identification.
+                          type: string
+                        max-valid-lifetime:
+                          description: Maximum valid lifetime.
+                          format: int32
+                          type: integer
+                        min-valid-lifetime:
+                          description: Minimum valid lifetime.
+                          format: int32
+                          type: integer
+                        option-data:
+                          description: Subnet-level DHCP option data.
+                          items:
+                            description: OptionData defines a DHCP option value.
+                            properties:
+                              always-send:
+                                description: Always include this option in responses.
+                                type: boolean
+                              code:
+                                description: Numeric option code.
+                                format: int32
+                                type: integer
+                              csv-format:
+                                description: Whether data is in comma-separated format.
+                                type: boolean
+                              data:
+                                description: Option data value as text or hexadecimal.
+                                type: string
+                              name:
+                                description: Option name (e.g., "domain-name-servers",
+                                  "routers").
+                                type: string
+                              never-send:
+                                description: Never include this option in responses.
+                                type: boolean
+                              space:
+                                description: 'Option space (default: "dhcp4" or "dhcp6").'
+                                type: string
+                            type: object
+                          type: array
+                        pd-pools:
+                          description: Prefix delegation pools.
+                          items:
+                            description: PDPool defines a prefix delegation pool (IPv6-specific).
+                            properties:
+                              client-class:
+                                description: Client class required to use this pool.
+                                type: string
+                              delegated-len:
+                                description: Length of the delegated prefix in bits.
+                                format: int32
+                                maximum: 128
+                                minimum: 1
+                                type: integer
+                              excluded-prefix:
+                                description: Excluded prefix.
+                                type: string
+                              excluded-prefix-len:
+                                description: Excluded prefix length.
+                                format: int32
+                                type: integer
+                              option-data:
+                                description: Pool-level DHCP option data.
+                                items:
+                                  description: OptionData defines a DHCP option value.
+                                  properties:
+                                    always-send:
+                                      description: Always include this option in responses.
+                                      type: boolean
+                                    code:
+                                      description: Numeric option code.
+                                      format: int32
+                                      type: integer
+                                    csv-format:
+                                      description: Whether data is in comma-separated
+                                        format.
+                                      type: boolean
+                                    data:
+                                      description: Option data value as text or hexadecimal.
+                                      type: string
+                                    name:
+                                      description: Option name (e.g., "domain-name-servers",
+                                        "routers").
+                                      type: string
+                                    never-send:
+                                      description: Never include this option in responses.
+                                      type: boolean
+                                    space:
+                                      description: 'Option space (default: "dhcp4"
+                                        or "dhcp6").'
+                                      type: string
+                                  type: object
+                                type: array
+                              prefix:
+                                description: Delegated prefix (e.g., "2001:db8:8::").
+                                type: string
+                              prefix-len:
+                                description: Length of the prefix in bits.
+                                format: int32
+                                maximum: 128
+                                minimum: 1
+                                type: integer
+                            required:
+                            - delegated-len
+                            - prefix
+                            - prefix-len
+                            type: object
+                          type: array
+                        pools:
+                          description: Address pools for dynamic allocation.
+                          items:
+                            description: Pool6 defines an IPv6 address pool for dynamic
+                              allocation.
+                            properties:
+                              client-class:
+                                description: Client class required to use this pool.
+                                type: string
+                              option-data:
+                                description: Pool-level DHCP option data.
+                                items:
+                                  description: OptionData defines a DHCP option value.
+                                  properties:
+                                    always-send:
+                                      description: Always include this option in responses.
+                                      type: boolean
+                                    code:
+                                      description: Numeric option code.
+                                      format: int32
+                                      type: integer
+                                    csv-format:
+                                      description: Whether data is in comma-separated
+                                        format.
+                                      type: boolean
+                                    data:
+                                      description: Option data value as text or hexadecimal.
+                                      type: string
+                                    name:
+                                      description: Option name (e.g., "domain-name-servers",
+                                        "routers").
+                                      type: string
+                                    never-send:
+                                      description: Never include this option in responses.
+                                      type: boolean
+                                    space:
+                                      description: 'Option space (default: "dhcp4"
+                                        or "dhcp6").'
+                                      type: string
+                                  type: object
+                                type: array
+                              pool:
+                                description: Address range (e.g., "2001:db8:1::1 -
+                                  2001:db8:1::ffff").
+                                type: string
+                              require-client-classes:
+                                description: Client classes that must be evaluated.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - pool
+                            type: object
+                          type: array
+                        preferred-lifetime:
+                          description: Preferred lifetime in seconds (T_pref).
+                          format: int32
+                          type: integer
+                        rapid-commit:
+                          description: Enable rapid commit (2-message exchange).
+                          type: boolean
+                        rebind-timer:
+                          description: Rebind timer (T2) in seconds.
+                          format: int32
+                          type: integer
+                        relay:
+                          description: Relay agent configuration.
+                          properties:
+                            ip-addresses:
+                              description: Relay agent IP addresses.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        renew-timer:
+                          description: Renew timer (T1) in seconds.
+                          format: int32
+                          type: integer
+                        require-client-classes:
+                          description: Client classes to evaluate.
+                          items:
+                            type: string
+                          type: array
+                        reservation-mode:
+                          description: Host reservation mode.
+                          enum:
+                          - all
+                          - out-of-pool
+                          - global
+                          - disabled
+                          type: string
+                        reservations:
+                          description: Host reservations within this subnet.
+                          items:
+                            description: Reservation defines a DHCP host reservation.
+                            properties:
+                              boot-file-name:
+                                description: Boot file name (DHCPv4 PXE boot).
+                                type: string
+                              circuit-id:
+                                description: RAI circuit identifier (DHCPv4 only).
+                                type: string
+                              client-classes:
+                                description: Client classes to assign to this host.
+                                items:
+                                  type: string
+                                type: array
+                              client-id:
+                                description: DHCP Client Identifier.
+                                type: string
+                              duid:
+                                description: DHCP Unique Identifier.
+                                type: string
+                              flex-id:
+                                description: Flex identifier.
+                                type: string
+                              hostname:
+                                description: Hostname to assign to the client.
+                                type: string
+                              hw-address:
+                                description: Hardware (MAC) address identifier.
+                                type: string
+                              ip-address:
+                                description: IPv4 address to reserve (DHCPv4 only).
+                                type: string
+                              ip-addresses:
+                                description: IPv6 addresses to reserve (DHCPv6 only).
+                                items:
+                                  type: string
+                                type: array
+                              next-server:
+                                description: Next server address (DHCPv4 PXE boot).
+                                type: string
+                              option-data:
+                                description: DHCP options for this reservation.
+                                items:
+                                  description: OptionData defines a DHCP option value.
+                                  properties:
+                                    always-send:
+                                      description: Always include this option in responses.
+                                      type: boolean
+                                    code:
+                                      description: Numeric option code.
+                                      format: int32
+                                      type: integer
+                                    csv-format:
+                                      description: Whether data is in comma-separated
+                                        format.
+                                      type: boolean
+                                    data:
+                                      description: Option data value as text or hexadecimal.
+                                      type: string
+                                    name:
+                                      description: Option name (e.g., "domain-name-servers",
+                                        "routers").
+                                      type: string
+                                    never-send:
+                                      description: Never include this option in responses.
+                                      type: boolean
+                                    space:
+                                      description: 'Option space (default: "dhcp4"
+                                        or "dhcp6").'
+                                      type: string
+                                  type: object
+                                type: array
+                              prefixes:
+                                description: Prefix delegation prefixes (DHCPv6 only).
+                                items:
+                                  type: string
+                                type: array
+                              server-hostname:
+                                description: Server hostname (DHCPv4).
+                                type: string
+                            type: object
+                          type: array
+                        subnet:
+                          description: Subnet prefix in CIDR notation (e.g., "2001:db8:1::/64").
+                          pattern: ^[a-fA-F0-9:]+/[0-9]{1,3}$
+                          type: string
+                        valid-lifetime:
+                          description: Valid lease lifetime in seconds.
+                          format: int32
+                          type: integer
+                      required:
+                      - id
+                      - subnet
+                      type: object
+                    type: array
+                  t1-percent:
+                    description: T1 percentage (0.0-1.0).
+                    type: string
+                  t2-percent:
+                    description: T2 percentage (0.0-1.0).
+                    type: string
+                  valid-lifetime:
+                    default: 4000
+                    description: Default valid lease lifetime in seconds.
+                    format: int32
+                    type: integer
+                required:
+                - interfaces-config
+                type: object
+              dhcpDdns:
+                description: DHCP-DDNS configuration. When set, creates a KeaDhcpDdns.
+                properties:
+                  container:
+                    description: Container configuration (image, resources, pull policy).
+                    properties:
+                      image:
+                        description: |-
+                          Container image override. Defaults to the per-component ISC Kea image
+                          (e.g., kea-dhcp4, kea-dhcp6, kea-ctrl-agent, kea-dhcp-ddns).
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets.
+                        items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      resources:
+                        description: CPU and memory resource requirements.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    type: object
+                  control-socket:
+                    description: Control socket configuration for management commands.
+                    properties:
+                      socket-address:
+                        description: |-
+                          HTTP socket bind address (for http type). Defaults to "127.0.0.1".
+                          Set to "0.0.0.0" for HA peer communication.
+                        type: string
+                      socket-name:
+                        description: UNIX socket file path (for unix type).
+                        type: string
+                      socket-port:
+                        description: HTTP socket port (for http type).
+                        format: int32
+                        type: integer
+                      socket-type:
+                        description: 'Socket type: "unix" for UNIX domain socket,
+                          "http" for HTTP.'
+                        enum:
+                        - unix
+                        - http
+                        type: string
+                    required:
+                    - socket-type
+                    type: object
+                  dns-server-timeout:
+                    default: 500
+                    description: DNS server timeout in milliseconds.
+                    format: int32
+                    type: integer
+                  forward-ddns:
+                    description: Forward DDNS domain configuration.
+                    properties:
+                      ddns-domains:
+                        description: List of DDNS domains.
+                        items:
+                          description: DDNSDomain defines a DNS domain for dynamic
+                            updates.
+                          properties:
+                            dns-servers:
+                              description: DNS servers to send updates to.
+                              items:
+                                description: DNSServer defines a DNS server endpoint
+                                  for DDNS updates.
+                                properties:
+                                  ip-address:
+                                    description: IP address of the DNS server.
+                                    type: string
+                                  port:
+                                    description: Port of the DNS server. Defaults
+                                      to 53.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - ip-address
+                                type: object
+                              type: array
+                            key-name:
+                              description: Name of the TSIG key to use for this domain.
+                              type: string
+                            name:
+                              description: DNS domain name (e.g., "example.com." —
+                                note trailing dot).
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  hooks-libraries:
+                    description: Hook libraries to load.
+                    items:
+                      description: HookLibrary defines a Kea hook library to load.
+                      properties:
+                        library:
+                          description: Full path to the hook library .so file inside
+                            the container.
+                          type: string
+                        parameters:
+                          description: Parameters passed to the hook library as arbitrary
+                            JSON.
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - library
+                      type: object
+                    type: array
+                  ip-address:
+                    default: 127.0.0.1
+                    description: IP address to listen on for NCR messages from DHCP
+                      servers.
+                    type: string
+                  loggers:
+                    description: Logging configuration.
+                    items:
+                      description: LoggerConfig defines logging configuration for
+                        a Kea daemon.
+                      properties:
+                        debuglevel:
+                          description: Debug verbosity level (0-99, only used when
+                            severity=DEBUG).
+                          format: int32
+                          maximum: 99
+                          minimum: 0
+                          type: integer
+                        name:
+                          description: Logger component name (e.g., "kea-dhcp4", "kea-dhcp6").
+                          type: string
+                        output-options:
+                          description: Output destinations for log messages.
+                          items:
+                            description: LogOutputOption defines where log messages
+                              are written.
+                            properties:
+                              flush:
+                                description: Flush output after each log message.
+                                type: boolean
+                              maxsize:
+                                description: Maximum log file size before rotation
+                                  in bytes.
+                                format: int64
+                                type: integer
+                              maxver:
+                                description: Maximum number of rotated log files to
+                                  keep.
+                                format: int32
+                                type: integer
+                              output:
+                                description: 'Output destination: "stdout", "stderr",
+                                  "syslog", "syslog:name", or a file path.'
+                                type: string
+                              pattern:
+                                description: Log message pattern.
+                                type: string
+                            required:
+                            - output
+                            type: object
+                          type: array
+                        severity:
+                          default: INFO
+                          description: Log severity level.
+                          enum:
+                          - FATAL
+                          - ERROR
+                          - WARN
+                          - INFO
+                          - DEBUG
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  ncr-format:
+                    default: JSON
+                    description: NCR format. Only "JSON" is currently supported by
+                      Kea.
+                    enum:
+                    - JSON
+                    type: string
+                  ncr-protocol:
+                    default: UDP
+                    description: NCR protocol. Only "UDP" is currently supported by
+                      Kea.
+                    enum:
+                    - UDP
+                    - TCP
+                    type: string
+                  placement:
+                    description: Pod scheduling constraints.
+                    properties:
+                      affinity:
+                        description: Pod affinity rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and subtracting
+                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Node selector key-value pairs.
+                        type: object
+                      podAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Additional annotations to set on the pod template. Useful for
+                          network attachment definitions (e.g., k8s.v1.cni.cncf.io/networks).
+                        type: object
+                      tolerations:
+                        description: Pod tolerations.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  port:
+                    default: 53001
+                    description: Port to listen on for NCR messages.
+                    format: int32
+                    type: integer
+                  replicas:
+                    default: 1
+                    description: Number of replicas.
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  reverse-ddns:
+                    description: Reverse DDNS domain configuration.
+                    properties:
+                      ddns-domains:
+                        description: List of DDNS domains.
+                        items:
+                          description: DDNSDomain defines a DNS domain for dynamic
+                            updates.
+                          properties:
+                            dns-servers:
+                              description: DNS servers to send updates to.
+                              items:
+                                description: DNSServer defines a DNS server endpoint
+                                  for DDNS updates.
+                                properties:
+                                  ip-address:
+                                    description: IP address of the DNS server.
+                                    type: string
+                                  port:
+                                    description: Port of the DNS server. Defaults
+                                      to 53.
+                                    format: int32
+                                    type: integer
+                                required:
+                                - ip-address
+                                type: object
+                              type: array
+                            key-name:
+                              description: Name of the TSIG key to use for this domain.
+                              type: string
+                            name:
+                              description: DNS domain name (e.g., "example.com." —
+                                note trailing dot).
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  tsig-keys:
+                    description: TSIG keys for authenticated DNS updates.
+                    items:
+                      description: TSIGKey defines a TSIG key for authenticated DNS
+                        updates (RFC 2845).
+                      properties:
+                        algorithm:
+                          description: TSIG algorithm (e.g., "HMAC-MD5", "HMAC-SHA256",
+                            "HMAC-SHA512").
+                          type: string
+                        digest-bits:
+                          description: Number of bits for digest truncation. 0 means
+                            no truncation.
+                          format: int32
+                          type: integer
+                        name:
+                          description: TSIG key name.
+                          type: string
+                        secretRef:
+                          description: Reference to a Secret key containing the base64-encoded
+                            TSIG secret.
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - algorithm
+                      - name
+                      type: object
+                    type: array
+                type: object
+              storkServer:
+                description: |-
+                  Stork server configuration. When set, creates a KeaStorkServer
+                  that provides a web UI for monitoring and managing Kea DHCP servers.
+                properties:
+                  container:
+                    description: Container image configuration for the Stork server.
+                    properties:
+                      image:
+                        description: |-
+                          Container image override. Defaults to the per-component ISC Kea image
+                          (e.g., kea-dhcp4, kea-dhcp6, kea-ctrl-agent, kea-dhcp-ddns).
+                        type: string
+                      imagePullPolicy:
+                        description: Image pull policy.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      imagePullSecrets:
+                        description: Image pull secrets.
+                        items:
+                          description: |-
+                            LocalObjectReference contains enough information to let you locate the
+                            referenced object inside the same namespace.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                      resources:
+                        description: CPU and memory resource requirements.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This field depends on the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                    type: object
+                  database:
+                    description: PostgreSQL database connection configuration.
+                    properties:
+                      credentialsSecretRef:
+                        description: |-
+                          Reference to a Secret containing database credentials.
+                          The Secret must have keys "username" and "password".
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      host:
+                        description: PostgreSQL host address.
+                        type: string
+                      name:
+                        default: stork
+                        description: Database name.
+                        type: string
+                      port:
+                        default: 5432
+                        description: PostgreSQL port number.
+                        format: int32
+                        type: integer
+                      sslMode:
+                        default: disable
+                        description: SSL mode for the PostgreSQL connection.
+                        enum:
+                        - disable
+                        - require
+                        - verify-ca
+                        - verify-full
+                        type: string
+                    required:
+                    - credentialsSecretRef
+                    - host
+                    type: object
+                  enableMetrics:
+                    default: true
+                    description: Enable the Prometheus metrics endpoint on the Stork
+                      server.
+                    type: boolean
+                  placement:
+                    description: Pod scheduling constraints and metadata.
+                    properties:
+                      affinity:
+                        description: Pod affinity rules.
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and subtracting
+                                  "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: Node selector key-value pairs.
+                        type: object
+                      podAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Additional annotations to set on the pod template. Useful for
+                          network attachment definitions (e.g., k8s.v1.cni.cncf.io/networks).
+                        type: object
+                      tolerations:
+                        description: Pod tolerations.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  port:
+                    default: 8080
+                    description: Port for the Stork server REST API and web UI.
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                  replicas:
+                    default: 1
+                    description: Number of Stork server replicas (typically 1).
+                    format: int32
+                    minimum: 1
+                    type: integer
+                required:
+                - database
+                type: object
+            type: object
+          status:
+            description: KeaServerStatus aggregates status from all deployed Kea components.
+            properties:
+              conditions:
+                description: Current conditions.
+                items:
+                  description: ConditionStatus mirrors metav1.Condition for embedding
+                    in status.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned.
+                      type: string
+                    message:
+                      description: Human-readable message.
+                      type: string
+                    reason:
+                      description: Machine-readable reason for the condition.
+                      type: string
+                    status:
+                      description: Status of the condition (True, False, Unknown).
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              controlAgentReady:
+                description: Whether the Control Agent component is ready.
+                type: boolean
+              dhcp4Ready:
+                description: Whether the DHCPv4 component is ready.
+                type: boolean
+              dhcp6Ready:
+                description: Whether the DHCPv6 component is ready.
+                type: boolean
+              dhcpDdnsReady:
+                description: Whether the DHCP-DDNS component is ready.
+                type: boolean
+              observedGeneration:
+                description: The generation last observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Current operational phase.
+                type: string
+              storkServerReady:
+                description: Whether the Stork server component is ready.
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/kea.openshift.io_keastorkservers.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/kea.openshift.io_keastorkservers.yaml
@@ -1,0 +1,1266 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  creationTimestamp: null
+  name: keastorkservers.kea.openshift.io
+spec:
+  group: kea.openshift.io
+  names:
+    kind: KeaStorkServer
+    listKind: KeaStorkServerList
+    plural: keastorkservers
+    shortNames:
+    - kss
+    singular: keastorkserver
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - jsonPath: .status.url
+      name: URL
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KeaStorkServer is the Schema for the keastorkservers API.
+          It deploys an ISC Stork server that provides a web UI for monitoring
+          and managing Kea DHCP servers, including lease browsing, subnet utilization,
+          HA status, and configuration management.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeaStorkServerSpec defines the desired state of KeaStorkServer.
+            properties:
+              container:
+                description: Container image configuration for the Stork server.
+                properties:
+                  image:
+                    description: |-
+                      Container image override. Defaults to the per-component ISC Kea image
+                      (e.g., kea-dhcp4, kea-dhcp6, kea-ctrl-agent, kea-dhcp-ddns).
+                    type: string
+                  imagePullPolicy:
+                    description: Image pull policy.
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  imagePullSecrets:
+                    description: Image pull secrets.
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  resources:
+                    description: CPU and memory resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This field depends on the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              database:
+                description: PostgreSQL database connection configuration.
+                properties:
+                  credentialsSecretRef:
+                    description: |-
+                      Reference to a Secret containing database credentials.
+                      The Secret must have keys "username" and "password".
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  host:
+                    description: PostgreSQL host address.
+                    type: string
+                  name:
+                    default: stork
+                    description: Database name.
+                    type: string
+                  port:
+                    default: 5432
+                    description: PostgreSQL port number.
+                    format: int32
+                    type: integer
+                  sslMode:
+                    default: disable
+                    description: SSL mode for the PostgreSQL connection.
+                    enum:
+                    - disable
+                    - require
+                    - verify-ca
+                    - verify-full
+                    type: string
+                required:
+                - credentialsSecretRef
+                - host
+                type: object
+              enableMetrics:
+                default: true
+                description: Enable the Prometheus metrics endpoint on the Stork server.
+                type: boolean
+              placement:
+                description: Pod scheduling constraints and metadata.
+                properties:
+                  affinity:
+                    description: Pod affinity rules.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and subtracting
+                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: Node selector key-value pairs.
+                    type: object
+                  podAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Additional annotations to set on the pod template. Useful for
+                      network attachment definitions (e.g., k8s.v1.cni.cncf.io/networks).
+                    type: object
+                  tolerations:
+                    description: Pod tolerations.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              port:
+                default: 8080
+                description: Port for the Stork server REST API and web UI.
+                format: int32
+                maximum: 65535
+                minimum: 1
+                type: integer
+              replicas:
+                default: 1
+                description: Number of Stork server replicas (typically 1).
+                format: int32
+                minimum: 1
+                type: integer
+            required:
+            - database
+            type: object
+          status:
+            description: KeaStorkServerStatus defines the observed state of KeaStorkServer.
+            properties:
+              adminSecretName:
+                description: The name of the Secret containing admin credentials (username
+                  and password keys).
+                type: string
+              conditions:
+                description: Current conditions of the component.
+                items:
+                  description: ConditionStatus mirrors metav1.Condition for embedding
+                    in status.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned.
+                      type: string
+                    message:
+                      description: Human-readable message.
+                      type: string
+                    reason:
+                      description: Machine-readable reason for the condition.
+                      type: string
+                    status:
+                      description: Status of the condition (True, False, Unknown).
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              configHash:
+                description: SHA-256 hash of the current rendered configuration.
+                type: string
+              configMapRef:
+                description: Name of the ConfigMap holding the rendered Kea configuration.
+                type: string
+              observedGeneration:
+                description: The generation last observed by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: Current operational phase.
+                type: string
+              readyReplicas:
+                description: Number of ready replicas.
+                format: int32
+                type: integer
+              serverTokenSecretName:
+                description: |-
+                  The name of the Secret containing the server agent token (key "token").
+                  Stork agents use this token to register with the server.
+                type: string
+              url:
+                description: The URL of the Stork server web UI (set when Route is
+                  created on OpenShift).
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ocp-kea-dhcp
+    control-plane: controller-manager
+  name: ocp-kea-dhcp-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keacontrolagent-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keacontrolagent-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ocp-kea-dhcp
+  name: ocp-kea-dhcp-keacontrolagent-editor-role
+rules:
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keacontrolagents
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keacontrolagents/status
+  verbs:
+  - get

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keacontrolagent-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keacontrolagent-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ocp-kea-dhcp
+  name: ocp-kea-dhcp-keacontrolagent-viewer-role
+rules:
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keacontrolagents
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keacontrolagents/status
+  verbs:
+  - get

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keadhcp4server-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keadhcp4server-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ocp-kea-dhcp
+  name: ocp-kea-dhcp-keadhcp4server-editor-role
+rules:
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keadhcp4servers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keadhcp4servers/status
+  verbs:
+  - get

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keadhcp4server-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keadhcp4server-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ocp-kea-dhcp
+  name: ocp-kea-dhcp-keadhcp4server-viewer-role
+rules:
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keadhcp4servers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keadhcp4servers/status
+  verbs:
+  - get

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keadhcp6server-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keadhcp6server-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ocp-kea-dhcp
+  name: ocp-kea-dhcp-keadhcp6server-editor-role
+rules:
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keadhcp6servers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keadhcp6servers/status
+  verbs:
+  - get

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keadhcp6server-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keadhcp6server-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ocp-kea-dhcp
+  name: ocp-kea-dhcp-keadhcp6server-viewer-role
+rules:
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keadhcp6servers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keadhcp6servers/status
+  verbs:
+  - get

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keadhcpddns-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keadhcpddns-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ocp-kea-dhcp
+  name: ocp-kea-dhcp-keadhcpddns-editor-role
+rules:
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keadhcpddns
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keadhcpddns/status
+  verbs:
+  - get

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keadhcpddns-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keadhcpddns-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ocp-kea-dhcp
+  name: ocp-kea-dhcp-keadhcpddns-viewer-role
+rules:
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keadhcpddns
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keadhcpddns/status
+  verbs:
+  - get

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keaserver-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keaserver-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ocp-kea-dhcp
+  name: ocp-kea-dhcp-keaserver-editor-role
+rules:
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keaservers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keaservers/status
+  verbs:
+  - get

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keaserver-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-keaserver-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: ocp-kea-dhcp
+  name: ocp-kea-dhcp-keaserver-viewer-role
+rules:
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keaservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kea.openshift.io
+  resources:
+  - keaservers/status
+  verbs:
+  - get

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: ocp-kea-dhcp-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp.v0.0.27.clusterserviceversion.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/manifests/ocp-kea-dhcp.v0.0.27.clusterserviceversion.yaml
@@ -1,0 +1,859 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    com.redhat.openshift.versions: "v4.18"
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kea.openshift.io/v1alpha1",
+          "kind": "KeaControlAgent",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "ocp-kea-dhcp"
+            },
+            "name": "ca-example"
+          },
+          "spec": {
+            "control-sockets": {
+              "dhcp4": {
+                "socket-name": "/run/kea/kea-dhcp4-ctrl.sock",
+                "socket-type": "unix"
+              },
+              "dhcp6": {
+                "socket-name": "/run/kea/kea-dhcp6-ctrl.sock",
+                "socket-type": "unix"
+              }
+            },
+            "http-host": "0.0.0.0",
+            "http-port": 8000,
+            "loggers": [
+              {
+                "name": "kea-ctrl-agent",
+                "output-options": [
+                  {
+                    "output": "stdout"
+                  }
+                ],
+                "severity": "INFO"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "kea.openshift.io/v1alpha1",
+          "kind": "KeaDhcp4Server",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "ocp-kea-dhcp"
+            },
+            "name": "dhcp4-example"
+          },
+          "spec": {
+            "interfaces-config": {
+              "dhcp-socket-type": "raw",
+              "interfaces": [
+                "net1"
+              ]
+            },
+            "lease-database": {
+              "lfc-interval": 3600,
+              "persist": true,
+              "type": "memfile"
+            },
+            "loggers": [
+              {
+                "name": "kea-dhcp4",
+                "output-options": [
+                  {
+                    "output": "stdout"
+                  }
+                ],
+                "severity": "INFO"
+              }
+            ],
+            "option-data": [
+              {
+                "data": "192.168.1.1",
+                "name": "routers"
+              },
+              {
+                "data": "8.8.8.8, 8.8.4.4",
+                "name": "domain-name-servers"
+              },
+              {
+                "data": "example.org",
+                "name": "domain-name"
+              }
+            ],
+            "placement": {
+              "podAnnotations": {
+                "k8s.v1.cni.cncf.io/networks": "dhcp-net"
+              }
+            },
+            "rebind-timer": 32400,
+            "renew-timer": 21600,
+            "subnet4": [
+              {
+                "id": 1,
+                "pools": [
+                  {
+                    "pool": "192.168.1.100 - 192.168.1.200"
+                  }
+                ],
+                "reservations": [
+                  {
+                    "hostname": "workstation-a",
+                    "hw-address": "1a:1b:1c:1d:1e:1f",
+                    "ip-address": "192.168.1.10"
+                  },
+                  {
+                    "hostname": "workstation-b",
+                    "hw-address": "2a:2b:2c:2d:2e:2f",
+                    "ip-address": "192.168.1.11"
+                  }
+                ],
+                "subnet": "192.168.1.0/24"
+              }
+            ],
+            "valid-lifetime": 43200
+          }
+        },
+        {
+          "apiVersion": "kea.openshift.io/v1alpha1",
+          "kind": "KeaDhcp4Server",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "ocp-kea-dhcp"
+            },
+            "name": "dhcp4-ha-example"
+          },
+          "spec": {
+            "control-socket": {
+              "socket-name": "/run/kea/kea-dhcp4-ctrl.sock",
+              "socket-type": "unix"
+            },
+            "high-availability": {
+              "heartbeat-delay": 10000,
+              "max-ack-delay": 10000,
+              "max-response-delay": 60000,
+              "max-unacked-clients": 10,
+              "mode": "load-balancing",
+              "peers": [
+                {
+                  "auto-failover": true,
+                  "name": "server1",
+                  "role": "primary",
+                  "url": "http://kea-dhcp4-0.kea-dhcp4:8000/"
+                },
+                {
+                  "auto-failover": true,
+                  "name": "server2",
+                  "role": "standby",
+                  "url": "http://kea-dhcp4-1.kea-dhcp4:8000/"
+                }
+              ],
+              "this-server-name": "server1"
+            },
+            "interfaces-config": {
+              "dhcp-socket-type": "raw",
+              "interfaces": [
+                "net1"
+              ]
+            },
+            "lease-database": {
+              "lfc-interval": 3600,
+              "persist": true,
+              "type": "memfile"
+            },
+            "loggers": [
+              {
+                "name": "kea-dhcp4",
+                "output-options": [
+                  {
+                    "output": "stdout"
+                  }
+                ],
+                "severity": "INFO"
+              }
+            ],
+            "placement": {
+              "podAnnotations": {
+                "k8s.v1.cni.cncf.io/networks": "dhcp-net"
+              }
+            },
+            "rebind-timer": 32400,
+            "renew-timer": 21600,
+            "replicas": 2,
+            "subnet4": [
+              {
+                "id": 1,
+                "option-data": [
+                  {
+                    "data": "192.168.1.1",
+                    "name": "routers"
+                  },
+                  {
+                    "data": "8.8.8.8, 8.8.4.4",
+                    "name": "domain-name-servers"
+                  }
+                ],
+                "pools": [
+                  {
+                    "pool": "192.168.1.100 - 192.168.1.200"
+                  }
+                ],
+                "subnet": "192.168.1.0/24"
+              }
+            ],
+            "valid-lifetime": 43200
+          }
+        },
+        {
+          "apiVersion": "kea.openshift.io/v1alpha1",
+          "kind": "KeaDhcp6Server",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "ocp-kea-dhcp"
+            },
+            "name": "dhcp6-example"
+          },
+          "spec": {
+            "interfaces-config": {
+              "interfaces": [
+                "net1"
+              ]
+            },
+            "lease-database": {
+              "persist": true,
+              "type": "memfile"
+            },
+            "loggers": [
+              {
+                "name": "kea-dhcp6",
+                "output-options": [
+                  {
+                    "output": "stdout"
+                  }
+                ],
+                "severity": "INFO"
+              }
+            ],
+            "option-data": [
+              {
+                "data": "2001:db8:1::dead:beef",
+                "name": "dns-recursive-name-server"
+              }
+            ],
+            "placement": {
+              "podAnnotations": {
+                "k8s.v1.cni.cncf.io/networks": "dhcp6-net"
+              }
+            },
+            "preferred-lifetime": 3000,
+            "subnet6": [
+              {
+                "id": 1,
+                "pd-pools": [
+                  {
+                    "delegated-len": 64,
+                    "prefix": "2001:db8:8::",
+                    "prefix-len": 48
+                  }
+                ],
+                "pools": [
+                  {
+                    "pool": "2001:db8:1::100 - 2001:db8:1::1ff"
+                  }
+                ],
+                "subnet": "2001:db8:1::/64"
+              }
+            ],
+            "valid-lifetime": 4000
+          }
+        },
+        {
+          "apiVersion": "kea.openshift.io/v1alpha1",
+          "kind": "KeaDhcpDdns",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "ocp-kea-dhcp"
+            },
+            "name": "ddns-example"
+          },
+          "spec": {
+            "forward-ddns": {
+              "ddns-domains": [
+                {
+                  "dns-servers": [
+                    {
+                      "ip-address": "10.0.0.53",
+                      "port": 53
+                    }
+                  ],
+                  "key-name": "ddns-key",
+                  "name": "example.org."
+                }
+              ]
+            },
+            "ip-address": "127.0.0.1",
+            "loggers": [
+              {
+                "name": "kea-dhcp-ddns",
+                "output-options": [
+                  {
+                    "output": "stdout"
+                  }
+                ],
+                "severity": "INFO"
+              }
+            ],
+            "port": 53001,
+            "reverse-ddns": {
+              "ddns-domains": [
+                {
+                  "dns-servers": [
+                    {
+                      "ip-address": "10.0.0.53",
+                      "port": 53
+                    }
+                  ],
+                  "key-name": "ddns-key",
+                  "name": "1.168.192.in-addr.arpa."
+                }
+              ]
+            },
+            "tsig-keys": [
+              {
+                "algorithm": "HMAC-SHA256",
+                "name": "ddns-key",
+                "secretRef": {
+                  "key": "secret",
+                  "name": "ddns-tsig-secret"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "kea.openshift.io/v1alpha1",
+          "kind": "KeaServer",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "ocp-kea-dhcp"
+            },
+            "name": "keaserver-example"
+          },
+          "spec": {
+            "controlAgent": {
+              "control-sockets": {
+                "dhcp4": {
+                  "socket-name": "/run/kea/kea-dhcp4-ctrl.sock",
+                  "socket-type": "unix"
+                }
+              },
+              "http-host": "0.0.0.0",
+              "http-port": 8000,
+              "loggers": [
+                {
+                  "name": "kea-ctrl-agent",
+                  "output-options": [
+                    {
+                      "output": "stdout"
+                    }
+                  ],
+                  "severity": "INFO"
+                }
+              ]
+            },
+            "dhcp4": {
+              "control-socket": {
+                "socket-name": "/run/kea/kea-dhcp4-ctrl.sock",
+                "socket-type": "unix"
+              },
+              "interfaces-config": {
+                "dhcp-socket-type": "raw",
+                "interfaces": [
+                  "net1"
+                ]
+              },
+              "lease-database": {
+                "persist": true,
+                "type": "memfile"
+              },
+              "loggers": [
+                {
+                  "name": "kea-dhcp4",
+                  "output-options": [
+                    {
+                      "output": "stdout"
+                    }
+                  ],
+                  "severity": "INFO"
+                }
+              ],
+              "placement": {
+                "podAnnotations": {
+                  "k8s.v1.cni.cncf.io/networks": "dhcp-net"
+                }
+              },
+              "subnet4": [
+                {
+                  "id": 1,
+                  "option-data": [
+                    {
+                      "data": "192.168.1.1",
+                      "name": "routers"
+                    },
+                    {
+                      "data": "8.8.8.8, 8.8.4.4",
+                      "name": "domain-name-servers"
+                    }
+                  ],
+                  "pools": [
+                    {
+                      "pool": "192.168.1.100 - 192.168.1.200"
+                    }
+                  ],
+                  "subnet": "192.168.1.0/24"
+                }
+              ],
+              "valid-lifetime": 43200
+            }
+          }
+        },
+        {
+          "apiVersion": "kea.openshift.io/v1alpha1",
+          "kind": "KeaStorkServer",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/managed-by": "kustomize",
+              "app.kubernetes.io/name": "ocp-kea-dhcp"
+            },
+            "name": "stork-example"
+          },
+          "spec": {
+            "database": {
+              "host": "postgres.example.svc.cluster.local",
+              "port": 5432,
+              "name": "stork",
+              "credentialsSecretRef": {
+                "name": "stork-db-credentials"
+              },
+              "sslMode": "disable"
+            },
+            "port": 8080,
+            "enableMetrics": true
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Networking
+    containerImage: quay.io/mooyeg/ocp-kea-dhcp:v0.0.27
+    createdAt: "2026-06-21T23:28:47Z"
+    description: Manages ISC Kea DHCP servers on Kubernetes and OpenShift
+    operators.operatorframework.io/builder: operator-sdk-v1.38.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/MoOyeg/kea-dhcp-operator
+    support: moyegunl@redhat.com
+  name: ocp-kea-dhcp.v0.0.27
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: |-
+        KeaControlAgent is the Schema for the keacontrolagents API.
+        It manages a Kea Control Agent deployment that provides a REST API
+        for managing Kea DHCP servers.
+      displayName: Kea Control Agent
+      kind: KeaControlAgent
+      name: keacontrolagents.kea.openshift.io
+      version: v1alpha1
+    - description: |-
+        KeaDhcp4Server is the Schema for the keadhcp4servers API.
+        It manages a Kea DHCPv4 server deployment on Kubernetes or OpenShift.
+      displayName: Kea Dhcp4 Server
+      kind: KeaDhcp4Server
+      name: keadhcp4servers.kea.openshift.io
+      version: v1alpha1
+    - description: KeaDhcp6Server is the Schema for the keadhcp6servers API.
+      displayName: Kea Dhcp6 Server
+      kind: KeaDhcp6Server
+      name: keadhcp6servers.kea.openshift.io
+      version: v1alpha1
+    - description: |-
+        KeaDhcpDdns is the Schema for the keadhcpddns API.
+        It manages a Kea DHCP-DDNS (D2) server that performs dynamic DNS updates
+        on behalf of the DHCP servers.
+      displayName: Kea Dhcp Ddns
+      kind: KeaDhcpDdns
+      name: keadhcpddns.kea.openshift.io
+      version: v1alpha1
+    - description: |-
+        KeaServer is the Schema for the keaservers API.
+        It is a convenience umbrella resource that deploys any combination
+        of Kea DHCP components (DHCPv4, DHCPv6, Control Agent, DDNS).
+      displayName: Kea Server
+      kind: KeaServer
+      name: keaservers.kea.openshift.io
+      version: v1alpha1
+    - description: |-
+        KeaStorkServer is the Schema for the keastorkservers API.
+        It manages an ISC Stork server deployment for centralized monitoring
+        and management of Kea DHCP servers.
+      displayName: Kea Stork Server
+      kind: KeaStorkServer
+      name: keastorkservers.kea.openshift.io
+      version: v1alpha1
+  description: |
+    ## Kea DHCP Operator
+
+    The Kea DHCP Operator manages [ISC Kea](https://www.isc.org/kea/) DHCP servers
+    on Kubernetes and OpenShift clusters. It provides a declarative way to deploy
+    and configure DHCPv4, DHCPv6, Control Agent, and Dynamic DNS services.
+
+    ### Features
+
+    * **DHCPv4 and DHCPv6** — Full support for subnets, address pools, host reservations,
+      shared networks, client classes, and option data
+    * **Control Agent** — REST API for managing running Kea daemons and querying lease data
+    * **Dynamic DNS** — Automatic forward and reverse DNS zone updates from DHCP lease events
+    * **High Availability** — Built-in HA with hot-standby and load-balancing modes
+    * **Flexible Storage** — Lease persistence via memfile, MySQL, or PostgreSQL backends
+    * **Umbrella Resource** — Deploy multiple Kea components from a single KeaServer resource
+    * **Configuration Rendering** — CRD spec is rendered to native Kea JSON configuration
+    * **Rolling Updates** — Configuration changes trigger automated rolling restarts via config hash
+    * **Stork Monitoring** — Optional ISC Stork agent sidecar for Prometheus metrics and centralized monitoring
+    * **Auto-fill HA Peer URLs** — HA peer URLs are auto-generated from StatefulSet naming when omitted
+
+    ### CRDs
+
+    | CRD | Description |
+    |-----|-------------|
+    | `KeaDhcp4Server` | DHCPv4 server with subnets, pools, and reservations |
+    | `KeaDhcp6Server` | DHCPv6 server with prefix delegation |
+    | `KeaControlAgent` | REST API management agent |
+    | `KeaDhcpDdns` | Dynamic DNS update service |
+    | `KeaServer` | Umbrella resource for deploying multiple components |
+
+    ### Getting Started
+
+    Create a DHCPv4 server on a secondary network (NAD):
+
+    ```yaml
+    apiVersion: kea.openshift.io/v1alpha1
+    kind: KeaDhcp4Server
+    metadata:
+      name: my-dhcp4
+    spec:
+      valid-lifetime: 43200
+      interfaces-config:
+        interfaces: ["net1"]
+        dhcp-socket-type: raw
+      placement:
+        podAnnotations:
+          k8s.v1.cni.cncf.io/networks: "dhcp-net"
+      subnet4:
+        - id: 1
+          subnet: "192.168.1.0/24"
+          pools:
+            - pool: "192.168.1.100 - 192.168.1.200"
+    ```
+  displayName: Kea DHCP Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO29d3yc1Z3v/35mNNKoV6tY7pZt2XIvuBCwDaGYTmADCb9cEpLclM3CQnLv3d3c3XX2pmwCm4UkN7vJZnPTnCyhYwgYMAZsYuNeZbnIVXKTrDKjNvX8/hhN08w8z3lmRs0+n9cLo3nO93O+X2nmfZ4y5zwPKCkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKSkpKV0p0oa7AD1VTF1bbtG0BZomZqAxw482wwLlAnKBYgL/z4xr1kL/JJSI6zH2xc9l0qfFfxFTk4Qn2VyyHiHriwkxn0vWJ+KGGPgSNifjC23sQ9CJJjqE0DqFRTujIfajsc/rE/s69nzjtH7nw6sRNQCMHbs2hxztJqGJGzTBaqExGw0tOSAV/En7FPwGzbEbReLmM5rGep/QXm3rc7zHobVu/YRDqxEwAKy1VNZwvUXjYQH3AfmhJgmQY6TgT82n4DdoNgX/wAYHaOuE4MeXdz9+WD/50GjYBoBJk9ba+zJ4RNP4BjA5JkDBr+tJNpesR8Evt9EE/FE2De0dNP/TLTu//if9QgZXQz4AjB27Nsefy1ct8ISAqrhBCn5dT7K5ZD0KfrmNScI/sOl9LHyjdfsTO/WLGhwN6QAwtuZbdwuLeAbBxIRBCn5dT7K5ZD0KfrmNaYI/3J3GH/B6/kfrnv91Tr/A9GpIBoDK2rWTLD5+LOAO42oU/Ar+sK4C+CPVBvxl684n/iuxOb0a9AGgsmbt/RaNXwgoNK5Ewa/gD+sqgz+y8Vm3TXzVsfWJNr3odGjQBoCamh9ldWttPwAelatCwa/gD+sqhj+oswjuad31+G49V6oalAGguva7pcLnfk3AMrkKFPwK/rAU/CE50cRDrTueWK/nTkXWdHc4duq3xws87wILDIMV/LqeZHPJehT8chuHCX7QyALtgZyxtzh7zm3YptdLskrrADB2+tpaofnfA6YaBiv4dT3J5pL1KPjlNg4j/OGfNO2W7Opb3b3nNmzR6y0ZpW0AGDf929V+/JuACYbBCn5dT7K5ZD0KfrmNIwD+yE035oy9jZ5zb76v16tZpWUAqK79bqnf79kE1BgGK/h1PcnmkvUo+OU2jiT4gw1CY1XOuDW9vc1vfqjXuxmlPADU1PwoyyO63kKd86PgN+9T8Mvliqjpxuxxtx7ubX6zXi+LrCypdtBD27+oq/3RLxT8cj4Fv1yuAZ8niyb4Tck1/7pcL5OsTFISrcqatfdrGs/JZVHwK/jDUvDL5Ur4edK4qPnEgtZdj5/Xy2qkpI8AKmvXTrJo/MIwUMGv60k2l6xHwS+3cZTBD1AhMiy/gbUpHcUnb/bxIzW9V8Fv1qfgl8tlAH9AQny89Jrib+hlN1JSpwBja751t9DEy8Y9K/gV/GEp+OVyScEflsfityxt2fnoHr1KEsn0EcDYsWtzhEU8oxuk4Nf1JJtL1qPgl9t4BcAPYPNbxE+TPRUwbfLnan+p1vMnqEnCk2wuWY+CX27jFQJ/sHFZyTXFj+hFJdX1QE2atNbutnFC3clHwS/rU/DL5UoB/uBPrW6rb4bZJcSmjgD6MnhEwa/gl/Up+OVypQo/gIAym8/6hJ7DdIporbVUTeM46gaepj3J5pL1KPjlNl6p8EfI4bH6Jps5CpA+Aqicqq1EwW/ak2wuWY+CX27jVQA/aBRk+i2P6bkHSv4UwCI+E78WBb+CPywFv1yuQYAfAIH2V+OW/zBbr5dISQ0A48b9MNsCn4hNqOBX8Iel4JfLNVjw96u4T2R8IkFkjDJkgvx2581Rs/4U/LqeZHPJelKBP7+ylOpFdZROHY+9MB8/0NvupK3xLM27DtJ9qU3BL1XGiIQfACHE54F1ej1KpQ2qatraZwje3FPBr+tJNpesJ1n4LRkZzLztOsYtmQ2ahhDgB4QI9CkE+IWgeccBGjdsQfh80jUq+OVyDQX8/RIZfn/NxR2Pn9DrGSRPATTB6nBCBf9ohH/Jw3cx/po5CeEP9j12yVzmfPpONKtVKpeCXy7XEMIPaJrXatV/Bke/DAeAiqlry/uf0muUNU4dxh4Fv5wnlcP+mbdfT/HkceE9PbHwR/6/YPI4Jt90rWEqBb9criGGP/CvnzV6UUEZDgAWTVuAekS3rifZXLKeVM/5xy2uk4ZfIBACKhbPIXtMScJUCn65XMMBP4DQWDV20c9y9KJB4iKgpokZQsE/KuEHqF5UF3PYb7PCvdNtLKoMjP87zvt5vsGDyyeiTgfK58/k9Nuxt59T8MvlGi74+2V3Z7qWAO/ruYyvAWjMMIyJqUPBn7QvjfADlNWMj9nz3zvdxsoJVvIyNfIyNVZPtHJfbUbMEUHh5NgbPCv45XINM/wACL+YrecCiQFAYJluFBNdh4I/aV+a4QfIKsiLOexfUBH7ti+utMacDtgK8qNiFPxyuUYC/Ggg0OboOUHmCECISsOYUB0K/qR9gwA/gE/EOdeP05XfIE7BL5drpMAPYNGo03OD3ClAvkRM4mL6peCX86R7hl9fZ1fMnn33BX9M3K4Lvpi4vk5noCYFv1SukQQ/gB/K9HoAuZmA+gPAKIc/v6qM6sWzKamZgL2oIDAzrs1BW+MZzu08QPdFE8urRxj8AG3Hz5JdVhIF9/MNHgSCJVWBx0JsP+fj2cOe6ElBgOPEmVEPf35FCeMXzKRkyjiy+0+Hejq6aDvZRPOeerpa2uVrHEXw99dTpNeLYRqAqunfcgGZid2jE35LhpXaO1YxbmniyTF+ITj30X4a3/ggYmacuVyynsGAHyC3vITFX/00wQ9p5Fd9ib4K9AN+v+Dwf/6B3lYTgOg2Dy38lgwrs25ZwfhFs3Tf36Zd9TS+82f8Pp9+jaMPfjRwXd72qF2vN5mZgFck/IsfuZfxy+Ym/HAEgaxaOo/Zn7mnf2acuVyy9Q0W/ADdl9po3nHAFPxCwKXdB0Y1/Nc8dBsTFsd+BTrw/a1eVMecT96GxapzMDwK4e//OUuvN0j2tuCjGH6A2jtXUTxlvPzMuCnjmHzLdaZyydY3mPAHwxo3bKH9xFlp+B2nmmjeOPD7/9EBP8CsW6+lZFK19PtbOGksk29I8HCrUQq/rMwPAKMc/vyqMsZdM8f0zLjya+aSXT5gZtwogB9A+Hwc/P16zm3fj1/EHwSCh/0Xd+3n+B/XI/z+2I6k60vFl4Zz/oUzTb+/lQtnkVNWLFn+aIHf+HMitRw4ur/RCz9A9eLY1XCyM+PGLKjjzIbNurlk6xsq+EP5fH5OvLmZ87sOUT5/JoWTJ2ArzOu/2t+F48QZWvfXj9rD/qDGL5iZ9PtbPncGp97dZpjrSoEfzAwAVwD8AKXTJiScGRfU6olWBIJ1Bz3RM+OmTAQ2jzr4Izf0trT1T++NPsQf7Vf7gyqdUp38+ztpPLDtqoEfZE8BrhD4AbL6b4KR1My4woJRDX8iXSnwA9gLkn9/Mwvyrir4QW4ikGGnowV+SHFmnIiMVPCnx5c++AF88S50xomL//4mznUlwg9SRwBXDvwAfR3OmDddemacw2muRgW/QXN64QfoTWHmY6+jK26uUQu/xEfH3EXAARpt8KNB2/EzZI8pjXrzpWfGNZ6Wr1HBb9CcfvjRoO1EMzmlSc58PHU2psMrGX5IYQAYjfADnNt5gKpl8wm+uUKAyxe4IPS7g564h4XBr8gu7603XZ+CX25jOuAHaN5Tz9jFs0nm/W090BDV4ZUOPyQ5EWi0wg/QfbGNcx/tj/keeOCHIvLDIQRYervwdsY7REycS8EvtzFd8EPgFKDP0W36/b209xC9lztCHV4N8EMSA8Bohj/4ovGND2hvPCP94ci0alSOKWDpf7+PzFydZy4o+A2aBxd+W46d+Q/dRWZ+HkII6fe383QzTe9tC3V4tcAPJgeAKwF+AOHzcei3r3B+2z7DmXGuc+cpzQrYC6vLWf7VB8gtjbPISsFv0Dy48NsL81nwmXvIqxxDYL8PzvOtxjMf9xzk+Itv9M98vLrgl7JVzfgnEbeQUQr/QGWXlzBmQR2FUyZiK8rvnxnnxNF4mst76+lraaN60SzmfOJGNEtgvOxz9rDrVy/jONcS072CX25jOuHPLStm7oN3kJmfCwj8QnD8zS2c33uYnLJiyufOoHDSeDIL8kJX+x2nztJ6oOGKP+xv2/pXyVYfUNWMf4r9evQKgd+Mr3zmZBZ8+ja0jAwQ4O5zsec362k/3TygJgW/0cZ0wl9QXcGcv7iNjOwsQOD3+ji8fhOtDXGeiaGT60qEH4wHAIl7AiZKePXAD3Dp8Ek++vkLeLr7EIDNnsWiR+6lom5aRE0KfqON6YS/dNpE5n/6zhD8nj43+//rTwp++QCTFwGvUviD6jh7gY/+47nQbbY0q5U5D65h7JLZcvkU/KnlimiqnDuD2Z+4JXBEhsDV3cO+devpPHveRJdXN/xgZgC4yuEPqutiG9t//hzdwVtJaRqz7r6RmptXmMhjokYFf0zThOULqL1tNVgsgKC3w8G+366n+9JlE10q+MHUYiBzHSftG8HwB8N6Oxx89LNn6TgT2NsIAZOuW8yMO1ahaTJvmILfVC4t/P+pNy5nyqql/b+nwHm+lT2/eYXe9k4TXSr4g5JcDGS+4ysV/qA8vS52/eplWo+eBgI1jls6l9kP3IYlIyOuJ9lcsr4rGX6L1cqsuz7O+Gvm9fcpaD91jn2/X4+nu9dElwr+SEmeAij4Y98wDZ/bw951r3HhwJHAdgFjZk1l7mfuJMOepeBPNVd/kzXTxuz7b2XMrBr6p/fQcuQkB//4Jj63x0SXCv6BSnk1YOLwKxv+0Gufj4PPbeD0lt2h9uLJ45n38L3YomYNKvhN5epvstmzmPvgHRRPGU9wgs+5XYc4/NI7+H1eE11ehfBLfOSSuymoYR1XB/yRDcc3bKHx7T8HZpsJyBtbzsIvfJLs0qKkcsnWeCXDby/MZ8HD91JQXUEQ/rNb93H8rQ8H3JvBOJeCP77SNwBcrfBH6PTmnTS8/Db+/htqZhUXMu+z95NXafiAFgX/gKbcsmIWfOYeskuKCM7uO/bGZk6+95HJLhX8ekrPAKDgD3ku7D3MoWdfx+f1ggBbXg5zHv4EhROrJeuTy3Ulw19QXcH8/++e8NRer4/DL2/k/N7DJrtU8Bsp9QFAwR/juXzkJPt+9RKenj5AYLVnMvuhuyibVWNQn1yuKxl+U7P7DHIp+I2V2gCg4E/QtYaz6QL7fvUCfY6uQEcZVqbfdwsVi+p0fUa6kuE3NbvPIJeCX07JDwAK/gRdhzf0tLSx//+9SE9wxZmmMfW21Uy4YYWCf0CTqdl9BrkU/PJK4dFgJjNfZfAH5epwsP+Xz+FouhBajz722oVMuvX6iFmDVzH8WrzZfS2JZ/cZ5FLwm1OSjwYzmfkqhT8ob6+LQ799hY7GM6HfuWLRXGo+cStahs0w1ZUKf+LZfa/Fn91nkEvBbzogmUeDyXUcv4arD/6g/B4PDX98nZo7b6SkbjoAxbVTmWG3c+y51+PPaCN1+K3Z2djHVpBZXExmcSG2wgKsmZmQlYWlf/Dxezz4XS78bheejk7cHQ7c7R30XbiIv9cVW5NUKfpgWTNt1N17c/9DWgPf8bceOUnDK5viT/AxyKXgNx0gF1VZ+38GcKHgN9ig79Ngwg0fo3LZ/EBeAd3nWzj6x/V4B+z1koXfXj6GvGmTyRlXTWZxcWjvGvxf1N8/+FoLbw3NsRHgbu+gt+kc3Y0ncbdeTgv8NnsWsz95W9QEn3O7DvVPpErw6VDwJ+Vr+/NfJvtXCKiy9v8IBX+irs3nCm6oWr6QcauWgxbI72rv5Oh/vYarPXDB0Cz8lsxMCutmUDBzGraiokjeSQr+oEuEX7nbO+k6epyuhmP4vfGPWIzAshfmM/fB20MTfAKz+/Zy8r3tur5EDQp+/YDUB4CZ/UcACn6jDaZ9ZXNqmXj7ajSLBSHA09XD8T+up/tSq0xHAFjtWRTNnUXh3DqsmZlR0KYT/ogf8bvcOOsbcNQfxu9yG9YYbIp/777NnN/boOtL1KDgNw5I0wCg4DfYkLSvcNokptwT/O4bvH1uGl94na6z5/TzaVAwvYayFddgzbYDDAn8kU1+l5vOPftwHj6i/wZrie7d9y6tDSd1fYkaFPzGAUKD9g9THgC+rctu4t4U/LK+3OpKav7idizZ9sAe1uvj1Gvv0HHkeFyfrSifyhtWYq8sD20baviDRgG4LrbQtnkrXqeTGGmB2X1199wUmuDj6XNz6Pk36Tx7Ie7fI+hL1KDgNw4InkIaDQCDsBgo+oWC39jX3XyBhnUv4Xb032sww8rEu2+mbF5dTGze1ImMv+/uEQM/QFbFGCruWkP25InRxWqJZve9quBPIpdsQPzrR/GV5sVA0S8U/HI+oUFfaxtH171E3+WOwCCARvUtq6hauby/G43yjy2l6pYbsWZlhr2hf4YH/mA/ms1G6cqPUbhkIWgaaIlm971K96W2xH8MBX9KPjPwQ4pPB46tQcFv1hf5hrk7HRz7/YtMuf8Osvv38GOWLkCzZYDFSm7NlGhv6J/hhT9SeXUzycjOpiRHo3rh7FBdjgstHHz2T3h6YucVhKTgT8lnFn6pNLrXABT8KfkSfdVnybQx+Z415E4cF4gDPC4PPq8v7A39M3LgF/0bC3JsVBRnh+pqO9lE/Ytv4XMnmOADCv4UfYngH7xrAAr+lHx63/P73R5OvvA67Q3H4v49RzL8wZ+D9+67VH+cQ8+9qeBPIpdsQDJ7/qCSOwVQ8Kfkk5nk4/f5cHU48PR/z+7zBu4yNNLhB3D0eEIz+i40teH3+UkoBX9KvlTgh2QGAAV/Sj7ZGX55NZMpnFMXAh/SB39+lkZptgV7hgYIer2C1h4/zr6oXkNGM/AHf3L2BPb4ObNm4mprp+/k6ZjfUcGfmi9V+CHpxUDRLxT8cj5Z+G2FBVSsujbaG/rHPPxlORaum5jJ3EobtWUZFNjj1+ro81Pf4mXfeQ+bT7tp6fIlBf/AOguvWYyn5TK+ri69XzvUoOA3DpCD3zjIMCJ0EVDBn5JPem6/BuPvvSMt3/PPq7Rxf52dBVU24j2wSE9+AXvOuXn2QC97z3uShj9Yk+diC5ff2Rh4oeBPyWcG/vYPv6obLXcEoOBPyWdmYU/BzOkpwz+u0MpXr8lhXmX0vQYuOP0cuOjhTIePi90+nK6AKT9LY0yelUlFVuZUZFCZb8WiwaLqTBZVZ7Kr2c1PtnXT1OmLqEkefgBbxRiyp0ym98TJuL+3gl8uIF17/qCMBwAFf0o+M/Bb7VmMWbY47A39Iw//nbV2vrAwhwxroKnXI9hw3MVbx1ycbPchc8FvckkGt07L4tZpduwZGovGZvLze2z8+/ZuXjncZxr+oPLmz8fV1Izf7R7QouCXCUg3/GDqGoCC36zP7JLeorl1WOzJLeyxWgWPLc/lxilZQOAQ/rWGPtbt78XRJ0LBRvAL4ESbl59+5OV3e3v5zPxs7qjNxmbR+KtleUwvzeCHHzrx+c3BLwRY7FnkTJ9G18FDUX8PBb9xQFLwS3hMPxtQwS/nS2o9/9xZAW/oH3n4/+76vBD8l7r8fONNB/+2o8c0/BEv6ezz85Nt3Xz9T51c6g58G3HLNDt/v7ogMLs3Xp0J4A9GZc+YHpjZ2P/3UPAbBwwW/GDy2YAKfjlfMnfyKaybkfR6/seW5bJsfGB9wJFWL4++3snhFm/ULtos/JE6eMnDV15pp6E1cBOQj03M4vFr803DD6BlZZI9dSoKfrmAwYQfTMwEVPDL+ZK9jVdBbU1S8N8xw86NUwN7/iOtXv7uLSedLpE2+IMX/Dr7/PzPNzpDg8CaaXbumpltCv7g72efMkXBLxEw2PCD5ACg4JfzpXIPP1txsWn4xxVa+eKiHCBw2P+PG530eNMPf1DdHsE333ZwqTvwbcBXluZSXWAxBT9ARmEBGcVFMX8KBX9YQwE/SAwACn45Xyp3782bNtk0/ABfvSZwtd8v4J83dw3Knn9AF3T0+PnOJid+ATarxmMr8k3BH/zRPnFitEnBH9JQwQ+DsBhoUHxXMPwAOeMCDw41A/+8Slvoe/7XGvrSes6fCP7gDwcueljfELiD8aLqTOZVhecbyMCPAFtFRXijgj+koYQf0rwYaFB8BvDnV5ZSvWg2pTXjsRfm4wd62520NZ6hedeh/kdLjVz4rdnZSd26+/66wNeFvR7Buv29QwZ/sM5f7+rm5v55Ap+el8u+8x3S8ANkFBViycqMMycgUsMPf0FFMePnzaB0UjXZ+bn4gZ7Obi6faqZp3xG6WjuSqC9+wFDDD2lcDDQoPh34LRlWZt5+PeOWzAZNQwjwAxYBOeUlZI8poWrpPJq3H6BxwxaEz4euhgF+APvYCtPwl+VYWNC/191w3JXSV30DUknBj4D2Pj9vHOnl3rocFlXbKM2x0NrtRwZ+gQANbGPG4GpuJr6GF36r1cqsm5YxYcGMmM9XblkROaVFVC+cRdOeBo5t2o4/8vM1SuCHNC0GGhSfAfxLHr6b4injEBB6c4LP3hMi7Bl7zVxyyoo5sG594kFgmOAHyCopxgz8QsB1EzNDc/vfOuYKBcvAn2nVuHumnZtqsphSEnj7T7R52XDMxSv1vbh9A7xx4A+2vXmsj3vrcrBoGtdPyuLFQz3hWD34+2UtLIS4A8Dww7/0UzdTMmGs4eeresFMckoK2ffC24FBYBTBD2auAYwQ+AFm3n69IfyR/y+YPI7JN0Wvrktc0tDBD2ArKuzvVA5+gLn95/7nnX7p6b0CGJNr4ef3FPHYijxmlduwZ2jYMzRmldt4/No8/uPeYsbkWqTgBzjW6uViV2DEWFidGY6VgB8Blvz8OH+R4T/sn3XzMkP4I/9fOKGKqSuXjED4jQPlBoARBH9+ZSnjlsyWfnMEAiGgYskcsseU6NQnV2O6H9RpK8w3BT9AbVlgz33oogcze/4nby2kpjTxQd+0sgyeXFNEplUzhD9Y077zgXkBs8ozTMEvgIyYAWD44S+oKGbC/BmmP1+V82vJKY3z1aZOruGGH2QGgBEEP0D1ouhzfiHAZoUHZtp48oYsnrohiwdn2bBZwm9OsK/y+bN0Shp6+AEsWXZT8OdlaaH1/Kc6fFLwA9w9064Lf1DTyzK4qzZiPYIO/AAn2wMDQHG2lfzM8C9rBD+Alhm+u/FIgB8Nxs+bkfTnq2L2dOkaRwL8YOprwOGHH6CsZlzMyHzvdBsrJ1jJy9TIy9RYPdHKfbUZMSN24ZQJCUoaHvgBNFvEkl0D+AVQlh1+yy50RZ+wJ4If4OYau36tEbp1ul0KfhBccIbvWFSWYw3XYQA/RP7uIwN+gLJJY5P+fBVNqJbKNVLghyQWA5kLTS/8AFn9X/VF/vEXVMT+GosrrTGHa7aC/BEFP4A1CIEE/Aj6b+MVUI9HIAO/EDCp2Kpfb4QCFweN4QfococHgJxMTRp+AKxWRhL8APaCvKQ/X5n5eYa5hhR+CZ+pxUDmQtMPP4BPxDkXixPnl4obXvjDSeTgj3gV9aMR/GblF8QF1sz3/EbwJ3wMeFDDAD+AT4jkP19Rv9PIhx+G4NFgsh4Z+AH6Op0xI+/uC7F3nd11wRcT19cZ+ey6kQG/z+0xBX+vN9yYY9Ok4T/VbjAPIkIn273S8Odmhj9CPa5gmxz8wpvgVuHDBD9Ab2d30p+vXmd3wo5HIvwwyI8Gk/XIwo8GbcfPxoy8zzd4ePe0F6db4HQLNp7y8uxhT1ScH3CcOC1d45Ds+QG/xyMNvwBae8Ifxoq8iMN6gz3/m8f6EtYwUG8ejY7V2/NX5Yc/Qi3dPlN7fuHxxCYfRvgBLp86l/Tnq/N0U9yORyr8MIiPBpP1mIEfoHnXIaqWzgO00B/f5ROsO+jhdwc9cQ7LAm+O3y9o3VcvlWuo4Afw9fWSkZ8byGsAP4CzL7A0t9BuCZ/XS8zwe6W+lztm2JlWpv+WH2318nJ9b5y+4h/2T+6fTNTW48MZcT1A5rBfuAZMAx5m+AGa9h2heuEskvl8tRw6FtPfSIYfUj0CGGL4AbovXaZ5+4GINyHOOduAN0cIuLRrP32J5m1HaCjhRwNvpyOQVwL+4A8NLYFD53mVNin4EQK3T/CNNzo42pr4CT1HW718/fV2PD4xoK/48AtgXmXgq7z6S56oBkP4BdGPEx8B8AN0tXbQtKfB9Ofr4v7D9LZ1RvU10uGHoV4NmCL8wQ2NG7bQfuKs9JvjONXEuY1/Nkw11PADuDucpuAXwN7+yTfleZbQdF5IDH9Ql7r9fOGldv5ls5NDFz30egS9HsHBCx6e2uzkkRfaQrf+koF/RpmNinwrINjV7A41yMAP4O9yRv0t4mvo4A8GHNu0nbbT56Q/X51nznN2886onkYD/DCUqwHTBD+A8Pk4uG49k2+6loolc4g8XBt4WHZp137Obfwzwq/zeCqGB34Ad3t7uIbQP4Ef4sEPsPm0my8uycWiwS3TsvjpR15D+IM/ebyC5w/28tzBXoK0xgIb7YoHPwLWTLcDAp8f3j/ZZwp+AK/DMeLgh8Bj2fa/8DZTVy6hcn4tep+vi/sPc3bzzqjP12iBH4ZqNWAa4Q/14/Nx4s0POL/rIOXzZ1E4ZQK2wrz+q/1dOE6cpnVf/Yg87I9U34WLAXA0pOAHaOnysfucm8XVmdw6zc7v9vbS2TfwEWKx8Ef3lRr8xdkW1tRmA7CjyU1rl98U/EKA73IriTU88Afl9/k4tmkbzfsbqJg9naIJ1WQW5Aau9ju66TzdRMuhY6PysD9Sg78acBDgj1RvSxun395i2heqaRjhB/D3unC3d2AL3SJLbm7/Hw/0srg6E3uGxmfmZ/OTbd3h2EGGH+CRxbnY+z896/Z0m4Mf8HZ24h94ETCk4YU/cnPP5Q5Ovr9dyjfy4DcOGtzVgIMMf6q+4U6lTxwAABvkSURBVIY/uLG3+VywIin4IXAdIHjefUdtdsRinMGHf26VjTtmBvb+28642Xs+GmQj+AG8ly4SXyMHfjO+kQh//L9TtAZvNaCC36A5vLH7+EnMwN//kp9s68btE1g1+OaqAgqzwn0OFvzF2Rr/eGMhFg1cXnh6i2NAX8bwIwSeM2eIlYI/PT45+GGwVgMq+A2aoze6Wy/jau+/ViEJP0BTp4+f7Qgc+pfnWvjOzQXRswPTDH+2Db6/ppiy3MDH5kcfOmh2hGcYysLvczjxdkafOyv40+WThx8GYzWggt+gOc6HCOg+2mgK/qBeOdzHhv5ZfrVlNn6wppAiu2VQ9vzP3FnCjDGBE//1h3t59XDkhCE5+AFcp08NqETBnx7fAPglPOldDajgN2iODz9AV8Mx/C63KfiD5/w//NDJltOBW4PVltn4t7uLqKuwpQ3+OVU2fnFfaQj+90+4+JcPwof+ZuD3u924T56MiFbwp8dnHn5I52pABb9Bc2L4AfxeD47DRyIa5W/g6fPDP21y8Eb/kUB5rpWnby/i0RV5FGVZkoa/ONvC16/L50d3hg/7Xzvcyz++04EveIRhAn4BuI4fj1gEpOBPjy85+CEdawEGJFTwy22M94Y5D9WTXzsNS1aWNPzB1z4/PPWBkyMtHr66NA+bVePumdncMs3OG0d6efNYH8davVLwzyizsWa6nTW12aGv+lzewDl/sof9AhAuF67GxoR/k4GbFfxynmThlwqvmP09/WsKCn6DZjn4g8qbVkPxx5aFYyXgj/xBANUFFh5bkc+i6swob0u3jz3nPJxs93DR6cfhCjzjO99uoTLPwuSSDOZXZVKeZ42qctsZN09vSe6CX+Tr7p07+6/+K/jT4zOGv+ODL+v2lNoRgILfoNkc/ABdx4+TM20qWRVjkoIfBM2dPv7HGx3Mr7LxqXm5LK62oWkaY3Kt3DzNChjdHiwwvXdHk5t1e7qT+p5/IPze1st4zir40+dLbc8fVPIDgILfoNk8/IEgjbbNWym/cw2WzIhHboEU/JEX/Pae97D3fAelORaun5TFoupMZpZnUJwd//ZgbT0+6i8FJhi9d6KPy90mp/cO2Bh8LTweenftTEyRgt+kLz3wQxoWAyn45TbKvWGBBq/TSfuHWyldfX3Ym8IMv9ZuPy8e6uHFQz0IIM+mMSbPGpoz0OMStHQnsZ5fAn6Anl278XX36P3KMZ64ATqbpAIU/DFKaTGQgl9uoxn4g+o9fRbnocPk1c1MCf4BUSCgyy3oavNGXQA0ew8/Wfj7jhzFc+4ccaXgN+lLL/xg9n4ACn6D5vTAH1Tnzt30HGsMvU4H/FFbBxl+95mz9NXXE1cKfpO+9MMPSS4GUvDLbUwF/qA6tn2Eq/ncqIPfc+48vbt3EXMlExT8pn3Jwm8caHoxkIJfbmPK8Pc3Cb/g8rsf0HP8xKiB333mLD3bP0L4Ffyp+wYPfpC5BqDgN2gePPhD/Qk/HVu3Ifpc5NTNZMTCL6Dv6FH66g/Fp1vBb9I3uPCDiYuACn65jemGP7Ljzt17cbW2ULhs6YDn6g0//MLrpWfXLjzN6oJfenxpgF/CIzUAKPjlNg4a/BGNfWea8bS9RdHypdgqxgTyDjP83tbL9Ozcgb+nl7hS8Jv0DQ38IDEAKPjlNg4F/EH5urq4/M5GsidPJm/BfCz2LIYDfuF203foEK5TJxNTpOA36Rs6+EHqCEDBb7RxKOGPTNp78iSu5mZypk8je8Z0tKzMIYHf5/bgPn4MV2Nj/9N9FPzp8Q0t/JD2JwOZqEDBL1GGsc/vdtN18BDdR46QPXUq9imTySgsHBT4fQ4HrlOncJ86pZb0pt039PBDGhcDmapAwS9Rhjmf8HjpaThKd8NRMoqLsE+cSGZlJdbCfNC0UMGm4BfgdXTivXgRz5kz6jZeUho98EOaFgOZqkDBL1FGMr7wh8jb3kFXewewD0tWJrYxY7AWFmAtKMCal4+WZUPLyISMwNsvPB6E14voc+HtcuJ3OvE6HPgut46KW3eb8Sn4o5WGJwOZqEDBL1FGavAPlN/txtXcDM3Nacql06jgN+kbXvghmWcDKvhTyzWE8Kc/l06jgt+kb/jhhxQWA5mqQMEvUYaC32wu2QAFf2Il+WQgExUo+CXKUPCbzSUboODXl9w1AAW/+VwajJ87HYCzB44mokOvw8GFX4Pxc6b113dMz5S408GEX4MJdTUAnDl03MgUt2MFv3GwqcVApiq4muEnAP+i+24INZ/dd1S2CMNc6djzj58zjcX3rgrXtz/RIDA8e/7xs2tYfHf/HZEscPaA3iCg4Nf16cjkRUAFv2yu3JKCuD9LdDgkh/25Jfnhn4vzY9p1Ox2Cw/68iJryEtYXv2MFv3zwoD4aTNZ3pcFvXMbwwi+nEXDObygFf6q+QXs0mKxPwS+X66qDPwmfgt+8b1AeDSbrU/DL5VJX+40DFPzJ+cxPBDLILVuBgl8ul4LfOEDBn6wvHQOAgl+qDPM+Bb9MgII/efgh1QFAwS9Vhnmfgl8mQMGfGvyQygCg4Jcqw7xvqOE39gw//LFS8KcOPyQ7ACj4pcow71Pwy0jBL+dL+FmK0JCsBrz64E/Gpw77ZaTgTx/8MASrARX8crkU/MZS8KcXfhjk1YAKfrlcCn7jAAV/MvAbJzD9aDDZjhX8MlLwywTI7dEU/GbhB5kBQMEvUcYohj9CIxF+OSn4k4EfBmE1oIJfRgr+JALkfAp+U7nSuhpQwS+jEQJ/MkCqw/7Uco0w+CGNqwEV/HK5FPzGAeqC39DAD2laDajgl8ul4DcOUPAPHfyQhsVACn65XAp+4wAF/9DCDykOAAp+uaaRBv9IvOCn4B96+CGFAUDBL+sbylzJwm82j1wu2QAF//DAD0kOAAr+kZZLp1HBb9J39cAPSQwACn65XKPjsN9sHrlcsgFy8JvNkyBQwR9XpgYABb9cLgW/cYCCf/jhBxNPB1bwD2jSBjxZRwQapOGP8h9PTGmy8GuBh2sAnDk4sP84vjj1RT2ZJxGxycKvwYS6qf39N8b5/Q0g1mDCrH5/faRfwW9GUgOAgj+2afzc6Sy6dzUA+WVF1L+709Sef9bqJcy4bkEoIO6TeVLY84+fM43Fd68M1Xdo006ZTkOqW7mIGR+bD4DQtPhP5klhzz+hroYld10XqK+0kEPv707si5On7vqF1K6YG2o/c7BRyhevxisXfuNgw1MABb9x0/TrFjJ21mS9TqNUPXMyMz62QD8ojYf9M66dT/XMSUadhuurncSMa+enUF/8gEQHEbUr5lFdO1G2Y6pnTKR2+Vz9fAp+qagkvgVQ8AM07T/GxWNnQm0L715FQXmxXudAYG+88O6Vof4uNTbRNHDvmgb4mw4c58Kxs6G2RXetpGCMRH2lRSy687pwfSeaaTrYaKK++AED4T97qJELx5tC4YvvuE6yvkIW335tVH1nD500WV8g6IqHX8KT3tWAVwn8AEIIdjz/Ls7WdgAysmws+/StZGZnJfRk2jNZ/qlbyMjKBKCrrZPtz29EiIjfLE17fiEE21/aFK4v08byB28K1xdHmfZMVjxwU1R9H72wyUR98QPi7fmFEHz0yvs4WztC9a34i48b/v1W3H9jqD5nu4NtL39gsr5AkII/oPStBryK4A82eFxuPvqvt/G63ADkFuWz5P4b0SyxJk3TWPyJG8gtKQTA6/bw0bNv4+lzp1ZjgsN+AK/LzbY/vhtV3zWfWJ24vntWhR5k6nV72PbcRjwu2friB+hd7fe63Gx9YVNEfXksvWdlwvqW3HU9eZH1vbDJZH2BIAV/WOlZDXgVwh+sydnawc6X3gsVWT51HDNXL45xzLphMRXTJgReCNjz6gc4LrWnVqMO/MEA5+UOdrzyQbi+KdXMWrkwJrJu1SIqa8aHOtv92hYcLR2S9cUPkPmqz3m5kx3rt4TrmzyWWdfHXh+pu34BlVPHherb9ac/m6wvEKTgj5bVKCC38ua1MnlNNOg0jy74g+pq7cBitVA2sQqAsglVuHv6Que0fd29TFk0K9TnkS17aNx+KLUaJeAP1Xe5M1DfhMpAfeMrcfcOqG/hzHB9H+6lccdhyfriB5iZ4ecM1VcRqG9cBa7ePgrKisL1LagNpWnYup/GnQ0m6gsEXY3wu06++i09Z5qfDGTYoNM8OuEP6vB7O6MuClbNmBhqq54xKdTnpcYmDm/alVqNJuAPqv793Vw4Hr4oWDV9QkR9E8P1nWim/v09kvXFD0hmem/95j1caAxfFBw7bXy4vukTouv7YK+J+gJBVyP8Mkrjk4EMG3SaRzf8aIGLWjtffJfutk4ALNbwwZUlI/Bzd1snOyIv+g0R/KH6Xn6P7jZHbH3WYH0Otr+4SbK++AHJzu0XQrDj1Q/o0qmvq83BR698YKK+QJCCP7HS9GQgwwad5tEPf1DuPjdb/7AhdFErUl63h23Pvo07eNFvCOGPrO/Pz76dsL6tz70jWV/8gFQX9rj73Pz5+Y2J63txk4n6AkEKfn2l4clAhg06zVcO/EE5WzvY/cr70b+IgN0vvx++6DcM8Ifqu9zBrvWbY+rb9erm8EW1YYA/XF8nO1//MKa+na99aKK+QJCC31gpPhnIsEGn+cqDP6jmw6c4siV8Hn1kyx6aD5809A02/KH6Gk5x5MN94fo+3EdzwymJ+uIHpHtJb/OR0zRs3R963bB1P81HTkvWFwhS8MtJejGQgt9crvpNO3G2Bq4HnD1wTNqntzmdd/I59P6uUH1nDh2X9g3UYK3nP/TBbpytgesBZ+obpX0KfnOSGwAU/OZzCaIX+Iwg+IMdnjl4PGazoS9Cg3ozD6EFVgma8in4zSqJJwMZNug0XyXwp8M3mPCnwafu5DMa4Dc2JPk1oII/9Vw6jQp+kz4Ff0KfgYZoNaCCX7pRwW/Sp+BPxTcEqwEV/NKNCn6TPgV/qr5BXg2o4JduVPCb9Cn40+EbxNWACn7pRgW/SZ+CP12+1J8NqOBPzafgN+lT8Mv6En6+IzQIqwEV/NKNCn6TPgW/rE8Gfkj7akAFv3Sjgt+kT8Ev65OFH9K6GlDBL92o4DfpU/DL+szAD2bWAgzIa7RRwX9lwH/dwmruuaGG2TWllBTaaXe4OHvBydtbz/Dqeye47bpJuDw+1r9/wihZbD4FfxKexD6z8EulHrPgqXC/Cv6kfMvmj+X731hJfm5m3Gi3x8eFlm7e39nEb145RGt7r1SeMSU53LlqKtlZ4XG8q8fDyxuP09ntorw0hztXTsEe0e7sdvPqpkY6nLFr7iPhLy7I4nuPXccnb5meML/L4yPLFrhZx+fXvs1LG2MfHrJ8XhU/ePy6hL+7ENB8qYtjp9vZtLOJV9+LHEgU/LK+RJ9vx8bP62ZIcTWggl+m8SsPzqeupkzPRM2EYj62aBxffmA+T3x/E6+912j44fjVd9awbF5VzPYblk3g4b97g99+7zYW11XEtK9cMp7P//1bUdsi4Z9YVcCGn32C8pIc3fxB+AEmVObHjfnKJ+dRN7VUt5+JVfmsmFfFw3fNYlf9Jb787Y00NjkU/JK+ZPb8QcldA1Dwp+R79o0GHF2xe9x4Ki2y8+vvreGJz8XeWXhgrl6XN26Ly+0DwO+P/9t393iiXkfCr2nwzN+sDsHv9fl5Zt0ebv7Si4y/6RfU3fsb/vu33uHAsVap3+e5t47R4XRJxQIsmlXOb79zK9n2iH2Tgj+hLxX4pcoYs/CpODkU/NKN/Ztzsm2ceffLQADQsSt/GgoYU5JDXU0p3/zSMhbOCuyxPV4/qz/7LIdPXE7YaW62je8/cT2fur0WgA/3NPOHPzWw/r1Guno8lBVnc+u1k/nC/XOYMy1wBPKT3+/luz//CJcnMEgMPOd/+K5Z/Ov/XBWq8/avvcTu+paY9Jk2C6/9+J7QEca3/n0bz6zbQ0xgv77+3xbyzS9eA8DT6/bwTz/7KBChQWVZLvesnsraLy/DlhHYJ333P3fw5K93K/h1fMbwazg2PqKbLS2LgRT8+vCD/gW/lrYe3tt+llu/+Dx/+iBwDmzLsPD0367W7bS71xM1QBw42sof/tRAV/8evrW9l9+9Vs/Jps5QzMFjrQnhB/jCfXNCPz/5q51x4Qdwe/z823Phu/ZcautJWGe8l0EJAedbuvm3P+7np8+G+1s6p1LBr+OTgV8ml8lvART80o2S8EfKJwTfePJ9Vi0ZT062jcV1lUybWMyx0+0JPckqHvxF+VlR5+u/XX84OmCA57X3T/APP92KRdN4/u1jiQOlytbYcyQ82NSML5IxoeBP4JPMZWIAUPBLNxrCn9hz8XI3u+ovct2iwFNwlsyu7B8AjHPJBiT6nr+iNHzRr6WtlxaDbyM8Xj8/+cPeAVuTg18A82eMCW05frYjcXi8zhX8YZ+JXJIDgIJfujEF+IM6eKw1NACUl+ZI5QL48gPz+PID83RT6U3yifw6sbVD7qtI3YIkfJqmUV6ayz2rpvCXD4Qf+f3ezib5XAr+sM9kLokBQMEv3ZgG+AF6+8JX9zNtCZ7elr6zgbiyWsx+eOXh/+uHFvDXD8U+/y+oI6fa+fmLB+VyKfjDviQ+E6ZnAir403fOn6iryjG5oZ+d3XG+Pkzg6+710BnnK7eSQnvUZKBEanOEvROrC7DZLHi8fkNfcof98XWiuZOHvrkBtydRXgV/XF+Sf3OZAcAFZMUUouCPuzkd03vnRpwLn73glPb99tV6vvmjD2O2/79v38Jdq6cmNvZ3fL6lm64eD3k5NrJsVlbMG8v7u0wcihvUF1RXjwdH/8Dm9flxdrs50exg044mfv/mkdA8Bt1cCv6wL3EuwwkYxgOAoAONCgV/GuHX0f03T2d2/6xBj9fP5p3NyXYVqEnKo4XyvfbBCR68dQYAP/7b1az+/HNc7uyL79I0/uFLS7l+0Ti++4vtbNx+VqqmX7x0iG/1zwNI6hRDwR/26edy6rYiMw/AQqeCf/DhL8rP4uufXcLTf3NDaNvTv9lFZ5fLbFfhmkzAH9T3f7mTvv4ZhuMq8tj6uwf5yifnUV2eh6X/uoDForF0ThXrvreGxx5awILaMfzNI0vMF6jgT+hLz2G/ZjgAGHZRtuBftqBxrX60gl8vYP7Mcv7hK8tZuSTwyGsh4OwFR6i9KN9OQV70Ypl9DS3c/MXn8fr8cUvIy7Hx3ceuY8X8sUweVwjAuUtdHDjWyo/X7eHP+8/z8WUT+NJfzGXejDGUFWUD0HCyjc27m/n7n3yI2zOg8v48az42iV9/+xYyrNH7B5fHh8PppqTIHr5I2K9//uUOfvCrXQzU8rlV/PNj1zKhqoDC/t/R0e0OTQ/2eP28vvkU//jv2+L+FRX8CXwSuQRiv/Odz+t+LWR8CqBRD1yr4I+/WWbP/7VPLwjBD6BpMKGqIGHWlzce55vPbEkIP8B9N03noTtmRm0bW57H2PI8crJt3P3oK/zgieuZNDY6T+3kEmonl/D21jO8s+1M3JLf2HKKVY88z3f+agUrF48Lbc+yWRlTkh3VX2+flx/9YW9c+AG+8sm5oWnIQRXkZlIQsTrw0U/N4+nf76HdMfCUVcEf1yeZS8NywSjGcADQNA4mLkrBL+N75d3jrFwynpJCe1yHy+OjvbOPnQcv8h/P72fL7mbD+t7bfpbGsx1Mri4MHZoDNDZ18suXAl+hrXv9MI9/ZiE5dluovbfPy7b959m8W//aQv2Jy9z7+HpuWj6B+z8+ncV1FZSXZKNpGmcvODl7wckHu5v53esNuot9nnvrGCvmV1FSEP93b3P08fw7xxX8MTUl8JnK5T8iWUlilS1+chXCssmUVcEvmUcul2yAupOPgj/aYvma4+3P/l+9EMOLgHab9SOgN3qrgl/Kp+BPLZeCP+xLIpcmjI8ADAeApq1P9GqwOaqYxDl1CzLfpOCXCVDwK/jjePx+YR24PjtGUsuBBWwIdayTM6lGBX9KPgW/gj++R+xzbnw43s0koiQ1AGhCexW0pK4FKvjN55INUPAr+BN5NHhXxiE1ALTsfuI4gg8S5dQtyHSTgl8mQMGv4NfzCLT0DQAAwiJ+GS+nbkGmmxT8MgEKfgW/gafT0ZUb55u7WEkPAFki73kgfJcGBb9kHrlcsgEKfgW/kUdo/JGtn+yNHx8t6QHg3K4v9Qj4STCnbkGmmxT8MgEKfgW/lEfjt7I9mLopqCeTf0XTW2Gk4DebSzZAwa/gl/Nox50bPrtFthdTA4Bj6xNtmkaCmUUKfrO5ZAMU/Ap+WY+m8SR639gNkOnbgvdpmU9pMOD7RQW/2VyyAQp+Bb+sR6A1dVodvzbTm+kBwLn9a5eFJv42qqBEUvCn5FPwK/jNeDSNJ3njUfnHMJHk48Fbdzj/U9PYpuA3n0s2QMGv4Dfl0Wh0uMXPzfaa1AAAa/0I8VXAE7dZwZ+ST8Gv4DftETzKe5+Lf+82HSU5AEDLzq/vEfC/YxoU/Cn5FPwKfrMeDfGS4+3P/clsz5DCAABweWfnU8A7EZUkkIJfJkDBr+BPwtNu1XjMbM9BpTQABE4F+G/ARQV/aj4Fv4I/CY8QQnyu7a1H5G7HHEcpDgDQuuvx81jEHcDAx8Oi4JcLUPAr+JPyCO1p5zuPvGK290ilPAAAtG5/YqemaZ8FIh7nouCXCVDwK/iT8gg2O4pz/sZs7wOV4MFz5tXT/GZ99rhb+zS4ScEvF6DgV/An49HQDmpZmbe4Xv5Ut9kMA5W2AQCgt3nDh9nj1vQBH48boOAPScGv4E/GI9CarMJyY8eGz1w0myGe0joAAPQ2v/lhTvUtbtBujGpQ8Iek4FfwJ+k5g9/y8c6ND58wmyGR0j4AAPSe27Ale+ytDk3jJkBT8Iel4FfwJ+PR0A56fJbV3e8+fMpsBj2l5SJgPLXt/Ot/1fDfQ9qXD+s0KvhN+hT8sr7hvuBHpu363ncfbjYONqdBGwAAWnc8sd7v11ZocDK2VcFv6FPwp5Zr9MMvQPzIUZz78c7XH2o3m0GyisFXwfIflmT6LT8VggcM0yr4JfOk4lPwy/qGc4afEOJzqX7PL1HJ0Kls6TMPCsH/BUrMV6PgT49PwS/rG865/VaNx1KZ4WeimqFV2bU/His8/h8An47Kr+CXzJOKT8Ev6xuuJb0IHk12YU8yGvIBIKiya368WOB/Clip4JfNk4pPwS/rG447+WiIpxwefpbMkt5UNGwDQFDFy368xiL8fw39XxlGScGfHp+CX9Y31Dfw1DSe7CzM+RXPfdJtttd0aNgHgKBKl/+4Fr//a8BDQJGCP10+Bb+sb4jg7xAaz6Hx28Dde+Vv4DkYGjEDQEiLfmYrtblW4tfuQhN3ARNDbQp+kz4Fv6xvEOH3g9gH2iZgo8PDu0N9mK+nkTcADFDxomcmWG3aPIGYq6HNEzBeQBHh/+yBSAX/wCAFv5wvRfjdQBfQIQROTdMugjiKZmnQhP+IX1j3yDylV0lJSUlJSUlJSUlJSUlJSUlJSUlJSUlJSUlJSUlJSUkpVf3/EVFjZXmdpY0AAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kea.openshift.io
+          resources:
+          - keacontrolagents
+          - keadhcp4servers
+          - keadhcp6servers
+          - keadhcpddns
+          - keaservers
+          - keastorkservers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kea.openshift.io
+          resources:
+          - keacontrolagents/finalizers
+          - keadhcp4servers/finalizers
+          - keadhcp6servers/finalizers
+          - keadhcpddns/finalizers
+          - keaservers/finalizers
+          - keastorkservers/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - kea.openshift.io
+          resources:
+          - keacontrolagents/status
+          - keadhcp4servers/status
+          - keadhcp6servers/status
+          - keadhcpddns/status
+          - keaservers/status
+          - keastorkservers/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - podmonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - get
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - create
+          - get
+          - update
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - kea-dhcp
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: ocp-kea-dhcp-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: ocp-kea-dhcp
+          control-plane: controller-manager
+        name: ocp-kea-dhcp-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                command:
+                - /manager
+                image: quay.io/mooyeg/ocp-kea-dhcp:v0.0.27
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                  requests:
+                    cpu: 10m
+                    memory: 128Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: ocp-kea-dhcp-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: ocp-kea-dhcp-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - dhcp
+  - kea
+  - networking
+  - ipam
+  - dhcpv4
+  - dhcpv6
+  links:
+  - name: Kea DHCP Operator
+    url: https://github.com/MoOyeg/kea-dhcp-operator
+  - name: ISC Kea Documentation
+    url: https://kea.readthedocs.io/
+  maintainers:
+  - email: moyegunl@redhat.com
+    name: Moyo Oyegunle
+  maturity: alpha
+  minKubeVersion: 1.28.0
+  provider:
+    name: Moyo Oyegunle
+  version: 0.0.27

--- a/operators/ocp-kea-dhcp/0.0.27/metadata/annotations.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/metadata/annotations.yaml
@@ -1,0 +1,18 @@
+annotations:
+  # OpenShift versions
+  com.redhat.openshift.versions: "v4.18"
+
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: ocp-kea-dhcp
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.38.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/ocp-kea-dhcp/0.0.27/tests/scorecard/config.yaml
+++ b/operators/ocp-kea-dhcp/0.0.27/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.38.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.38.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.38.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.38.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.38.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.38.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
Update: Kea DHCP Operator v0.0.27
- Security: patch 3 Go stdlib CVEs via toolchain bump 1.25.10 -> 1.25.11
- CVE-2026-42504 (HIGH) stdlib, fixed in Go 1.25.11
- CVE-2026-27145 (MEDIUM) stdlib, fixed in Go 1.25.11
- CVE-2026-42507 (MEDIUM) stdlib, fixed in Go 1.25.11

Container image: quay.io/mooyeg/ocp-kea-dhcp:v0.0.27
Bundle image:    quay.io/mooyeg/ocp-kea-dhcp-bundle:v0.0.27

Signed-off-by: Moyo Oyegunle <moyegunl@redhat.com>