### PR TITLE
operator ravendb-operator (2.0.0)

### DIFF
--- a/operators/ravendb-operator/2.0.0/bundle.Dockerfile
+++ b/operators/ravendb-operator/2.0.0/bundle.Dockerfile
@@ -1,0 +1,21 @@
+FROM scratch
+
+# Core bundle labels.
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=ravendb-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.38.0
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
+
+# Labels for testing.
+LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
+LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
+
+# Copy files to locations specified by labels.
+COPY ./manifests /manifests/
+COPY ./metadata /metadata/
+COPY ./tests/scorecard /tests/scorecard/

--- a/operators/ravendb-operator/2.0.0/manifests/ravendb-operator-webhook-service_v1_service.yaml
+++ b/operators/ravendb-operator/2.0.0/manifests/ravendb-operator-webhook-service_v1_service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: ravendb-operator-webhook-service
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    app: ravendb-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/ravendb-operator/2.0.0/manifests/ravendb-operator.clusterserviceversion.yaml
+++ b/operators/ravendb-operator/2.0.0/manifests/ravendb-operator.clusterserviceversion.yaml
@@ -1,0 +1,596 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "ravendb.ravendb.io/v1",
+          "kind": "RavenDBCluster",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/name": "ravendb-operator"
+            },
+            "name": "ravendbcluster-sample",
+            "namespace": "ravendb"
+          },
+          "spec": {
+            "clientCertSecretRef": "ravendb-client-cert",
+            "domain": "domain.development.run",
+            "email": "user@ravendb.net",
+            "externalAccessConfiguration": {
+              "ingressControllerContext": {
+                "ingressClassName": "nginx"
+              },
+              "type": "ingress-controller"
+            },
+            "image": "ravendb/ravendb:latest",
+            "imagePullPolicy": "IfNotPresent",
+            "licenseSecretRef": "ravendb-license",
+            "mode": "LetsEncrypt",
+            "nodes": [
+              {
+                "certSecretRef": "ravendb-certs-a",
+                "publicServerUrl": "https://a.domain.development.run:443",
+                "publicServerUrlTcp": "tcp://a-tcp.domain.development.run:443",
+                "tag": "a"
+              },
+              {
+                "certSecretRef": "ravendb-certs-b",
+                "publicServerUrl": "https://b.domain.development.run:443",
+                "publicServerUrlTcp": "tcp://b-tcp.domain.development.run:443",
+                "tag": "b"
+              },
+              {
+                "certSecretRef": "ravendb-certs-c",
+                "publicServerUrl": "https://c.domain.development.run:443",
+                "publicServerUrlTcp": "tcp://c-tcp.domain.development.run:443",
+                "tag": "c"
+              }
+            ],
+            "storage": {
+              "data": {
+                "size": "10Gi",
+                "storageClassName": "local-path"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "ravendb.ravendb.io/v1",
+          "kind": "RavenDBCluster",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/name": "ravendb-operator"
+            },
+            "name": "ravendbcluster-sample-selfsigned",
+            "namespace": "ravendb"
+          },
+          "spec": {
+            "caCertSecretRef": "ravendb-ca-cert",
+            "clientCertSecretRef": "ravendb-client-cert",
+            "clusterCertSecretRef": "ravendb-cert",
+            "domain": "domainselfsigned.development.run",
+            "externalAccessConfiguration": {
+              "ingressControllerContext": {
+                "ingressClassName": "nginx"
+              },
+              "type": "ingress-controller"
+            },
+            "image": "ravendb/ravendb:latest",
+            "imagePullPolicy": "IfNotPresent",
+            "licenseSecretRef": "ravendb-license",
+            "mode": "None",
+            "nodes": [
+              {
+                "publicServerUrl": "https://a.domainselfsigned.development.run:443",
+                "publicServerUrlTcp": "tcp://a-tcp.domainselfsigned.development.run:443",
+                "tag": "a"
+              },
+              {
+                "publicServerUrl": "https://b.domainselfsigned.development.run:443",
+                "publicServerUrlTcp": "tcp://b-tcp.domainselfsigned.development.run:443",
+                "tag": "b"
+              },
+              {
+                "publicServerUrl": "https://c.domainselfsigned.development.run:443",
+                "publicServerUrlTcp": "tcp://c-tcp.domainselfsigned.development.run:443",
+                "tag": "c"
+              }
+            ],
+            "storage": {
+              "data": {
+                "size": "10Gi",
+                "storageClassName": "local-path"
+              }
+            }
+          }
+        }
+      ]
+    containerImage: docker.io/ravendb/ravendb-operator:2.0.0
+    capabilities: Basic Install
+    categories: Database
+    createdAt: "2026-06-15T18:12:55Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.38.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+  name: ravendb-operator.v2.0.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - displayName: Raven DBCluster
+      kind: RavenDBCluster
+      name: ravendbclusters.ravendb.ravendb.io
+      resources:
+      - kind: Ingress
+        name: ravendb
+        version: v1
+      - kind: Service
+        name: ravendb-<nodeTag>
+        version: v1
+      - kind: StatefulSet
+        name: ravendb-<nodeTag>
+        version: v1
+      - kind: ConfigMap
+        name: ravendb-bootstrapper-hook
+        version: v1
+      - kind: ConfigMap
+        name: ravendb-cert-hook
+        version: v1
+      - kind: Job
+        name: ravendb-cluster-init
+        version: v1
+      - kind: ServiceAccount
+        name: ravendb-ops-sa
+        version: v1
+      specDescriptors:
+      - displayName: CA Certificate Secret
+        path: caCertSecretRef
+      - displayName: Client Certificate Secret
+        path: clientCertSecretRef
+      - displayName: Cluster Certificate Secret
+        path: clusterCertSecretRef
+      - displayName: Cluster Domain
+        path: domain
+      - displayName: Let's Encrypt Email
+        path: email
+      - displayName: Additional Environment Variables
+        path: env
+      - displayName: External Access Configuration
+        path: externalAccessConfiguration
+      - displayName: AWS Node Mappings
+        path: externalAccessConfiguration.awsExternalAccessContext.nodeMappings
+      - displayName: Azure Node Mappings
+        path: externalAccessConfiguration.azureExternalAccessContext.nodeMappings
+      - displayName: Ingress Annotations
+        path: externalAccessConfiguration.ingressControllerContext.additionalAnnotations
+      - displayName: Ingress Class
+        path: externalAccessConfiguration.ingressControllerContext.ingressClassName
+      - displayName: External Access Type
+        path: externalAccessConfiguration.type
+      - displayName: RavenDB Image
+        path: image
+      - displayName: Image Pull Policy
+        path: imagePullPolicy
+      - displayName: License Secret
+        path: licenseSecretRef
+      - displayName: Security Mode
+        path: mode
+      - displayName: Nodes
+        path: nodes
+      - displayName: Node Certificate Secret
+        path: nodes[].certSecretRef
+      - displayName: Public HTTPS URL
+        path: nodes[].publicServerUrl
+      - displayName: Public TCP URL
+        path: nodes[].publicServerUrlTcp
+      - displayName: Node Tag
+        path: nodes[].tag
+      - displayName: Storage
+        path: storage
+      - displayName: Additional Volumes
+        path: storage.additionalVolumes
+      - displayName: Additional Volume Mount Path
+        path: storage.additionalVolumes.mountPath
+      - displayName: Additional Volume Name
+        path: storage.additionalVolumes.name
+      - displayName: Access Modes
+        path: storage.data.accessModes
+      - displayName: Volume Size
+        path: storage.data.size
+      - displayName: StorageClass
+        path: storage.data.storageClassName
+      - displayName: VolumeAttributesClass
+        path: storage.data.volumeAttributesClassName
+      - displayName: Access Modes
+        path: storage.logs.audit.accessModes
+      - displayName: Logs Path
+        path: storage.logs.audit.path
+      - displayName: Volume Size
+        path: storage.logs.audit.size
+      - displayName: StorageClass
+        path: storage.logs.audit.storageClassName
+      - displayName: VolumeAttributesClass
+        path: storage.logs.audit.volumeAttributesClassName
+      - displayName: Access Modes
+        path: storage.logs.ravendb.accessModes
+      - displayName: Logs Path
+        path: storage.logs.ravendb.path
+      - displayName: Volume Size
+        path: storage.logs.ravendb.size
+      - displayName: StorageClass
+        path: storage.logs.ravendb.storageClassName
+      - displayName: VolumeAttributesClass
+        path: storage.logs.ravendb.volumeAttributesClassName
+      statusDescriptors:
+      - displayName: Cluster Conditions
+        path: conditions
+      - displayName: Status Message
+        path: message
+      - displayName: Node Statuses
+        path: nodes
+      - displayName: Observed Generation
+        path: observedGeneration
+      - displayName: Cluster Phase
+        path: phase
+      version: v1
+  description: |
+    RavenDB Operator automates the lifecycle of secure RavenDB clusters on Kubernetes, including cluster bootstrap, certificate management, storage provisioning, and rolling upgrades. It reconciles RavenDBCluster custom resources into StatefulSets, Services, Ingresses, and Jobs, and continuously evaluates cluster health and readiness so you can operate RavenDB in a Kubernetes-native way.
+  displayName: RavenDB Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAArcAAAK3CAYAAACfnWd3AAAt20lEQVR4Ae3dXYzW133g8RNDgoH10JmW1jbYWIWkXXuoVNX4AkuslFxgelOSiwVf1Y1kR0q07EXt3sRIVXBvYucilhLJIDnp3mCk1ZpIq2IitV2PBJVMWq86Y2/ihV1jGGA7zVDGYWBcqPf5PXhsXublmZnn5X/O//ORRuAkbV5sw3fO8/ud87mU0scJAAAKcFcCAIBCiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKIa4BQCgGOIWAIBiiFsAAIohbgEAKMbyBF3Wt/HxtPax/5iAMl2/MpGuNb6mTV08c+PH8ekfP2j8ay7d8q8BaBdxS9etGHggrd2yOwFE+Eb0RuxeHn3n0z+eHB0Wv8CiiFsAemZF/wPNr9A/uOOWfy7idvLcSCN0R9LV8bOf/Fz0AnMTtwBU0vKVfalv49bm180icuN099LJv0sfnjrWOPEdSQDTxC0AWVl1/2Dza/qkd/qEd3z4jeaPEyePJaC+xC0AWbv9hDdiN050I3YnGj9OL7IB9SBuAShKxG6c6k6f7E6cOt4MXSMMUA/iFoCi3XyqG6e4F0eOpPND+53oQqE+1/j6OEEXxTVgG5/8fgLopZjPPf/mAaMLUBgntwDUUiylTX+jHae5YycOpfHhIwnIm7gFoPamZ3TjBDcid+zEa05zIVPLGl9/nqCLVq8bTAObdySAqlm+ck3q27Q13bftmbRi4MF0/eqEyIXMOLkFgBms3bKr+RW3LYy9deM0F6i+uxIAMKu4aSFmc3//+Z81F2KBahO3ANCCFQMPiFzIgLgFgAUQuVBt4hYAFkHkQjWJWwBYgunIffhbrzd/DvSWuAWANojFszjF3fjkyyIXekjcAkAbxfVhD3/z9eZduUD3iVsAaLM4ud2wc1/zJNcpLnSXuAWADomwjcDdsPOFtHxlXwI6T9wCQIfdt+3ptPlP/8atCtAF4hYAumD6VoVYOHOKC50jbgGgi2LhLE5x+zY9noD2E7cA0GVxivvwN/9bWr/9uQS0l7gFgB5Zv/1ZNypAm4lbAOihG6e4r1s2gzYRtwDQY9PLZsYUYOnELQBURIwp/N6zf21MAZZA3AJAhay6f7A5piBwYXHELQBUTITt7/3pX6f7tj2TgIURtwBQQctWrkkbdu4zhwsLJG4BoMJiDnfDzhcS0BpxCwAVd9+2p9PD33rds73QAnELABno27i1+WyvRTOYm7gFgExMP/ggcGF24hYAMiJwYW7ilq67fuVSAmDxBC7MTtzSddeuiluApRK4MDNxCwCZErhwJ3ELABkTuHArcQsAmRO48BlxCwAFELhwg7gFgEJMB66XzKgzcQsABWkGrqd6qbHlCWrg2tWJW+7XjZ9fuzJxx7/u5o/zlq1ck5bf7TcHID+r7h9MG3a+kE4d3JOgbsQtWZu6eCZNjcfXB42vs80/jnC9On7jx9kidiHi9CNCdzp8Vww8mFb0P9D8x78wED+uSavWDQphoFLWbtnV/PXx7NEXE9SJuCULEa0TJ499GrDx83aEayvi3yO+4jeJG47P+K+L2G1GbsRu49Rk1bpH0t2N+I2fA/TC+u3PNn+tPD+0P0FdfK7x9XGCLurbtLW58DCbGCGIeJ04dTxNjo40v7oRsZ0U/53j5Hd1I3Tj54IX6KZ3f/i15q+rUAfilq67PW5vjtmLw0duOiEtWzNyGye9A4M7jDUAHRW/rr77w6/W5tdX6k3c0nURdRuffLkZsuMjRxphezyRmoEb/9tE7PZt3JoA2mny3Eh69wdfzf6TMJiPuIWKitBdu2X3jZGGfpeyA0t3fuhAOn34+QQlE7eQgelT3d/cssu8LrAkpw/vtWBG0cQtZCYW0yJ079v2jNAFFixuT4gFs8ujIwlKJG4hYxG6Ebn9m3cYXQBaFotlw9/7svlbirSs8fXnCcjS9cZvTP/y879NFxofMcZtE/H96up1TnOBucV93J/7/Mp06ed/k6A0Tm6hMNNjC+u3P+c0F5jTez96Ko0PH0lQEnELBZu+cSGe4QS4Xczf/uP3vuL+W4oibqEG4jQ3TnJjNtdjEcDNYqQp7r+FUpi5hRqI2dyLI0fSL98+3DypWfHrDzZn7gDim9/4NeJXp/8+QQmc3EJNrX1sl7lcoMl4AiURt1BzIhcIxhMohbEEqLnJ0XeaV4kF4wpQXzGeMHnunXTln04myJmTW+BT049C3Nv4AuonxhPefuFRjzuQNSe3wKemH4UYO3GoeYLrQQiol7s+f7fHHciek1tgVnFP7sYnXzaPCzXz7g+/liZOHkuQIye3wKxiczrmca9fvZRW/tYXzeNCTcSIUnyCAzkSt8C8fnX6H5r35BpVgHqwXEbOxC3QkumHIKYunmkGrlNcKNu/2/AH6Z9PvJb+7dpUgpyIW2BB4uowp7hQvvh7/N+ufdS8/xZyYqEMWDQPQEDZXA1GjpzcAos2fYob83krf/OLCShLXA3m9JbciFtgSWIW95dvH27+vG/T4wkoy+p1j6R/+ru/NHtLNsQt0BZxshNXBw1s3mHZDAri9Jbc3JUA2iTuxX33B19N4yNHElCO+7Y93fimtS9BDpzcAm1lTAHK4/SWnIhboCPiN8F42ezXfvfLCcif2VtyIW6BjomXzcZH3ki/9u+/bA4XMuf0llyYuQU6anJ0pDmHGy+bAXkze0sOxC3QcdOLZpPnRhKQr2WNT2DWbtmdoMrELdAVNwL3awIXMvcb4paKE7dA11y7cin940tfad6HC+QpFsvchEKViVug604d3CNwIWPrtz+boKrELdATAhfy1bdxq8UyKkvcAj0TgetaIcjTvdu+kaCKxC3QU++9+pQlM8hQXAsGVSRugZ6KJbO4RcE9uJCXuBbMYhlVJG6BnrsRuB56gNxYLKOKPtf4+jgBVMCqdYPp4W++fsuiys3Be70RwdeuTKTFiP+fyz55Ajh+XH63ZRhYqvh78u0XHl3035fQCeIWqJTpCI1HH7r579cM3sbPl3/y8xX9DzT/+RUD6xtfD37y8wc+/ceBG04f3pvOD+1PUBXiFmYRF5Vv2PlCmhwdSVfHz6aPLn7QDK7Lo5af6q4ZuY2vCOEvNH68uxG8zR8H4scHnQpTK3HjSYwVQVWIW5hFhMujf/HejP9cfFQeoSt8mUmcAMeIRZz4rr7/kU/Dd9X9gwlK9LNvf9FoApUhbmEOv//8z5ondAshfJlLRG+EblyCHz+PLye95M5oAlUibmEOv/P1H6f+wR2pXYQvM7k9eONHyInRBKpE3MIcHtq5L9277ZnUDcKXm/Vt+ix04y5Rp7tUndEEqkLcwhwibCNwe0340gzdRvCKXarq1MH/nMZOvJag18QtzGFgcEf60td/nKpM+NZThG789dk84bWoRgWMnTjUCNw9CXpN3MIc5roxIQczhe/EyWM+OixMLD1G5K7dstu8Lj0TDzqc+PaXEvSauIV5LObGhCob/t5XnOoWLK4h69+8o7kIOdDGZUhoxbs//FrzG2jopWWNrz9PwKxii/3fbfiDVII4WXn/8N5Euf7t2lTjpP6d9Mu3D6cLQ/vTlbGTzU8gSvoGjeqKT4l+dfrvE/TSXQmY0/jIkVSKuK6H+ojxk7G3DjWvaHr7hUfT+z/Z2xxVgU6JTw2g18QtzGPi5PFiZlRLCnUWJmavL7y5P72979HGR8dfbS7/QLvFi3wxGgO9ZCwBWnDX51c0r1/KWZzYxVU9EKF7sfGNTgRu/Hzlb32xOboAS3XX5+9O//KL/9H86wp6xckttODC0IHsT2/jBBpu1jzNHbpxmnvqtT1GFmiLOL2FXnJyCy2IJZ3cT2/f+9FT6borwJhFLKFF6MZc9oqBBy2gsWgfN369jIVG6BUnt9CinE9vpz9+hvnECX8soMVcrgVEFsNdy/Sak1toUZzefnz9avq13/1yysmNWds9Tm1ZkPhmKL4pcpLLQsXcbfy149ccekXcwgL86vQ/NEcTcvqN/vRP9pq3ZdGmIze+SVq9btDiGS2JMZfJcx6LoTeMJcACxSloLos3ESVxzyksVfx1ZPGMVq1eZ6mM3nFyCwsUH7XFR7W//vtfbS6ZVVUEyHuv/nFznALaJU7k4hqxeLu9lJf7aL9//fCfLJXRM05uYRHiicn3fvTHqaoibGMpqJTHJ6iWGFWIZ5zj1TOnuMxk1f2DCXrFyS0sUvwGP3nunbTmd79cqRPc6bB1OwKdFp9ixPVh169eapziPlrpTzLorpjNjr82fHJELzi5hSUYHz7SvDKpKqdXwpZeOP/mgTT8vS9bIOIWccsG9IKTW1iimC2LGcTYJO/lLQoxB/y/GmH7rx+OJei2OMX9f8f/S/PnuT9VTXvE7TK+4aEXxC20QfzGHjcThFXrNnf149lrVyfSmf/+Qvq///XPfARIz8U3WfH3wsDmHa4Nq7mPGp8k/cvP/zZBt4lbaKP4jf2X//Nw8zf1OMntxr/fz/fv9hsIlRLf7P1zI3A/3/ebXfn7gGpyYwK9Ere5fJyAtosRhfXbn0v9cYJ1d19qp4jas0df9DgDlbd++7PNvw+on5j9jxs1oNvELXTY8pV9zcDtH9zRnEVcbOhG0E6cPNbcQHbFFznp27Q1bXzy5bSi3xO+dXL9yqV04ttfStBt4ha6bFXjY9p4vWf1/YPpC43T3RhhiABedtN8Ypx4TI1/0Pg621zIiKgVtOQsPsl4+FuvC9ya+dm3v+jXLrpO3ALQFRG4v/P1H7vgv0aGv/eVdHnUjQl0l3tuAeiK+ETi3R98LY2PHEnUwxcGnNTTfeIWgK65duVSeu/Vpz69Oo+yLb/bdXB0n7gFoOtOHdwjcGtghZNbekDcAtATArd8sSwL3SZuAegZgVu2ZV6powfELQA9FYEb9zhTHie39IK4BaDnYsks7nSmLE5u6QVxC0DPxS0Kv2gE7tTFM4lyiFt6QdwCUAlxD24ErhetyrHY58ZhKcQtAJUxOTqSTv/k+QSwWOIWgEoZe+tQujC0PwEshrgFoHLOHn3JglkBPOJAL4hbACpnesHM/C2wUOIWgEqKBbPRn343ASyEuAWgss6/ecADD8CCiFsAKi1eMDOeALRK3AJQaTGecGHolQTQCnELQOXF7QleL8tPfGMC3SZuAchCjCcAzEfcApCFiZPHLZcB8xK3AGTj7NEXE/m4dtUiIN0nbgHIRpzejp04lMjD9SuXEnSbuAUgK05vgbmIWwCyEhv4Zm/z4LYEekHcApAdp7d5MJZAL4hbALLj5oQ8eFmOXlieAOiq5Sv70rKVaxo/rmn+uGLggeY/vuzuNc1/7rN/TV9L//+mxs9++vOIietXLzVPzKbDYmr8g1v+uBRxevvwN19PVJexBHpB3AK00XS4rl43mL7Q/2C6e2B9M1Ljj5sh2/9A6qV45SuCI2I3fozgnf7HIoJzipE4vY3//Mtb/CaA7vOqHL0gbgEWIYJqxcCD6Z6NjzcDNk5fVzUCttfxOp/4zzfff8bJcyPNaJwcHUlXG6fC8ccRw5cbf1w1F4ZeSeu3P5eoJjO39MLnGl8fJwBmFSG7at3mtOr+wcYJ7MOpb9PjlY/YTmgG7yehe+nk3zV/Pjk63NNxh9XrHkmb//RvEtX0s29/0dwtXSduAW4TMdu/+Q/T6vsfaYTs1mbUMrsYZYjQvTz6TnPJq9vB+/C3Xk99G7cmqiW+CTrx7S8l6DZjCUDtTZ/MDgw+IWYXIUYy4qt/cMen/9insXvy+Cc/79xIw/jwEXFbQVcvnk3QC05ugVqKoP2NLU+mgc1PNGPWUlJnxUnuh6eONccZ4sd2xm7cOvHoX7yXqJaLI0fSL159KkG3ObkFaiNOF9du2d08nXXS113NUY/Gye706e507I4Pv5EmGj8u5ZaGa42Pv2Mcwp/TanENGL0iboGiRVTdu+0bgrZibo/d6Sd1x04cShMnj6WFiv8bf36rRdzSK+IWKE6EU9xocO+2ZwRPJpqn6gO7Gifru5p/HB9pL+RU12tl1XP53DsJesHMLVCMuGd2oHESGFFrhrYczRPdtw7NG7qP/sX/9ue9QlwDRq84uQWyF6e067c/65S2UPHndfrP7VyhGzO8N9/YQO+U+Nwz+RC3QJamZ2njY+z4SJt6mCl0L478VTOkLp08Lm4rwkgCvSRugaxMR63RA6ZD99qVfc0ZXXO31RH3G0OvmLkFsiBqIR+/+NFT6eLwkQS94OQWqDRRC/mZ7OCLdDAfcQtUkqiFPE1dPOOOW3pK3AKVE9d5bdi5z6IYZMipLb0mboHKcKUX5M8yGb0mboGei7GD9dufa44gAHlzDRi9Jm6Bnlq7ZXdzBMFcLeQvHm+YOHksQS+JW6AnYp5245MvG0GAgji1pQrELdB1MX4QYwhOa6Es7ralCsQt0DVOa6FsXomjCsQt0BVxvddvN8LWaS2UKe63vewaMCpA3AId5SYEqAdXgFEV4hbomBhDePibr3uMAWpgfMS8LdUgboGOWLtlV9qw8wVjCFATH7oCjIoQt0DbPbRznzEEqJGLjVPba1cmElSBuAXaJk5pv/T1v3QbAtSMkQSqRNwCbWG+FurLMhlVIm6BJevb9Hj60p/82Hwt1FCMJEyNn0lQFeIWWJKYrY0ZW6CejCRQNeIWWLT1259t3mEL1NP1K5c8uUvliFtgUdyIAIyPvOGWBCpH3AILtvHJl5v32AL1NnbiUIKquSsBLICwBcLUxTNpwsMNVJCTW6Al7rAFbnb26IsJqkjcAvOKsI07bFetG0wAwd22VJWxBGBewha4WczautuWqhK3wJxixlbYAjezSEaViVtgVpbHgNtZJKPqxC0wo3igQdgCt7NIRtWJW+AOXh4DZhKntmNvGUmg2sQtcIt4dUzYAjNxaksOxC3wqYHBHc1ndQFud2PW1vVfVJ+4BZpWDDyQfvvJlxPATGIcwfVf5EDcAs2wjbts47EGgJmMnXgtQQ7ELZB+509+3AxcgJlcGNrv1JZsiFuouZix9UgDMJuYtT3fiFvIhbiFGoubEeILYDZmbcmNuIWaitNaNyMAc2nea2vWlsyIW6ihmK+NOVuAucS9tk5tyY24hRrasPMFC2TAnLxGRq7ELdRMPK07MPhEApiL18jIlbiFGonTWk/rAvO5OHLEqS3ZErdQE/FAQzzUADCf9w/vTZArcQs1Yc4WaIUHG8iduIUaWLtld+NrVwKYSyyRmbUld+IWCndjzvbZBDCfCNtrVyYS5EzcQuFigcw4AjCfsROHLJFRBHELBevb9LhxBGBexhEoibiFgm3c/f0EMB8vkVEScQuFijlb4wjAfIwjUBpxCwWKqI0bEgDmYhyBEolbKJAlMqAVxhEokbiFwtw4tbVEBswtHmswjkCJxC0UJk5tAeZiHIGSiVsoiFNboBXv/uCrHmugWOIWCrJh574EMJfTh/eas6Vo4hYKEae2A4M7EsBsYs72fOMLSiZuoRBmbYG5mLOlLsQtFMCsLTCXCFtzttSFuIUCOLUF5nLq4B5zttSGuIXMObUF5nL26Etp4uTxBHUhbiFz9217JgHMJMLWnC11I24hc/1uSABmMD7yhrCllsQtZGztlt3NsQSAm02eG0n/5+B/SlBH4hYytvYxs7bAreJmhF+8+pSbEagtcQuZihPbvo1bE8C06Su/3IxAnYlbyJTrv4CbCVu4QdxCppzaAtOuXZ1ojiIIWxC3kKWBwR0WyYCmCNs4sZ0cHUmAuIUs9W92/RcgbGEm4hYys3zlGi+SAcIWZiFuITMebQCELcxueQKy4m5bqDe3IsDcnNxCRtxtC/UmbGF+4hYy0rfx8QTUUzypK2xhfsYSICNGEqCeJk4dT++9+see1IUWiFvIRNySYCQB6ufC0P70/uG9CWiNuIVMuCUB6ud0I2rPN+IWaJ24hUwMbH4iAfUQV33FGMLEyeMJWBhxC5m4xzIZ1IIbEWBpxC1koG/T1rR8ZV8CyjZ24lA6ffh5i2OwBOIWMrB2y+4ElM18LbSHuIUMuCUByhVjCL949SlP6UKbiFuouNXrHmm+TAaUxxgCtJ+4hYqzSAblidsQRt940RgCdIC4hYob2Ox+WyhJvDZ26uAetyFAh4hbqDCvkkE5nNZCd4hbqDBhC2VwWgvdI26hwvqNJEDW4rQ2FsbG3jqUgO4Qt1BhTm4hXxeG9qezR190EwJ0mbiFiorrv1wBBvmJEYSI2omTxxPQfeIWKqrPFWCQlXiMIUYQxoffSEDviFuoqIHNTySg+mKu9sKbrzTHEIwgQO+JW6gojzdAtYlaqCZxCxUUT+4uX9mXgOoRtVBt4hYqyKktVI+ohTyIW6ggT+5CdYhayIu4hQpyvy30XlzpNXbitXRx+IiohYyIW6iYvk3CFnolTmk/PHksnW+c0rqnFvIkbqFiBgaNJEC3TZ4bSeONE1qjB5A/cQsVs2rdYAI6L05p//mt19L4yBGntFAQcQsVsnzlGvO20EERtBeH/yqNnTiUJkdHnNJCgcQtVIiwhfYTtFAv4hYqxDIZtMfUxTNp7K3XmjceGDmAehG3UCFObmFpImpPHdwjaKHGxC1UxIqBByyTwSLF6MHpw883TmsPJaDexC1UxOr7hS0slNfDgNuJW6iIfk/uQstELTAbcQsVYd4WWhNBe/boi6IWmJG4hQqIedv4AmYXNx/EstjU+JkEMJu7EtBzfRsfT8DcVvQ/IGyBeYlbqICBzU8kYG7x6cb67c8lgLmIW6iAe5zcQkvu2/Z0MsIDzEXcQo/Fq2TLV/YlYH7LVq5JD+3clwBmI26hx1a53xYWpH9wR+ObQp92ADMTt9BjA+63hQXbuPv7CWAm4hZ6aHnjI1b328LCWS4DZiNuoYeELSye5TJgJuIWesiTu7B4lsuAmYhb6CEnt7A0lsuA24lb6JHV6x7xkSq0geUy4GbiFnpk1f2bE7B08U3ifdueSQBB3EKPrH1sVwLaY/32Zz2GAjSJW+gBV4BBe8Vy2YadLyQAcQs9IGyh/dZu2WW5DBC30AuuAIPOeGjndxJQb+IWesDJLXTGqvsHLZdBzYlb6DJXgEFnWS6DehO30GX3bDQTCJ1kuQzqTdxClw2Yt4WOs1wG9SVuoYtcAQbdY7kM6kncQhcJW+gey2VQT+IWusgVYNBdlsugfsQtdJGTW+iuWC5bt/3PElAf4ha6pG/TVleAQQ/ct+1py2VQI+IWuqTPFWDQMzGeANTD8gR0RZzc8pnh730lXbtyKeUqPu5++Juvm+fMRIwExXLZ+aH9CSibuIUuiHEE87afuXzunXR5dCTl7Uy6MPRK40TwuUQe4vR27MRrjW+qJhJQLmMJ0AVGEm41mX3Y3nBh6ECaungmkQfLZVAP4ha6wEjCrSZOHUsliLGKUwf3JPJhuQzKJ26hC4wk3Gpy9J1UiomTxxuxfjyRD8tlUDZxCx3mCrBbXW+cduY/b3srp7d5mV4uA8okbqHDzNveKpbJSjM1fiadPfpiIh9eLoNyiVvoMPO2typlmex2sVxmCz8flsugXOIWOsgVYHe6VOh8aiyXnf7J84l8WC6DMolb6CAjCXcq9eQ2jL11yHJZZiyXQXnELXSQkYRbxZ2wMZ9aMrO3ebFcBuURt9BBRhJuVfKp7bS4GuyCJ16zYrkMyiJuoUNcAXanCL86OHv0JctlGbFcBmURt9Ah5m3vVOI1YDOJ5bLRn343kQ/LZVAOcQsdYt72TpOjw6kuzr95wHJZZiyXQRnELXSAK8DuFKe2dfuo3nJZXiyXQRnELXSAkYQ71WGZ7HYxYzx24lAiH5bLIH/iFjrASMKdJk4dS3V0+vBey2UZsVwG+RO30AFGEu40OVqPZbLbWS7LTyyXrV43mIA8iVtos9XrHnEF2G2uNwLvcg3HEqbFctnkufr+98/Rhp37EpAncQttdo952zvU5Qqwubx/eG8iH/Hpy9otuxOQH3ELbTaweUfiVnVcJrtdLJeNjxxJ5OOhnd+xXAYZErfQRstXrjFvO4NL7nttslyWF8tlkCdxC20kbGfm5PaGqfEz6cLQK4l8WC6D/IhbaKN+Iwl3mLp4phl13HBh6EDzfxPyYbkM8iJuoY2c3N7Jqe2t4mqwUwf3JPJhuQzyIm6hTVwBNrNYpOJW8b/JhDnkrFgug3yIW2gTV4DNzDVgM4vTW8tl+Yjlsnu3fSMB1SduoU1cATazydHhxJ0sl+Vn/fZnfToDGRC30AauAJtZnNo6nZyd5bL8bHzy5QRUm7iFNhC2M7NMNrdYLjvt5bKsxN/rPqWBahO30AauAJuZuJ3f+PARy2WZ2fBH+yyXQYWJW2gDJ7czE22tcTVYXmLu1nIZVJe4hSVyBdjsLju5bcmN5bL9iXxYLoPqErewRK4Am5lT24U5e/Qly3eZsVwG1SRuYYksl8zMvO3CNJfLfvJ8Ih+Wy6CaxC0sgSvAZnfJye2Cjb11yIl3ZiyXQfWIW1gCYTs7J7eLc/boi4l8WC6D6hG3sASuAJvZ9cZH7LEkxcJNnDxuuSwzlsugWsQtLIGT25n5aH1pLJflx3IZVIe4hUVyBdjsLo++k1i8WC4b/el3E/mIb3T7Nrk5BapA3MIiuQJsdk5ul+78mwf875iZjbu/b7kMKkDcwiK5Amh2k6PDiaWzXJYXy2VQDeIWFsEVYLO7fO4d86JtEstlYycOJfJx37anjStBj4lbWARhO7uPxj9ItM/pw3t9s5CRZY1vfC2XQW+JW1gEV4DNLk4baR/LZfmxXAa9JW5hEZzczi7GEmivWC6buuje4JxYLoPeEbewQK4Am9vEyWOJ9jt1cE8iH5bLoHfELSxQ/+AfJmbm6qrOiXGP8ZEjiXxYLoPeELewQH2bjCTMZnJ0JNE5lsvyYrkMekPcwgLEKYx529ldcnLbUVPjZ9KFoVcS+bBcBt0nbmEB+rxKNqePxi09ddqFIctlubFcBt0lbmEBBjY/kZjZ9SuX0mVjCR0XV4NZLsuL5TLoLnELC3CPk9tZuQKse2K5zPJeXiyXQfeIW2hRLJL5aHF2Hm/orji9tVyWD8tl0D3iFlo0MOhVsrk4Sewuy2X5sVwG3SFuoUX94nZOk6PDie6yXJYfy2XQeeIWWhCzcublZhfztj4i775YLou7b8mH5TLoPHELLXAF2Nw+Gv8g0Rvjw0eMhGTGchl0lriFFqx9bFdidpbJeut9p7dZsVwGnSVuYR7LG78ReZVsbq4B66149vjC0P5EPiyXQeeIW5iHsJ3fxMljid46e/Qlc8+ZieUyoP3ELcyjf7NbEuZi3rMamstlP3k+kY+Yu12//bkEtJe4hXm4Amxuk57crYyxtw75ZiMzlsug/cQtzMGrZPO7JKYq5ezRFxP5iOWyh3buS0D7iFuYw9otuxNz+2jcIwJVEjdXWC7LS3w6ZLkM2kfcwhwsk83t+pVL6bKxhMqxXJYfy2XQPuIWZrF63SNm4ebhCrBqiuWy0Z9+N5EPy2XQPuIWZnGPV8nm5fGG6jr/5gHLZZmxXAbtIW5hFgOuAJuXeKo2y2V5sVwG7SFuYQZxemLedn6To8OJ6oqT9bEThxL5sFwGSyduYQZ9RhLmFfO2lpaq7/Thvf48Zeahnd9JwOKJW5jB2sd2Jeb20fgHieqL5bILQ68k8rHq/sF037ZnErA44hZus3zlGiMJLbBMlo+4GmzqovuIc7J++7MekIFFErdwG8/ttsY1YHk5dXBPIh+xXLZh5wsJWDhxC7cZ2PxEYn4TJ48l8hEn7eMjRxL5WLtll+UyWARxC7dxcjs/V4DlyXJZfiyXwcKJW7jJgLBtyaQnd7M0NX7GcllmLJfBwolbuEm/hxtacsnJbbYuDB2wXJYZy2WwMOIWbmIkoTUfjYujXMXVYJbL8mK5DBZG3MInYiTB6cj8rjfi6LKxhKzFcpm56bxYLoPWiVv4hJGE1rgCrAxxemu5LC8xngDMT9zCJzzc0BqPN5TBcll+4tcoy2UwP3ELDX2btqYVAw8k5nf5nJGEUlguy4/lMpifuIUU82y7E6350OMNxYjlsrj7lnzEctm67X+WgNmJW0hGEloVp3zmNMsyPnzEcllm7tv2tOUymIO4pfaMJLTO4w1let/pbXYsl8HsxC21ZyShdZbJyhTftFwY2p/Ih+UymJ24pfY83NA614CV6+zRl4ycZMZyGcxM3FJrHm5YmAnLZMWK5bLRn343kQ/LZTAzcUutebihdU5ty3f+zQOWyzJjuQzuJG6preWNUw8jCa1zBVg9nD36YiIvlsvgVuKW2uo3krAgHm+oh1gatFyWF8tlcCtxS20NbH4i0brJUWMJdWG5LD+Wy+Az4pZainttjSS07vqVS+myO25rw3JZfiyXwWfELbXUt9ECxkJYJqsfy2X5sVwGN4hbamntY7sSrfMyWT1ZLsuP5TIQt9RQjCTEAgatu+QEr5ZiuWzsxKFEPiyXgbilhszaLpyT2/o6fXiv5bLMWC6j7sQtteNUY2GmLp5JU+NnEvUUy2UXhl5J5MNyGXUnbqmV1eseaY4l0DqntsTVYPFNDvmwXEadiVtq5d5t30gsTMxdwqmDexJ5sVxGXYlbasUi2cK5BowQ3+S4Giwv8evd2i27E9SNuKU2BgZ3GElYhMnR4QQhTm8tl+XloZ3fsVxG7YhbasPdtgsXp7ZihmmxWGi5LC+Wy6gjcUsteG53cSyTcbsLQwcsl2UmlstWrxtMUBfillrw3O7iTJw6luBmcTWY5bL8bNi5L0FdiFtqwdbw4kyOWibjTpbL8mO5jDoRtxSvb9NWi2SLcL1xQnfZWAKzsFyWH8tl1IW4pXhOKxbHFWDMxXJZfiyXURfilqItb/xibpFscSyTMR/LZfmxXEYdiFuKFmHrY7jFuWSmknnEctnpw3sTebFcRunELUVzt+3iObmlFePDRyyXZcZyGaUTtxQrlsg8t7s48VFzzFRCK953epsdy2WUTNxSrPXbn0ssjlNbFiL+erkwtD+Rj1guu3fbNxKUSNxSLKe2ixf3mMJCnD36kqvBMhP3f7smkRKJW4oU82R+0V4814CxULFcNvrT7ybysvHJlxOURtxSpLjuhsWbHB1OsFDn3zxguSwz8QnXwGbXJVIWcUtxVq97JK1yj+Oixamtj5dZrLNHX0zkZcMf7bNcRlHELcWxJLE0lslYipjXtlyWlxjh8usmJRG3FCV+kV67xd22SzFx6liCpbBclh/LZZRE3FKUvo2PJ5ZmctQyGUtjuSxPlssohbilKHH6wOJdb0TJZWMJtEEsl02e89dSTiyXUQpxSzFc/7V0rgCjnbxclh/LZZRA3FKMtY+ZtV0qy2S0UyyXjZ04lMiH5TJKIG4pQvyC7EWypbvkjlLa7HTj9NZyWV7innCfgpEzcUsR1m9/LrF0Tm5pt1guuzD0SiIfy1ausVxG1sQt2XP9V3tMXTyTpsbPJGi3uBos/voiH/FJWN8mt8+QJ3FL9oRtezi1pZNOHdyTyMvG3d+3XEaWxC3Zi1sSWLrL7relg2K5bMJMd1Ysl5ErcUvWXP/VPsKDTovTW8tlebFcRo7ELVnzaEP7TI4OJ+ikmOm2XJYXy2XkSNySrYHBHU4U2iQeb3CiRjdcGDpguSwzlsvIjbglW/f+h2cS7WGZjG6Jq8Esl+XHchk5EbdkafW6Rzza0Ebilm6yXJYfy2XkRNySJb/ItpfQoNuc3ubHchm5ELdkx6MN7XfZyS1dFstlZ4++mMiH5TJyIW7Jjqd228upLb1iuSw/lsvIgbglK05t28+8Lb0Sy2VOb/NjuYyqE7dkxalt+11ycksPjb11yKcHmbFcRtWJW7Lh1LYzPhr3sTC99f7hvYm8WC6jysQt2XBq237XGx8LWyaj12I05sLQ/kQ+LJdRZeKWLMQJQf/gjkR7xctkUAVnj77klbzMWC6jqj7X+Po4QcUtb5wS9G8Wt+0Wp7YWyqiKvk1bG9/IPpjIx9T4B81HOaBKxC0AAMUwlgAAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDHELQAAxRC3AAAUQ9wCAFAMcQsAQDH+Pz9dAkmbfqXjAAAAAElFTkSuQmCC
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - statefulsets/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - events.k8s.io
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+          - update
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ravendb.ravendb.io
+          resources:
+          - ravendbclusters
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ravendb.ravendb.io
+          resources:
+          - ravendbclusters/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ravendb.ravendb.io
+          resources:
+          - ravendbclusters/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - pods/exec
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        serviceAccountName: ravendb-operator-ravendb-operator-sa
+      deployments:
+      - label:
+          app: ravendb-operator
+        name: ravendb-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: ravendb-operator
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app: ravendb-operator
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                command:
+                - /manager
+                image: docker.io/ravendb/ravendb-operator:2.0.0
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: ravendb-operator-ravendb-operator-sa
+              terminationGracePeriodSeconds: 10
+              volumes:
+              - name: cert
+                secret:
+                  defaultMode: 420
+                  secretName: webhook-server-cert
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: ravendb-operator-ravendb-operator-sa
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - database
+  - nosql
+  - document-database
+  - nosql-data-storage
+  links:
+  - name: Ravendb Operator
+    url: https://github.com/ravendb/ravendb-operator
+  - name: RavenDB Documentation
+    url: https://ravendb.net/docs
+  maintainers:
+  - email: omer.ratsaby@ravendb.net
+    name: Omer Ratsaby (thegoldenplatypus)
+  - email: support@ravendb.net
+    name: RavenDB Team
+  maturity: alpha
+  minKubeVersion: 1.27.0
+  provider:
+    name: ravendb-operator
+  version: 2.0.0
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: ravendb-operator-controller-manager
+    failurePolicy: Fail
+    generateName: mravendbcluster.kb.io
+    rules:
+    - apiGroups:
+      - ravendb.ravendb.io
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - ravendbclusters
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-ravendb-ravendb-io-v1-ravendbcluster
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: ravendb-operator-controller-manager
+    failurePolicy: Fail
+    generateName: vravendbcluster.kb.io
+    rules:
+    - apiGroups:
+      - ravendb.ravendb.io
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - ravendbclusters
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-ravendb-ravendb-io-v1-ravendbcluster

--- a/operators/ravendb-operator/2.0.0/manifests/ravendb.ravendb.io_ravendbclusters.yaml
+++ b/operators/ravendb-operator/2.0.0/manifests/ravendb.ravendb.io_ravendbclusters.yaml
@@ -1,0 +1,521 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  creationTimestamp: null
+  name: ravendbclusters.ravendb.ravendb.io
+spec:
+  group: ravendb.ravendb.io
+  names:
+    kind: RavenDBCluster
+    listKind: RavenDBClusterList
+    plural: ravendbclusters
+    singular: ravendbcluster
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              caCertSecretRef:
+                type: string
+              clientCertSecretRef:
+                minLength: 1
+                type: string
+              clusterCertSecretRef:
+                type: string
+              domain:
+                minLength: 1
+                type: string
+              email:
+                pattern: ^[^@\s]+@[^@\s]+\.[^@\s]+$
+                type: string
+              env:
+                additionalProperties:
+                  type: string
+                type: object
+              externalAccessConfiguration:
+                properties:
+                  awsExternalAccessContext:
+                    properties:
+                      nodeMappings:
+                        items:
+                          properties:
+                            availabilityZone:
+                              type: string
+                            eipAllocationId:
+                              pattern: ^eipalloc-[a-z0-9]+$
+                              type: string
+                            subnetId:
+                              pattern: ^subnet-[a-z0-9]+$
+                              type: string
+                            tag:
+                              minLength: 1
+                              type: string
+                          required:
+                          - availabilityZone
+                          - eipAllocationId
+                          - subnetId
+                          - tag
+                          type: object
+                        minItems: 1
+                        type: array
+                    required:
+                    - nodeMappings
+                    type: object
+                  azureExternalAccessContext:
+                    properties:
+                      nodeMappings:
+                        items:
+                          properties:
+                            ip:
+                              pattern: ^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$
+                              type: string
+                            tag:
+                              minLength: 1
+                              type: string
+                          required:
+                          - ip
+                          - tag
+                          type: object
+                        minItems: 1
+                        type: array
+                    required:
+                    - nodeMappings
+                    type: object
+                  ingressControllerContext:
+                    properties:
+                      additionalAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      ingressClassName:
+                        enum:
+                        - nginx
+                        - traefik
+                        - haproxy
+                        minLength: 1
+                        type: string
+                    required:
+                    - ingressClassName
+                    type: object
+                  type:
+                    enum:
+                    - aws-nlb
+                    - azure-lb
+                    - ingress-controller
+                    type: string
+                required:
+                - type
+                type: object
+              image:
+                minLength: 1
+                type: string
+              imagePullPolicy:
+                enum:
+                - Always
+                - IfNotPresent
+                type: string
+              licenseSecretRef:
+                minLength: 1
+                type: string
+              mode:
+                enum:
+                - LetsEncrypt
+                - None
+                type: string
+              nodes:
+                items:
+                  properties:
+                    certSecretRef:
+                      type: string
+                    publicServerUrl:
+                      minLength: 1
+                      type: string
+                    publicServerUrlTcp:
+                      minLength: 1
+                      type: string
+                    tag:
+                      maxLength: 4
+                      minLength: 1
+                      type: string
+                  required:
+                  - publicServerUrl
+                  - publicServerUrlTcp
+                  - tag
+                  type: object
+                minItems: 1
+                type: array
+              storage:
+                properties:
+                  additionalVolumes:
+                    items:
+                      properties:
+                        mountPath:
+                          type: string
+                        name:
+                          type: string
+                        subPath:
+                          type: string
+                        volumeSource:
+                          properties:
+                            configMap:
+                              description: |-
+                                Adapts a ConfigMap into a volume.
+
+                                The contents of the target ConfigMap's Data field will be presented in a
+                                volume as files using the keys in the Data field as the file names, unless
+                                the items element is populated with specific mappings of keys to paths.
+                                ConfigMap volumes support ownership management and SELinux relabeling.
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    defaultMode is optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: |-
+                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                    ConfigMap will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the ConfigMap,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            persistentVolumeClaim:
+                              description: |-
+                                PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace.
+                                This volume finds the bound PV and mounts that volume for the pod. A
+                                PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another
+                                type of volume that is owned by someone else (the system).
+                              properties:
+                                claimName:
+                                  description: |-
+                                    claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    readOnly Will force the ReadOnly setting in VolumeMounts.
+                                    Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            secret:
+                              description: |-
+                                Adapts a Secret into a volume.
+
+                                The contents of the target Secret's Data field will be presented in a volume
+                                as files using the keys in the Data field as the file names.
+                                Secret volumes support ownership management and SELinux relabeling.
+                              properties:
+                                defaultMode:
+                                  description: |-
+                                    defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values
+                                    for mode bits. Defaults to 0644.
+                                    Directories within the path are not affected by this setting.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: |-
+                                    items If unspecified, each key-value pair in the Data field of the referenced
+                                    Secret will be projected into the volume as a file whose name is the
+                                    key and content is the value. If specified, the listed keys will be
+                                    projected into the specified paths, and unlisted keys will not be
+                                    present. If a key is specified which is not present in the Secret,
+                                    the volume setup will error unless it is marked optional. Paths must be
+                                    relative and may not contain the '..' path or start with '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: |-
+                                          mode is Optional: mode bits used to set permissions on this file.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          If not specified, the volume defaultMode will be used.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the relative path of the file to map the key to.
+                                          May not be an absolute path.
+                                          May not contain the path element '..'.
+                                          May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                optional:
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
+                                  type: boolean
+                                secretName:
+                                  description: |-
+                                    secretName is the name of the secret in the pod's namespace to use.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                      - mountPath
+                      - name
+                      - volumeSource
+                      type: object
+                    type: array
+                  data:
+                    properties:
+                      accessModes:
+                        items:
+                          type: string
+                        type: array
+                      size:
+                        pattern: ^\d+(Ei|Pi|Ti|Gi|Mi|Ki)$
+                        type: string
+                      storageClassName:
+                        type: string
+                      volumeAttributesClassName:
+                        type: string
+                    required:
+                    - size
+                    type: object
+                  logs:
+                    properties:
+                      audit:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            type: string
+                          size:
+                            pattern: ^\d+(Ei|Pi|Ti|Gi|Mi|Ki)$
+                            type: string
+                          storageClassName:
+                            type: string
+                          volumeAttributesClassName:
+                            type: string
+                        required:
+                        - size
+                        type: object
+                      ravendb:
+                        properties:
+                          accessModes:
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            type: string
+                          size:
+                            pattern: ^\d+(Ei|Pi|Ti|Gi|Mi|Ki)$
+                            type: string
+                          storageClassName:
+                            type: string
+                          volumeAttributesClassName:
+                            type: string
+                        required:
+                        - size
+                        type: object
+                    type: object
+                required:
+                - data
+                type: object
+            required:
+            - clientCertSecretRef
+            - domain
+            - image
+            - imagePullPolicy
+            - licenseSecretRef
+            - mode
+            - nodes
+            - storage
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                type: string
+              nodes:
+                items:
+                  properties:
+                    lastAttemptTime:
+                      format: date-time
+                      type: string
+                    lastAttemptedImage:
+                      type: string
+                    lastError:
+                      type: string
+                    status:
+                      enum:
+                      - Created
+                      - Failed
+                      type: string
+                    tag:
+                      type: string
+                  required:
+                  - status
+                  - tag
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+              phase:
+                enum:
+                - Deploying
+                - Running
+                - Error
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/ravendb-operator/2.0.0/metadata/annotations.yaml
+++ b/operators/ravendb-operator/2.0.0/metadata/annotations.yaml
@@ -1,0 +1,15 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: ravendb-operator
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.38.0
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/ravendb-operator/2.0.0/tests/scorecard/config.yaml
+++ b/operators/ravendb-operator/2.0.0/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.38.0
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.38.0
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.38.0
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.38.0
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.38.0
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.38.0
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
Update **ravendb-operator** to **2.0.0**.

### What's in 2.0.0
- Major release of the RavenDB Kubernetes Operator. The operator chart is now infrastructure-only (controller, CRD, RBAC, webhooks); cluster-side Secret provisioning moved out of the operator (a Helm-chart convenience, not relevant to OLM).
- Native Traefik `IngressRouteTCP` support and RFC 1035-safe per-node object naming.
- For OLM, this bundle installs the operator; users then apply a `RavenDBCluster` CR that references Secrets they create (see the CSV `alm-examples`). No provisioning fields remain in the CR.

### Details
- Operator image: `docker.io/ravendb/ravendb-operator:2.0.0` (multi-arch amd64/arm64).
- Release notes: https://github.com/ravendb/ravendb-operator/releases/tag/v2.0.0
- Update graph: `semver-mode` (per `operators/ravendb-operator/ci.yaml`); no `replaces`.
- First submission since 1.0.0 (1.1.0 was not submitted upstream); going 1.0.0 -> 2.0.0 directly, which semver-mode supports.
