### PR TITLE
operator [O] percona-server-mongodb-operator (1.13.0)

### DIFF
--- a/operators/percona-server-mongodb-operator/1.13.0/manifests/percona-server-mongodb-operator.v1.13.0.clusterserviceversion.yaml
+++ b/operators/percona-server-mongodb-operator/1.13.0/manifests/percona-server-mongodb-operator.v1.13.0.clusterserviceversion.yaml
@@ -214,7 +214,7 @@ metadata:
     support: Percona
     capabilities: Deep Insights
     repository: 'https://github.com/percona/percona-server-mongodb-operator'
-    olm.skipRange: <v1.13.0
+    olm.skipRange: <1.13.0
 spec:
   displayName: Percona Distribution for MongoDB Operator
   description: >+


### PR DESCRIPTION
## Summary
- Remove invalid `v` prefix from `olm.skipRange` annotation in percona-server-mongodb-operator v1.13.0
- `<v1.13.0` → `<1.13.0` — the `v` prefix is not valid semver range syntax and causes parse errors

## Test plan
- [ ] Verify the catalog builds without skipRange parse warnings for this package

Generated with [Claude Code](https://claude.com/claude-code)