### PR TITLE
operator [N] [CI] mitos (0.13.0)

### DIFF
--- a/operators/mitos/0.13.0/manifests/mitos.clusterserviceversion.yaml
+++ b/operators/mitos/0.13.0/manifests/mitos.clusterserviceversion.yaml
@@ -416,6 +416,16 @@ spec:
                       - --enable-husk-pods
                       - --husk-stub-image=ghcr.io/mitos-run/mitos-husk-stub:v0.13.0
                       - --husk-data-dir=/var/lib/mitos
+                    env:
+                      # Run the control plane (PKI bootstrap, forkd discovery) in
+                      # the namespace OLM installs the operator into, not the
+                      # hardcoded default. Without this the controller tries to
+                      # create its CA Secret in a "mitos" namespace that does not
+                      # exist under OLM and crash-loops.
+                      - name: FORKD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
                     ports:
                       - name: metrics
                         containerPort: 8080

--- a/operators/mitos/0.13.0/manifests/mitos.clusterserviceversion.yaml
+++ b/operators/mitos/0.13.0/manifests/mitos.clusterserviceversion.yaml
@@ -1,0 +1,448 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: mitos.v0.13.0
+  namespace: placeholder
+  annotations:
+    capabilities: Basic Install
+    categories: Application Runtime,Developer Tools
+    containerImage: ghcr.io/mitos-run/mitos-controller:v0.13.0
+    repository: https://github.com/mitos-run/mitos
+    support: mitos
+    createdAt: "2026-06-22T00:00:00Z"
+    description: >-
+      Snapshot-fork microVM sandboxes for AI agents on Kubernetes. mitos boots
+      Firecracker microVMs, forks them via copy-on-write snapshots, and exposes
+      the whole lifecycle through declarative CRDs.
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "mitos.run/v1",
+          "kind": "SandboxPool",
+          "metadata": {
+            "name": "python-agent-pool"
+          },
+          "spec": {
+            "template": {
+              "image": "python:3.12-slim",
+              "init": [
+                "pip install numpy pandas scikit-learn"
+              ],
+              "resources": {
+                "cpu": "2",
+                "memory": "2Gi"
+              },
+              "volumes": [
+                {
+                  "name": "datasets",
+                  "mountPath": "/data",
+                  "readOnly": true,
+                  "forkPolicy": "Share",
+                  "source": {
+                    "s3": {
+                      "bucket": "ml-datasets",
+                      "prefix": "/training",
+                      "region": "us-east-1"
+                    }
+                  }
+                },
+                {
+                  "name": "code",
+                  "mountPath": "/workspace",
+                  "size": "10Gi",
+                  "storageClass": "btrfs-csi",
+                  "forkPolicy": "Snapshot",
+                  "snapshotClass": "btrfs-snapshots",
+                  "source": {
+                    "git": {
+                      "repo": "https://github.com/org/agent-workspace",
+                      "branch": "main"
+                    }
+                  }
+                },
+                {
+                  "name": "state",
+                  "mountPath": "/state",
+                  "size": "2Gi",
+                  "forkPolicy": "Clone"
+                },
+                {
+                  "name": "scratch",
+                  "mountPath": "/tmp",
+                  "size": "1Gi",
+                  "forkPolicy": "Fresh"
+                }
+              ],
+              "network": {
+                "egress": "deny",
+                "allow": [
+                  "api.openai.com:443",
+                  "*.s3.amazonaws.com:443"
+                ]
+              }
+            },
+            "snapshots": {
+              "replicasPerNode": 10,
+              "snapshotAfter": "Ready",
+              "scaleDownAfterSnapshot": true
+            }
+          }
+        },
+        {
+          "apiVersion": "mitos.run/v1",
+          "kind": "Sandbox",
+          "metadata": {
+            "name": "agent-session-1"
+          },
+          "spec": {
+            "source": {
+              "poolRef": {
+                "name": "python-agent-pool"
+              }
+            },
+            "env": [
+              {
+                "name": "SESSION_ID",
+                "value": "abc-123"
+              }
+            ],
+            "secrets": [
+              {
+                "name": "openai-key",
+                "secretRef": {
+                  "name": "agent-secrets",
+                  "key": "OPENAI_API_KEY"
+                },
+                "envVar": "OPENAI_API_KEY"
+              }
+            ],
+            "lifetime": {
+              "ttl": "30m"
+            }
+          }
+        }
+      ]
+spec:
+  displayName: mitos
+  description: |-
+    ## mitos
+
+    Snapshot-fork microVM sandboxes for AI agents on Kubernetes. mitos boots
+    Firecracker microVMs, forks them via copy-on-write snapshots, and exposes
+    the whole lifecycle through declarative custom resources in the API group
+    `mitos.run`.
+
+    Agent harnesses need fast, isolated environments where agents can read and
+    write files, install packages, and run untrusted code. mitos gives each
+    agent an isolated, forkable computer: a Firecracker microVM that restores
+    from a memory snapshot, forks into parallel attempts via copy-on-write, and
+    can persist a durable workspace. You drive the whole lifecycle through
+    declarative CRDs on your own cluster.
+
+    ### What this operator installs
+
+    This operator deploys the mitos **controller**, a Deployment that reconciles
+    the mitos custom resources and selects nodes for sandbox placement. The
+    controller, once running, deploys and drives the per-node components it needs
+    (the privileged `forkd` DaemonSet and, on the husk pod-native default, warm
+    husk pods). Those node-level components are managed by the controller and are
+    not installed directly by OLM.
+
+    ### Custom resources
+
+    - **SandboxPool**: a warm pool built from an inline template (image, init
+      steps, resources, volumes, and an egress allowlist); pre-snapshots VMs
+      so a Sandbox activates in place.
+    - **Sandbox**: a single running sandbox instance. Created from a pool
+      snapshot (source.poolRef), forked from a live sandbox
+      (source.fromSandbox), or resumed from a WorkspaceRevision
+      (source.fromRevision).
+    - **Workspace** and **WorkspaceRevision**: durable, forkable workspace
+      state and its committed revisions.
+
+    ### Requirements (read before installing)
+
+    mitos runs real virtual machines. It requires:
+
+    - Cluster nodes with **KVM / hardware virtualization** available to the
+      `forkd` DaemonSet (nested virtualization if running on a virtualized
+      platform).
+    - The ability to run a **privileged DaemonSet** that accesses `/dev/kvm` and
+      host paths on those nodes.
+    - Bare metal is the reference platform (Hetzner plus Talos). Managed control
+      planes and locked-down platforms may not permit the privilege and device
+      access mitos needs; verify before relying on it.
+
+    The controller image referenced by this bundle is
+    `ghcr.io/mitos-run/mitos-controller:v0.13.0`. NOTE: the project is migrating
+    its image registry; the controller and the node images
+    (`mitos-forkd`, `mitos-husk-stub`, `mitos-kvm-device-plugin`, `mitos-facade`)
+    must be present under `ghcr.io/mitos-run` before this bundle can install and
+    run. Until then the images are published under `ghcr.io/paperclipinc`.
+
+    Project website: https://mitos.run
+    Documentation: https://mitos.run/docs
+    Source: https://github.com/mitos-run/mitos
+  version: 0.13.0
+  maturity: alpha
+  minKubeVersion: 1.28.0
+  keywords:
+    - sandbox
+    - firecracker
+    - microvm
+    - ai-agents
+    - fork
+    - snapshot
+    - kvm
+    - agents
+  provider:
+    name: mitos
+    url: https://mitos.run
+  maintainers:
+    - name: mitos maintainers
+      email: maintainers@mitos.run
+  links:
+    - name: Website
+      url: https://mitos.run
+    - name: Documentation
+      url: https://mitos.run/docs
+    - name: Source
+      url: https://github.com/mitos-run/mitos
+  icon:
+    - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI1MjMuNjA3IiBoZWlnaHQ9IjUyMy42MDciIHZpZXdCb3g9IjAgMCA1MjMuNjA3IDUyMy42MDciPgogIDx0aXRsZT5taXRvcyBtYXJrPC90aXRsZT4KICA8ZGVzYz5Ud28gb3ZlcmxhcHBpbmcgY2lyY2xlczogYSBmaWxsZWQgZGlzYyBkaXZpZGluZyBpbnRvIGFuIG9wZW4gcmluZy4gR2VvbWV0cnkgZGVyaXZlZCBmcm9tIHRoZSBnb2xkZW4gcmF0aW8uPC9kZXNjPgogIDxjbGlwUGF0aCBpZD0ibGVmdERpc2MiPgogICAgPGNpcmNsZSBjeD0iMjAwIiBjeT0iMjYxLjgwMyIgcj0iMTAwIi8+CiAgPC9jbGlwUGF0aD4KICA8Y2lyY2xlIGN4PSIyMDAiIGN5PSIyNjEuODAzIiByPSIxMDAiIGZpbGw9IiMwMDAwMDAiLz4KICA8Y2lyY2xlIGN4PSIzMjMuNjA3IiBjeT0iMjYxLjgwMyIgcj0iMTAwIiBmaWxsPSJub25lIiBzdHJva2U9IiMwMDAwMDAiIHN0cm9rZS13aWR0aD0iMTQuNTkiLz4KICA8ZyBjbGlwLXBhdGg9InVybCgjbGVmdERpc2MpIj4KICAgIDxjaXJjbGUgY3g9IjMyMy42MDciIGN5PSIyNjEuODAzIiByPSIxMDAiIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2ZmZmZmZiIgc3Ryb2tlLXdpZHRoPSIxNC41OSIvPgogIDwvZz4KPC9zdmc+Cg==
+      mediatype: image/svg+xml
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true
+  customresourcedefinitions:
+    owned:
+      - name: sandboxpools.mitos.run
+        kind: SandboxPool
+        version: v1
+        displayName: Sandbox Pool
+        description: >-
+          A warm pool of Firecracker microVM snapshots. Inlines the template
+          (image, init steps, resources, volumes, network policy) and governs
+          snapshot fan-out and the warm-pod autoscaler. Replaces the former
+          SandboxTemplate and SandboxPool pair.
+      - name: sandboxes.mitos.run
+        kind: Sandbox
+        version: v1
+        displayName: Sandbox
+        description: >-
+          A single running sandbox instance. Source is a required oneof:
+          poolRef (claim from a pool snapshot), fromSandbox (CoW fork of a
+          live sandbox), or fromRevision (resume from a WorkspaceRevision).
+          Replaces the former SandboxClaim and SandboxFork kinds.
+      - name: workspaces.mitos.run
+        kind: Workspace
+        version: v1
+        displayName: Workspace
+        description: >-
+          Durable, forkable workspace state. Tracks the head revision and the
+          resumable set, and reconciles its owned WorkspaceRevisions under a
+          retention policy.
+      - name: workspacerevisions.mitos.run
+        kind: WorkspaceRevision
+        version: v1
+        displayName: Workspace Revision
+        description: >-
+          A committed revision of a Workspace, owner-referenced by its
+          Workspace; carries the diff summary and lineage for a dehydrated
+          workspace state.
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+        - serviceAccountName: mitos-controller
+          rules:
+            - apiGroups:
+                - mitos.run
+              resources:
+                - sandboxes
+                - sandboxpools
+                - workspacerevisions
+                - workspaces
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - mitos.run
+              resources:
+                - sandboxes/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - mitos.run
+              resources:
+                - sandboxes/status
+                - sandboxpools/status
+                - workspacerevisions/status
+                - workspaces/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - nodes
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - clusterroles
+              verbs:
+                - bind
+              resourceNames:
+                - mitos-pool-secrets
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - rolebindings
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - create
+                - get
+                - list
+                - update
+                - watch
+      deployments:
+        - name: mitos-controller
+          label:
+            app.kubernetes.io/name: mitos
+            app.kubernetes.io/component: controller
+          spec:
+            replicas: 2
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: mitos
+                app.kubernetes.io/component: controller
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: mitos
+                  app.kubernetes.io/component: controller
+              spec:
+                serviceAccountName: mitos-controller
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                containers:
+                  - name: controller
+                    image: ghcr.io/mitos-run/mitos-controller:v0.13.0
+                    args:
+                      - --metrics-bind-address=:8080
+                      - --health-probe-bind-address=:8081
+                      - --enable-husk-pods
+                      - --husk-stub-image=ghcr.io/mitos-run/mitos-husk-stub:v0.13.0
+                      - --husk-data-dir=/var/lib/mitos
+                    ports:
+                      - name: metrics
+                        containerPort: 8080
+                      - name: health
+                        containerPort: 8081
+                    resources:
+                      requests:
+                        memory: "128Mi"
+                        cpu: "100m"
+                      limits:
+                        memory: "512Mi"
+                        cpu: "500m"
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                        drop:
+                          - ALL
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: health
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: health
+                      initialDelaySeconds: 15
+                      periodSeconds: 20

--- a/operators/mitos/0.13.0/manifests/mitos.run_sandboxes.yaml
+++ b/operators/mitos/0.13.0/manifests/mitos.run_sandboxes.yaml
@@ -1,0 +1,752 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: sandboxes.mitos.run
+spec:
+  group: mitos.run
+  names:
+    kind: Sandbox
+    listKind: SandboxList
+    plural: sandboxes
+    singular: sandbox
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.endpoint
+      name: Endpoint
+      type: string
+    - jsonPath: .status.pod
+      name: Pod
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          Sandbox is the v1 consolidated run-axis kind: one running sandbox. It
+          folds the former SandboxClaim and SandboxFork into one kind (ADR 0007). Its
+          source is a required oneof selecting the origin (a pool snapshot, a live
+          sandbox to fork, or a workspace revision to resume); replicas carries the
+          fork fan-out. A Sandbox with source.poolRef and replicas 1 is the old claim;
+          a Sandbox with source.fromSandbox and replicas N is the old fork.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Spec is the desired sandbox: its source, fan-out, lifetime, budget, and
+              the workspace/secret/network bindings carried from the v1alpha1 claim/fork.
+            properties:
+              budget:
+                description: |-
+                  Budget is the capability budget for runtime self-service: the five maxima
+                  (maxForks, maxCheckpoints, maxCpuSeconds, maxLifetimeExtension,
+                  maxEgressBytes). NEW v2 surface (v2-spec section 3); defaults from the
+                  pool's defaultBudget. Runtime enforcement is issue #25.
+                properties:
+                  maxCheckpoints:
+                    description: MaxCheckpoints bounds the self-initiated checkpoints
+                      the sandbox may take.
+                    format: int32
+                    type: integer
+                  maxCpuSeconds:
+                    description: MaxCpuSeconds bounds the cumulative CPU seconds the
+                      sandbox may consume.
+                    format: int64
+                    type: integer
+                  maxEgressBytes:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxEgressBytes bounds the cumulative egress bytes the sandbox may send. It
+                      is a Kubernetes quantity (for example "1Gi").
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxForks:
+                    description: |-
+                      MaxForks bounds the self-initiated forks (depth-aggregate) the sandbox may
+                      create at runtime.
+                    format: int32
+                    type: integer
+                  maxLifetimeExtension:
+                    description: |-
+                      MaxLifetimeExtension bounds the total lifetime extension the sandbox may
+                      request at runtime.
+                    type: string
+                type: object
+              env:
+                description: |-
+                  Env are environment variables delivered to the sandbox. Carried unchanged
+                  from SandboxClaim.env.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: |-
+                        Name of the environment variable.
+                        May consist of any printable ASCII characters except '='.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fileKeyRef:
+                          description: |-
+                            FileKeyRef selects a key of the env file.
+                            Requires the EnvFiles feature gate to be enabled.
+                          properties:
+                            key:
+                              description: |-
+                                The key within the env file. An invalid key will prevent the pod from starting.
+                                The keys defined within a source may consist of any printable ASCII characters except '='.
+                                During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                              type: string
+                            optional:
+                              default: false
+                              description: |-
+                                Specify whether the file or its key must be defined. If the file or key
+                                does not exist, then the env var is not published.
+                                If optional is set to true and the specified key does not exist,
+                                the environment variable will not be set in the Pod's containers.
+
+                                If optional is set to false and the specified key does not exist,
+                                an error will be returned during Pod creation.
+                              type: boolean
+                            path:
+                              description: |-
+                                The path within the volume from which to select the file.
+                                Must be relative and may not contain the '..' path or start with '..'.
+                              type: string
+                            volumeName:
+                              description: The name of the volume mount containing
+                                the env file.
+                              type: string
+                          required:
+                          - key
+                          - path
+                          - volumeName
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              lifetime:
+                description: |-
+                  Lifetime carries the wall-clock and idle limits and the terminate-time
+                  outputs/snapshot directives. It re-homes the v1alpha1 SandboxClaim
+                  timeout/idleTimeout/outputs/checkpointOnTerminate/ttlSecondsAfterFinished.
+                properties:
+                  idleTimeout:
+                    description: |-
+                      IdleTimeout reaps the sandbox after this much time with no exec or file
+                      activity. Zero means no idle limit. Maps from SandboxClaim.idleTimeout.
+                    type: string
+                  onTerminate:
+                    description: |-
+                      OnTerminate declares what the terminate step captures (outputs) and whether
+                      it retains a snapshot. Re-homes SandboxClaim.outputs and generalizes
+                      SandboxClaim.checkpointOnTerminate.
+                    properties:
+                      outputs:
+                        description: |-
+                          Outputs declares what the terminate-with-outputs step captures from the
+                          sandbox /workspace into the new WorkspaceRevision. Carried unchanged in
+                          shape from SandboxClaim.outputs (path, diff, git).
+                        items:
+                          description: OutputSpec is one terminate-with-outputs directive.
+                          properties:
+                            diff:
+                              description: |-
+                                Diff requests that the new revision record the content-hash diff against
+                                the workspace head revision before it.
+                              type: boolean
+                            git:
+                              description: Git pushes the workspace spec.git.paths
+                                content to a rendezvous remote.
+                              properties:
+                                branch:
+                                  description: Branch is the per-attempt branch the
+                                    push lands on.
+                                  type: string
+                                remote:
+                                  description: Remote is the rendezvous git remote
+                                    the workspace repo paths are pushed to.
+                                  pattern: ^(https://|http://|ssh://|git://|file://|[A-Za-z0-9._-]+@[A-Za-z0-9._-]+:).+
+                                  type: string
+                              type: object
+                            path:
+                              description: Path narrows the captured revision to this
+                                /workspace subtree.
+                              type: string
+                          type: object
+                        type: array
+                      snapshot:
+                        description: |-
+                          Snapshot is a retention directive (for example "retain-last-3") that
+                          generalizes the v1alpha1 SandboxClaim.checkpointOnTerminate boolean: a
+                          non-empty value requests a memory snapshot paired with the new revision so
+                          the workspace head becomes resumable.
+                        type: string
+                    type: object
+                  ttl:
+                    description: |-
+                      TTL is the maximum wall-clock lifetime of the sandbox (maxLifetime). Zero
+                      means no limit. Maps from SandboxClaim.timeout.
+                    type: string
+                  ttlSecondsAfterFinished:
+                    description: |-
+                      TTLSecondsAfterFinished bounds how long a finished sandbox lingers in the
+                      API before the garbage collector reaps it from etcd. Maps from
+                      SandboxClaim.ttlSecondsAfterFinished, re-homed under lifetime.
+                    format: int32
+                    type: integer
+                type: object
+              network:
+                description: |-
+                  Network carries per-sandbox network additions on top of the pool policy.
+                  NEW v2 surface (extraAllow); default empty.
+                properties:
+                  extraAllow:
+                    description: |-
+                      ExtraAllow adds host:port egress destinations on top of the pool template's
+                      allowlist for this sandbox only. Default empty.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              nodeName:
+                description: |-
+                  NodeName is an optional node preference for placement. Carried unchanged
+                  from SandboxClaim.nodeName.
+                type: string
+              replicas:
+                default: 1
+                description: |-
+                  Replicas is the fork fan-out: 1 (the default) is a single sandbox (the old
+                  claim), and a value greater than 1 with source.fromSandbox produces that
+                  many indexed sibling children (the old fork). Carried from
+                  SandboxFork.replicas.
+                format: int32
+                minimum: 1
+                type: integer
+              resume:
+                default: memory
+                description: |-
+                  Resume selects whether a fromSandbox/fromRevision source restores warm VM
+                  memory (memory, the default) or only the filesystem (filesystem). A
+                  cross-principal handoff forces filesystem (the memory-snapshot principal
+                  binding, ADR 0002, docs/fork-correctness.md). NEW v2 surface with a
+                  documented default; it has no v1 source field.
+                enum:
+                - memory
+                - filesystem
+                type: string
+              secretInheritance:
+                default: reissue
+                description: |-
+                  SecretInheritance governs whether a fork (source.fromSandbox) inherits the
+                  source sandbox's in-memory secrets. reissue (the default) gives each fork
+                  fresh credentials; inherit requires source opt-in and duplicates guest
+                  memory including secret values (docs/fork-correctness.md section 3). It
+                  replaces and inverts the v1alpha1 SandboxFork.allowSecretInheritance
+                  boolean (false -> reissue, true -> inherit).
+                enum:
+                - reissue
+                - inherit
+                type: string
+              secrets:
+                description: |-
+                  Secrets are the secret mounts delivered to the sandbox. Carried unchanged
+                  from SandboxClaim.secrets.
+                items:
+                  description: |-
+                    SecretMount delivers a Kubernetes Secret key to the sandbox as an env var
+                    or a mounted file.
+                  properties:
+                    envVar:
+                      type: string
+                    mountPath:
+                      type: string
+                    name:
+                      type: string
+                    secretRef:
+                      description: SecretKeySelector selects a key of a Secret.
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret or its key must
+                            be defined
+                          type: boolean
+                      required:
+                      - key
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - name
+                  - secretRef
+                  type: object
+                type: array
+              serviceAccount:
+                description: |-
+                  ServiceAccount is the principal this sandbox runs as: the identity workspace
+                  grants are evaluated against and a memory snapshot is bound to. Carried
+                  unchanged from SandboxClaim.serviceAccount.
+                type: string
+              source:
+                description: |-
+                  Source is the required discriminated union selecting the sandbox origin.
+                  Exactly one of poolRef, fromSandbox, or fromRevision is set.
+                properties:
+                  fromRevision:
+                    description: |-
+                      FromRevision resumes a sandbox from a workspace revision (lineage resume).
+                      NEW v2 surface; it has no v1 source.
+                    properties:
+                      revision:
+                        description: Revision is the workspace revision to resume
+                          (for example "rev-41").
+                        type: string
+                      workspace:
+                        description: Workspace is the durable workspace the revision
+                          belongs to.
+                        type: string
+                    required:
+                    - revision
+                    - workspace
+                    type: object
+                  fromSandbox:
+                    description: |-
+                      FromSandbox forks a live sandbox (the old SandboxFork path). Maps from
+                      SandboxFork.sourceRef. With replicas greater than 1 it fans out into that
+                      many indexed sibling children.
+                    properties:
+                      name:
+                        description: Name is the live sandbox to fork.
+                        type: string
+                      pauseSource:
+                        description: |-
+                          PauseSource pauses the source sandbox during the fork checkpoint. Reduces
+                          checkpoint time but briefly interrupts the source. Carried unchanged from
+                          SandboxFork.pauseSource.
+                        type: boolean
+                    required:
+                    - name
+                    type: object
+                  poolRef:
+                    description: |-
+                      PoolRef starts a fresh sandbox from a pool snapshot (the old SandboxClaim
+                      path). Maps from SandboxClaim.poolRef.
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              volumeOverrides:
+                description: |-
+                  VolumeOverrides override per-volume fork policies for this sandbox. Carried
+                  unchanged from SandboxClaim.volumeOverrides / SandboxFork.volumeOverrides.
+                items:
+                  description: VolumeOverride overrides the fork policy for a named
+                    volume on this sandbox.
+                  properties:
+                    forkPolicy:
+                      description: ForkPolicy governs how a volume is handled when
+                        a sandbox is forked.
+                      type: string
+                    name:
+                      type: string
+                  required:
+                  - forkPolicy
+                  - name
+                  type: object
+                type: array
+              workspaceRef:
+                description: |-
+                  WorkspaceRef binds this sandbox to a durable Workspace (single-writer).
+                  Carried unchanged from SandboxClaim.workspaceRef.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - source
+            type: object
+          status:
+            description: |-
+              Status reports the sandbox phase, endpoint, husk pod, produced revision,
+              budget spend, startup latency, conditions, and per-child status when
+              replicas exceeds one.
+            properties:
+              budgetSpend:
+                description: |-
+                  BudgetSpend reports the capability-budget accounting (forks, cpuSeconds,
+                  ...). NEW v2 field (issue #25).
+                properties:
+                  cpuSeconds:
+                    description: CpuSeconds is the cumulative CPU seconds spent.
+                    format: int64
+                    type: integer
+                  forks:
+                    description: Forks is the number of self-initiated forks spent.
+                    format: int32
+                    type: integer
+                type: object
+              checkpointTime:
+                description: |-
+                  CheckpointTime is when the fork checkpoint was taken. Maps from
+                  SandboxForkStatus.checkpointTime.
+                format: date-time
+                type: string
+              children:
+                description: |-
+                  Children is the per-replica status for a fan-out (replicas > 1) Sandbox.
+                  Maps from SandboxForkStatus.forks.
+                items:
+                  description: |-
+                    SandboxChild is the per-replica status for a fan-out Sandbox (the old
+                    SandboxForkStatus.forks ForkInfo).
+                  properties:
+                    endpoint:
+                      description: Endpoint is the child's sandbox API address.
+                      type: string
+                    name:
+                      description: Name is the child sandbox name.
+                      type: string
+                    node:
+                      description: Node is the node the child runs on.
+                      type: string
+                    phase:
+                      description: Phase is the child's lifecycle phase.
+                      type: string
+                    sandboxID:
+                      description: SandboxID is the child's engine-side identifier.
+                      type: string
+                    startupLatencyMs:
+                      description: StartupLatencyMs is the child's fork latency in
+                        milliseconds.
+                      format: int64
+                      type: integer
+                  required:
+                  - endpoint
+                  - name
+                  - node
+                  - phase
+                  - sandboxID
+                  type: object
+                type: array
+              conditions:
+                description: |-
+                  Conditions are the typed conditions with observedGeneration. Unchanged from
+                  v1alpha1.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              effectiveBudget:
+                description: |-
+                  EffectiveBudget is the controller-computed, attenuated capability budget
+                  this sandbox actually holds: the per-field minimum (intersection) of its own
+                  resolved budget and its parent's effective-remaining budget when it is a
+                  self-initiated fork (source.fromSandbox), or its resolved spec/pool budget
+                  otherwise. It is depth-aggregate: because each level intersects with its
+                  parent's remaining, a descendant can never hold a budget wider than the root
+                  has left, so the whole fork subtree is bounded by the root (issue #25, the
+                  never-widen attenuation invariant). A nil dimension means unlimited. This is
+                  STATUS only; the controller never mutates the user-owned spec.budget. NEW v2
+                  field.
+                properties:
+                  maxCheckpoints:
+                    description: MaxCheckpoints bounds the self-initiated checkpoints
+                      the sandbox may take.
+                    format: int32
+                    type: integer
+                  maxCpuSeconds:
+                    description: MaxCpuSeconds bounds the cumulative CPU seconds the
+                      sandbox may consume.
+                    format: int64
+                    type: integer
+                  maxEgressBytes:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      MaxEgressBytes bounds the cumulative egress bytes the sandbox may send. It
+                      is a Kubernetes quantity (for example "1Gi").
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  maxForks:
+                    description: |-
+                      MaxForks bounds the self-initiated forks (depth-aggregate) the sandbox may
+                      create at runtime.
+                    format: int32
+                    type: integer
+                  maxLifetimeExtension:
+                    description: |-
+                      MaxLifetimeExtension bounds the total lifetime extension the sandbox may
+                      request at runtime.
+                    type: string
+                type: object
+              endpoint:
+                description: Endpoint is the sandbox API address (host:port). Unchanged
+                  from v1alpha1.
+                type: string
+              finishedAt:
+                description: |-
+                  FinishedAt is when the sandbox reached a terminal phase, driving the GC TTL
+                  pass. Unchanged from v1alpha1.
+                format: date-time
+                type: string
+              forkSnapshotTaken:
+                description: |-
+                  ForkSnapshotTaken is the exactly-once fork-snapshot guard for a replicas >
+                  1 Sandbox, carried so the controller-restart correctness holds. Maps from
+                  SandboxForkStatus.forkSnapshotTaken.
+                type: boolean
+              node:
+                description: |-
+                  Node is the node the sandbox VM runs on. Unchanged from v1alpha1. It is the
+                  engine placement identity distinct from SandboxID: the GC orphan sweep,
+                  NodeLost detection, and the terminate/idle engine calls key off it on the
+                  raw-forkd path, where it is not derivable from a husk pod.
+                type: string
+              phase:
+                description: |-
+                  Phase is the sandbox lifecycle phase. The phase-name set is carried from
+                  v1alpha1 (Pending, Restoring, Ready, Terminating, Terminated, Failed);
+                  Terminated is a terminal phase reaped by TTL. The v2 phase rename
+                  (Hydrating, NodeLost) is deferred to a later task.
+                type: string
+              pod:
+                description: |-
+                  Pod is the husk pod name backing the sandbox (for example
+                  "heartbeat-7f3a-husk"), visible to kubectl, quotas, NetworkPolicy, and
+                  OpenCost. NEW explicit v2 field. On the husk path the node is derivable
+                  from the pod; on the raw-forkd path the node is carried in Node below.
+                type: string
+              readyReplicas:
+                description: |-
+                  ReadyReplicas is the ready child count for a replicas > 1 Sandbox. Maps
+                  from SandboxForkStatus.readyForks.
+                format: int32
+                type: integer
+              revision:
+                description: Revision is the WorkspaceRevision produced on terminate.
+                  NEW v2 field.
+                type: string
+              sandboxID:
+                description: SandboxID is the engine-side sandbox identifier. Unchanged
+                  from v1alpha1.
+                type: string
+              startedAt:
+                description: StartedAt is when the sandbox became Ready. Unchanged
+                  from v1alpha1.
+                format: date-time
+                type: string
+              startupLatencyMs:
+                description: |-
+                  StartupLatencyMs is the fork/activation latency in milliseconds. Renamed
+                  and rescaled from the v1alpha1 SandboxClaimStatus.forkTimeMicros.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/mitos/0.13.0/manifests/mitos.run_sandboxpools.yaml
+++ b/operators/mitos/0.13.0/manifests/mitos.run_sandboxpools.yaml
@@ -1,0 +1,813 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: sandboxpools.mitos.run
+spec:
+  group: mitos.run
+  names:
+    kind: SandboxPool
+    listKind: SandboxPoolList
+    plural: sandboxpools
+    singular: sandboxpool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.readySnapshots
+      name: Ready
+      type: integer
+    - jsonPath: .spec.template.image
+      name: Image
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          SandboxPool is the v1 consolidated pool kind. It inlines the former
+          SandboxTemplate into spec.template (ADR 0007); spec.templateRef survives as
+          the optional reuse alternative (the Deployment-embeds-PodSpec pattern). A pool
+          sets EXACTLY ONE of spec.template or spec.templateRef.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              Spec is the desired pool configuration: the template (inline or by
+              reference), the snapshot fan-out, the warm-pod autoscaler, and placement.
+            properties:
+              cpuPinning:
+                description: |-
+                  CPUPinning configures dynamic post-ready CPU pinning and a launch-time
+                  scheduling-priority bump for this pool's sandbox VMs (issue #168). Carried
+                  unchanged from v1alpha1.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enabled turns dynamic post-ready CPU pinning on for
+                      this pool.
+                    type: boolean
+                  launchRtPriority:
+                    default: true
+                    description: |-
+                      LaunchRtPriority bumps the Firecracker vCPU threads to an elevated
+                      scheduling priority during the activate window. Defaults to true.
+                    type: boolean
+                  policy:
+                    default: pack
+                    description: 'Policy is the packing strategy: Pack or Spread.'
+                    enum:
+                    - spread
+                    - pack
+                    type: string
+                  siblingPairing:
+                    default: true
+                    description: |-
+                      SiblingPairing assigns both hyperthread siblings of a physical core to
+                      the same vCPU. Defaults to true.
+                    type: boolean
+                type: object
+              drainPolicy:
+                default: Kill
+                description: |-
+                  DrainPolicy governs an active sandbox when its backing husk pod is lost
+                  (drain, eviction, deletion). Kill (the default) re-pends the sandbox onto a
+                  replacement dormant slot; Checkpoint attempts a live-VM snapshot first where
+                  the VMM still runs, then re-pends. Carried unchanged from v1alpha1.
+                enum:
+                - Kill
+                - Checkpoint
+                type: string
+              placement:
+                description: |-
+                  Placement pins this pool's husk pods (and the sandbox VMs they run) to a
+                  dedicated set of nodes for hard tenant separation (issue #172). Carried
+                  unchanged from v1alpha1.
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      NodeSelector is ANDed onto the husk pod so its sandbox VMs run only on
+                      nodes carrying these labels.
+                    type: object
+                  tolerations:
+                    description: Tolerations let the husk pods schedule onto tainted
+                      dedicated nodes.
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists, Equal, Lt, and Gt. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                            Lt and Gt perform numeric comparisons (requires feature gate TaintTolerationComparisonOperators).
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              snapshots:
+                description: |-
+                  Snapshots configures the per-node snapshot fan-out: how many warm snapshot
+                  restores each node holds, the prefetch posture, and the refresh schedule.
+                  It folds the v1alpha1 snapshotAfter, snapshotDelay, scaleDownAfterSnapshot,
+                  and snapshotStorage fields into one block.
+                properties:
+                  prefetch:
+                    description: |-
+                      Prefetch is the snapshot prefetch posture (for example "full"): how much of
+                      the snapshot is pulled onto a node before it is considered ready.
+                    type: string
+                  refresh:
+                    description: |-
+                      Refresh schedules a periodic snapshot rebuild (for example a nightly cron),
+                      so a pool's snapshots track a moving base image. NEW v2 surface; empty
+                      leaves snapshots fixed until the template changes.
+                    properties:
+                      schedule:
+                        description: Schedule is a cron expression (for example "0
+                          4 * * *") for the rebuild.
+                        type: string
+                    type: object
+                  replicasPerNode:
+                    description: |-
+                      ReplicasPerNode is the number of warm snapshot restores each holder node
+                      keeps. It carries the v1alpha1 spec.replicas value on conversion.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  scaleDownAfterSnapshot:
+                    description: |-
+                      ScaleDownAfterSnapshot scales down the source sandbox after the snapshot is
+                      taken. Re-homed from v1alpha1 spec.scaleDownAfterSnapshot.
+                    type: boolean
+                  snapshotAfter:
+                    description: |-
+                      SnapshotAfter is the trigger condition before a snapshot is taken (for
+                      example Ready). Re-homed from v1alpha1 spec.snapshotAfter.
+                    type: string
+                  snapshotDelay:
+                    description: |-
+                      SnapshotDelay is the delay after the trigger before the snapshot is taken,
+                      allowing init scripts to finish. Re-homed from v1alpha1 spec.snapshotDelay.
+                    type: string
+                  storage:
+                    description: |-
+                      Storage is where snapshot artifacts are stored on the node. Re-homed from
+                      v1alpha1 spec.snapshotStorage.
+                    type: string
+                type: object
+              template:
+                description: |-
+                  Template is the inline pool template carrying every field a v1alpha1
+                  SandboxTemplate carried (image, init, command, env, resources, volumes,
+                  network, encrypted). It is the common path; mutually exclusive with
+                  TemplateRef. Exactly one of Template or TemplateRef must be set.
+                properties:
+                  buildSteps:
+                    description: |-
+                      BuildSteps is the ordered, declarative build recipe (issue #220), the
+                      code-first alternative to Init. Carried unchanged from v1alpha1.
+                    items:
+                      description: |-
+                        BuildStep is one ordered step of a declarative template build (issue #220).
+                        Exactly one shape is meaningful per Type. The build path flattens run, env,
+                        and workdir steps into the in-VM init commands in order; copy steps are
+                        staged by the file path. The whole ordered list feeds the chained,
+                        content-addressed cache key so an unchanged prefix is reused.
+                      properties:
+                        dest:
+                          type: string
+                        envName:
+                          description: EnvName and EnvValue are the variable name
+                            and value for an env step.
+                          type: string
+                        envValue:
+                          type: string
+                        run:
+                          description: Run is the shell command for a run step.
+                          type: string
+                        source:
+                          description: |-
+                            Source and Dest are the host source and in-image destination for a copy
+                            step.
+                          type: string
+                        type:
+                          description: 'Type selects the step kind: run, env, workdir,
+                            or copy.'
+                          enum:
+                          - run
+                          - env
+                          - workdir
+                          - copy
+                          type: string
+                        workdir:
+                          description: Workdir is the directory for a workdir step.
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    type: array
+                  command:
+                    description: Command overrides the container entrypoint inside
+                      the sandbox.
+                    items:
+                      type: string
+                    type: array
+                  defaultBudget:
+                    description: |-
+                      DefaultBudget is the pool's default capability budget inherited by a
+                      Sandbox created from this pool when the Sandbox sets no budget of its own
+                      (v2-spec section 3). NEW v2 surface; default empty (no budget). Runtime
+                      enforcement is issue #25.
+                    properties:
+                      maxCheckpoints:
+                        description: MaxCheckpoints bounds the self-initiated checkpoints
+                          the sandbox may take.
+                        format: int32
+                        type: integer
+                      maxCpuSeconds:
+                        description: MaxCpuSeconds bounds the cumulative CPU seconds
+                          the sandbox may consume.
+                        format: int64
+                        type: integer
+                      maxEgressBytes:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          MaxEgressBytes bounds the cumulative egress bytes the sandbox may send. It
+                          is a Kubernetes quantity (for example "1Gi").
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      maxForks:
+                        description: |-
+                          MaxForks bounds the self-initiated forks (depth-aggregate) the sandbox may
+                          create at runtime.
+                        format: int32
+                        type: integer
+                      maxLifetimeExtension:
+                        description: |-
+                          MaxLifetimeExtension bounds the total lifetime extension the sandbox may
+                          request at runtime.
+                        type: string
+                    type: object
+                  encrypted:
+                    default: false
+                    description: |-
+                      Encrypted requests at-rest encryption of the template snapshot and every
+                      fork built from it. Carried unchanged from v1alpha1.
+                    type: boolean
+                  env:
+                    description: Env are environment variables baked into the template
+                      at build time.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Image is the OCI base image the template snapshot
+                      is built from.
+                    type: string
+                  init:
+                    description: |-
+                      Init is the ordered list of build-time shell commands run inside the
+                      booting template VM. Pool-build only; never per-sandbox.
+                    items:
+                      type: string
+                    type: array
+                  minIsolationTier:
+                    description: |-
+                      MinIsolationTier requires the sandbox to be scheduled only onto a node
+                      whose isolation assurance meets this floor (issue #40). Carried unchanged
+                      from v1alpha1.
+                    enum:
+                    - hardware-kvm
+                    - pvm
+                    - gvisor
+                    type: string
+                  network:
+                    description: |-
+                      Network is the per-sandbox egress/inbound posture enforced by the per-tap
+                      nftables datapath. Mapped from the v1alpha1 networkPolicy field.
+                    properties:
+                      allow:
+                        items:
+                          type: string
+                        type: array
+                      allowCidrs:
+                        description: AllowCIDRs is the egress CIDR allowlist. Ignored
+                          when BlockNetwork is true.
+                        items:
+                          type: string
+                        type: array
+                      blockNetwork:
+                        description: |-
+                          BlockNetwork drops ALL egress for the sandbox, overriding Egress and the
+                          allowlists. It is the total-deny primitive.
+                        type: boolean
+                      egress:
+                        description: EgressPolicy is the default verdict for sandbox
+                          egress traffic.
+                        type: string
+                      inbound:
+                        description: |-
+                          Inbound governs unsolicited inbound connections to the guest. Empty means
+                          the secure default, deny-by-default.
+                        type: string
+                      inboundCidrs:
+                        description: |-
+                          InboundCIDRs narrows an InboundAllow to source CIDRs. Only meaningful
+                          when Inbound is allow.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  requireHardwareKvm:
+                    default: false
+                    description: |-
+                      RequireHardwareKvm is a convenience equivalent to
+                      minIsolationTier=hardware-kvm (issue #40). Carried unchanged from v1alpha1.
+                    type: boolean
+                  resources:
+                    description: Resources is the per-sandbox CPU and memory request
+                      (and optional GPU).
+                    properties:
+                      cpu:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      gpu:
+                        description: |-
+                          GPU requests GPU passthrough for the sandbox (issue #221). When set the
+                          pool's sandboxes are scheduled ONLY onto GPU-capable nodes, and the
+                          requested device count and type are recorded for metering. A GPU sandbox
+                          is documented as NOT live-forkable while the device is attached.
+                        properties:
+                          count:
+                            description: Count is the number of GPUs to attach, exclusively,
+                              to the sandbox.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          type:
+                            description: Type names the GPU SKU the pool requires
+                              (for example "nvidia-a100").
+                            type: string
+                        required:
+                        - count
+                        type: object
+                      memory:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  volumes:
+                    description: |-
+                      Volumes are the backing drives attached to each sandbox, with per-volume
+                      fork policies (Fresh, Share, Clone, Snapshot).
+                    items:
+                      description: SandboxVolume is a backing drive attached to each
+                        sandbox.
+                      properties:
+                        forkPolicy:
+                          description: ForkPolicy governs how a volume is handled
+                            when a sandbox is forked.
+                          type: string
+                        mountPath:
+                          type: string
+                        name:
+                          description: |-
+                            Name identifies the volume; it becomes the host backing-file name and the
+                            Firecracker drive id.
+                          maxLength: 64
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9_-]*$
+                          type: string
+                        readOnly:
+                          type: boolean
+                        size:
+                          type: string
+                        snapshotClass:
+                          description: 'For Snapshot fork policy: the CSI snapshot
+                            class to use.'
+                          type: string
+                        source:
+                          description: VolumeSource selects the backing data source
+                            for a sandbox volume.
+                          properties:
+                            gcs:
+                              description: GCSVolumeSource seeds a volume from a GCS
+                                bucket.
+                              properties:
+                                bucket:
+                                  type: string
+                                prefix:
+                                  type: string
+                              required:
+                              - bucket
+                              type: object
+                            git:
+                              description: GitVolumeSource seeds a volume by cloning
+                                a git repository.
+                              properties:
+                                branch:
+                                  type: string
+                                ref:
+                                  type: string
+                                repo:
+                                  type: string
+                              required:
+                              - repo
+                              type: object
+                            pvc:
+                              description: PVCVolumeSource seeds a volume from a PersistentVolumeClaim.
+                              properties:
+                                claimName:
+                                  type: string
+                              required:
+                              - claimName
+                              type: object
+                            s3:
+                              description: S3VolumeSource seeds a volume from an S3-compatible
+                                bucket.
+                              properties:
+                                bucket:
+                                  type: string
+                                prefix:
+                                  type: string
+                                region:
+                                  type: string
+                              required:
+                              - bucket
+                              type: object
+                          type: object
+                        storageClass:
+                          description: 'For persistent volumes: the storage class.'
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                required:
+                - image
+                type: object
+              templateRef:
+                description: |-
+                  TemplateRef references a shared template-shaped object by name, for the
+                  rarer case of several pools sharing one template definition. Mutually
+                  exclusive with Template. Exactly one of Template or TemplateRef must be set.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+              warm:
+                description: |-
+                  Warm is the husk-pod autoscaler: the floor, ceiling, and target pending
+                  headroom of DORMANT warm husk pods. It re-homes the v1alpha1
+                  replicas/autoscale fields into one block (warm.min carries the fixed
+                  replicas count for back-compat).
+                properties:
+                  cooldownSeconds:
+                    description: |-
+                      CooldownSeconds is the anti-thrash window after a scale-down before the pool
+                      may scale down again. It carries the v1alpha1
+                      autoscale.scaleDownCooldownSeconds on conversion.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  max:
+                    description: |-
+                      Max is the ceiling: the dormant warm husk pod count never exceeds this. It
+                      carries the v1alpha1 autoscale.maxWarm on conversion. Zero means no
+                      autoscaler ceiling (the fixed-pool back-compat shape).
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  min:
+                    description: |-
+                      Min is the floor: the dormant warm husk pod count held when fully idle. It
+                      carries the v1alpha1 autoscale.minWarm (or, when no autoscale was set, the
+                      fixed spec.replicas) on conversion.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  targetPending:
+                    description: |-
+                      TargetPending is the headroom of spare dormant pods kept ready on top of
+                      the in-use count, so a claim burst hits a warm pod instead of cold-starting.
+                      It carries the v1alpha1 autoscale.targetSpare on conversion.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: Status reports snapshot and warm-pool readiness.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              desiredWarm:
+                description: DesiredWarm is the autoscaler's computed desired dormant
+                  pod count.
+                format: int32
+                type: integer
+              lastScaleDownTime:
+                description: LastScaleDownTime records when the pool last reduced
+                  its dormant pod count.
+                format: date-time
+                type: string
+              lastSnapshotTime:
+                format: date-time
+                type: string
+              nodeDistribution:
+                additionalProperties:
+                  format: int32
+                  type: integer
+                type: object
+              readySnapshots:
+                format: int32
+                type: integer
+              restoringCount:
+                format: int32
+                type: integer
+              templateDigest:
+                description: |-
+                  TemplateDigest is the content-addressed manifest digest of the pool's
+                  snapshot. A content address, safe to log.
+                type: string
+              totalSnapshots:
+                format: int32
+                type: integer
+            required:
+            - readySnapshots
+            - restoringCount
+            - totalSnapshots
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.warm.min
+        statusReplicasPath: .status.readySnapshots
+      status: {}

--- a/operators/mitos/0.13.0/manifests/mitos.run_workspacerevisions.yaml
+++ b/operators/mitos/0.13.0/manifests/mitos.run_workspacerevisions.yaml
@@ -1,0 +1,245 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: workspacerevisions.mitos.run
+spec:
+  group: mitos.run
+  names:
+    kind: WorkspaceRevision
+    listKind: WorkspaceRevisionList
+    plural: workspacerevisions
+    singular: workspacerevision
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.workspaceRef.name
+      name: Workspace
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              contentManifest:
+                description: |-
+                  ContentManifest is the content-addressed manifest digest of the revision's
+                  artifact (a lowercase hex sha256). It is set by dehydrate (a later W4
+                  slice). A revision with a valid ContentManifest is committed; once
+                  committed the manifest is immutable.
+                type: string
+              memorySnapshotPrincipal:
+                description: |-
+                  MemorySnapshotPrincipal is the principal (the capturing claim's
+                  ServiceAccount) the paired memory snapshot is bound to. A memory snapshot
+                  carries secrets-in-RAM, so it is never served across principals: a resume
+                  loads the memory image only when the activating claim's principal matches
+                  this value. Set together with MemorySnapshotRef; nil for a content-only
+                  revision.
+                type: string
+              memorySnapshotRef:
+                description: |-
+                  MemorySnapshotRef pairs the revision with a memory snapshot, making the
+                  revision resumable. Principal-bound per the secrets policy.
+                type: string
+              source:
+                description: |-
+                  Source records the lineage origin of the revision: a sandbox claim that
+                  produced it, or a parent revision it forks from. Exactly one is set in a
+                  well-formed lineage; both unset marks a root revision.
+                properties:
+                  fromClaim:
+                    description: FromClaim names the sandbox claim whose dehydrate
+                      produced this revision.
+                    type: string
+                  fromWorkspaceRevision:
+                    description: |-
+                      FromWorkspaceRevision names the parent revision this revision forks from,
+                      the DAG lineage edge. The parent must be a revision in the same workspace.
+                    properties:
+                      revision:
+                        description: Revision is the name of the parent revision.
+                        type: string
+                      workspace:
+                        description: Workspace is the name of the workspace the parent
+                          revision lives in.
+                        type: string
+                    required:
+                    - revision
+                    - workspace
+                    type: object
+                type: object
+              workspaceRef:
+                description: WorkspaceRef names the Workspace this revision belongs
+                  to.
+                properties:
+                  name:
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - workspaceRef
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              diffSummary:
+                description: |-
+                  DiffSummary records the content-hash diff of this revision against the
+                  workspace head revision before it, when a terminate {diff: true} output
+                  requested it. It is a path-level summary (added, removed, modified file
+                  names plus counts); the file contents stay in the content store, never in
+                  the status. Unset when no diff was requested or the revision is a root.
+                properties:
+                  added:
+                    items:
+                      type: string
+                    type: array
+                  addedCount:
+                    description: |-
+                      AddedCount, RemovedCount, and ModifiedCount summarize the lists for a quick
+                      human read and for indexers that do not want the full path lists.
+                    format: int32
+                    type: integer
+                  modified:
+                    items:
+                      type: string
+                    type: array
+                  modifiedCount:
+                    format: int32
+                    type: integer
+                  parentRevision:
+                    description: |-
+                      ParentRevision is the head revision the diff was computed against. Empty
+                      when this revision is the first in the workspace (a root: everything added).
+                    type: string
+                  removed:
+                    items:
+                      type: string
+                    type: array
+                  removedCount:
+                    format: int32
+                    type: integer
+                type: object
+              gitPushes:
+                description: |-
+                  GitPushes records the git rendezvous pushes this revision's terminate
+                  performed (the per-attempt branch and the remote), so the fork-and-merge
+                  rendezvous is auditable. The push content is the workspace repo paths; git
+                  is the merge layer and the engine never merges working trees.
+                items:
+                  description: GitPushRecord is one git rendezvous push performed
+                    on terminate.
+                  properties:
+                    branch:
+                      description: Branch is the per-attempt branch the push landed
+                        on.
+                      type: string
+                    remote:
+                      description: Remote is the rendezvous remote the workspace repo
+                        paths were pushed to.
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                description: |-
+                  Phase is Pending until the revision's ContentManifest is a valid
+                  content-addressed digest, then Committed. A committed revision is
+                  immutable.
+                enum:
+                - Pending
+                - Committed
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/mitos/0.13.0/manifests/mitos.run_workspaces.yaml
+++ b/operators/mitos/0.13.0/manifests/mitos.run_workspaces.yaml
@@ -1,0 +1,345 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.21.0
+  name: workspaces.mitos.run
+spec:
+  group: mitos.run
+  names:
+    kind: Workspace
+    listKind: WorkspaceList
+    plural: workspaces
+    singular: workspace
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.head
+      name: Head
+      type: string
+    - jsonPath: .status.revisions
+      name: Revisions
+      type: integer
+    - jsonPath: .status.resumable
+      name: Resumable
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              git:
+                description: |-
+                  Git declares the repo paths that get history and the fork-and-merge
+                  rendezvous remote. Git is the merge layer; the engine never does
+                  filesystem merge. The rendezvous itself is a later W4 slice.
+                properties:
+                  credentialsSecretRef:
+                    description: |-
+                      CredentialsSecretRef names a Secret key holding the credential token used to
+                      authenticate the {git} rendezvous push to an external remote. The token is a
+                      secret VALUE: it is resolved at push time, delivered to git only through an
+                      ephemeral credentials file in an isolated HOME, and never logged, never put
+                      on the git argv, and never recorded in a condition or revision. The username
+                      is taken from CredentialsUsername (or defaults to "x-access-token", the
+                      token-only forge convention). Unset means an unauthenticated push (a local
+                      bare repo or an already-credentialed remote helper on the host).
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  credentialsUsername:
+                    description: |-
+                      CredentialsUsername is the basic-auth username paired with the token from
+                      CredentialsSecretRef. It is not a secret. Defaults to "x-access-token" when
+                      unset, which most token-based forges accept. Ignored when CredentialsSecretRef
+                      is unset.
+                    type: string
+                  paths:
+                    description: |-
+                      Paths are the repo paths inside the workspace that get version history and
+                      the rendezvous remote.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              grants:
+                description: |-
+                  Grants are the explicit, auditable workspace access grants. Workspace
+                  access is declarative Kubernetes RBAC over these grant objects, not a
+                  pod-scoped mechanism.
+                items:
+                  properties:
+                    access:
+                      description: Access is the level of access the grant confers.
+                      enum:
+                      - readonly
+                      - readwrite
+                      type: string
+                    serviceAccount:
+                      description: ServiceAccount is the principal the grant applies
+                        to.
+                      type: string
+                  required:
+                  - access
+                  - serviceAccount
+                  type: object
+                type: array
+              retention:
+                description: |-
+                  Retention bounds how many committed revisions are kept and how old a
+                  revision must be before it is eligible for pruning.
+                properties:
+                  minAge:
+                    description: |-
+                      MinAge is the minimum age a revision must reach before it is eligible for
+                      pruning. A revision younger than MinAge is never pruned even if the count
+                      is over Revisions. Unset treats every over-count revision as eligible.
+                    type: string
+                  revisions:
+                    description: |-
+                      Revisions is the maximum number of committed revisions to keep. Committed
+                      revisions beyond this count that are also older than MinAge are pruned
+                      oldest-first. The head and any ancestor on the head's lineage path are
+                      never pruned. Zero or unset disables count-based pruning.
+                    format: int32
+                    type: integer
+                type: object
+              store:
+                description: |-
+                  Store selects the content-addressed object store that backs the
+                  workspace's revision artifacts.
+                properties:
+                  encryptionKeyRef:
+                    description: |-
+                      EncryptionKeyRef names a Secret key holding the wrapped at-rest
+                      data-encryption key (DEK). When set, every revision chunk and manifest is
+                      encrypted at rest with AES-256-GCM under that DEK before it reaches the
+                      store (node CAS or S3), and decrypted on hydrate. The DEK the controller
+                      generates is keyed per-template (by templateID), so a template's workspaces
+                      share its DEK; per-workspace crypto-shred is a future option if finer
+                      granularity is wanted. The DEK is a secret VALUE
+                      delivered wrapped (envelope encryption via internal/kms): it is unwrapped
+                      only in node memory for the duration of a hydrate/dehydrate and is never
+                      logged, never placed in an error or condition, and never written to a host
+                      path. The encrypted round trip stays byte-identical and content-addressed
+                      dedup is preserved because the manifest digest is computed over plaintext.
+                      The key is principal-bound, mirroring the memory-snapshot policy. Unset
+                      keeps today's plaintext store path (backward compatible).
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  objectStorageRef:
+                    description: |-
+                      ObjectStorageRef names the S3-compatible, content-addressed object store
+                      that holds the workspace's chunked revision artifacts. When set, the
+                      workspace's hydrate/dehydrate artifacts live in the referenced S3 bucket
+                      (an alternative to the node CAS), with the same content-addressed,
+                      byte-identical, deduplicated semantics. The bucket and credentials are
+                      resolved from S3 below; unset keeps the default node CAS.
+                    type: string
+                  s3:
+                    description: |-
+                      S3 configures the S3-compatible object-store backend that holds the
+                      workspace's revision artifacts when ObjectStorageRef selects it. Credentials
+                      are taken from a referenced Secret and are never logged.
+                    properties:
+                      accessKeyIdKey:
+                        description: |-
+                          AccessKeyIDKey is the Secret key holding the S3 access-key id. Defaults to
+                          "accessKeyId".
+                        type: string
+                      bucket:
+                        description: Bucket is the S3 bucket that holds the workspace's
+                          chunks and manifests.
+                        type: string
+                      credentialsSecretRef:
+                        description: |-
+                          CredentialsSecretRef names a Secret holding the S3 access-key id and
+                          secret-access-key used to authenticate to the bucket. The secret values are
+                          resolved at use time, passed to the S3 client only in memory, and never
+                          logged, never put in an error, and never written to a host path. The
+                          conventional keys are "accessKeyId" and "secretAccessKey" unless overridden
+                          by AccessKeyIDKey / SecretAccessKeyKey.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      endpoint:
+                        description: |-
+                          Endpoint is the S3 endpoint URL. Empty uses the AWS default for the region;
+                          set it for S3-compatible stores (MinIO, Ceph RGW, etc).
+                        type: string
+                      prefix:
+                        description: |-
+                          Prefix is an optional key prefix under which the chunks/ and manifests/
+                          object keys are written, so several workspaces can share one bucket without
+                          colliding. The content-addressed layout under the prefix is unchanged.
+                        type: string
+                      region:
+                        description: |-
+                          Region is the S3 region. Defaults to us-east-1 when unset (the path-style
+                          default many S3-compatible stores accept).
+                        type: string
+                      secretAccessKeyKey:
+                        description: |-
+                          SecretAccessKeyKey is the Secret key holding the S3 secret-access-key.
+                          Defaults to "secretAccessKey".
+                        type: string
+                    required:
+                    - bucket
+                    type: object
+                type: object
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              head:
+                description: |-
+                  Head is the name of the latest committed revision in the workspace's
+                  lineage. Empty until the first revision commits. Ordering is by revision
+                  creationTimestamp, then by name as a deterministic tiebreaker.
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              resumable:
+                description: |-
+                  Resumable reports whether the head revision pairs with a memory snapshot
+                  (its memorySnapshotRef is set), so a sandbox bound to the workspace can
+                  resume from the captured VM state rather than a cold start.
+                type: boolean
+              revisions:
+                description: Revisions is the number of committed revisions.
+                format: int32
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/mitos/0.13.0/metadata/annotations.yaml
+++ b/operators/mitos/0.13.0/metadata/annotations.yaml
@@ -1,0 +1,16 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: mitos
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+
+  # Recommended annotations.
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.1
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: unknown
+
+  # OperatorHub validation hints.
+  operatorframework.io/suggested-namespace: mitos

--- a/operators/mitos/ci.yaml
+++ b/operators/mitos/ci.yaml
@@ -1,0 +1,4 @@
+---
+updateGraph: replaces-mode
+reviewers:
+  - stubbi

--- a/operators/mitos/ci.yaml
+++ b/operators/mitos/ci.yaml
@@ -1,4 +1,4 @@
 ---
-updateGraph: replaces-mode
+updateGraph: semver-mode
 reviewers:
   - stubbi


### PR DESCRIPTION
### New Submissions

- [x] Are you familiar with our [contribution guidelines](https://github.com/k8s-operatorhub/community-operators/blob/main/docs/contributing-prerequisites.md)?
- [x] Have you [packaged and deployed your Operator](https://github.com/k8s-operatorhub/community-operators/blob/main/docs/packaging-required-criteria-ocp.md) for Operator Framework?
- [x] Have you [tested your Operator](https://github.com/k8s-operatorhub/community-operators/blob/main/docs/testing-operators.md) with all Custom Resource Definitions?
- [x] Have you read the [project documentation about review process](https://github.com/k8s-operatorhub/community-operators/blob/main/docs/pull_request_process.md)?

Adds the **mitos** operator, version `0.13.0` (initial listing).

Mitos provides snapshot-fork sandboxes for AI agents on Kubernetes: Firecracker microVMs that restore from memory snapshots in milliseconds, fork a running VM into N copies, and persist durable, versioned workspaces. Declarative CRDs (SandboxPool, Sandbox, Workspace, WorkspaceRevision) in API group `mitos.run`.

- Project: https://mitos.run
- Source: https://github.com/mitos-run/mitos
- Images: `ghcr.io/mitos-run/*:v0.13.0` (published and pullable)

The bundle passes `operator-sdk bundle validate` including the `operatorframework` suite.