### PR TITLE
operator [R] project-quay (3.10.19 3.12.15 3.9.19)

### DIFF
--- a/operators/project-quay/3.10.19/manifests/quay-operator.clusterserviceversion.yaml
+++ b/operators/project-quay/3.10.19/manifests/quay-operator.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    olm.skipRange: ">=3.6.x <v3.10.19"
+    olm.skipRange: ">=3.6.x <3.10.19"
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     containerImage: quay.io/projectquay/quay-operator:v3.10.19

--- a/operators/project-quay/3.12.15/manifests/quay-operator.clusterserviceversion.yaml
+++ b/operators/project-quay/3.12.15/manifests/quay-operator.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    olm.skipRange: ">=3.6.x <v3.12.15"
+    olm.skipRange: ">=3.6.x <3.12.15"
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     containerImage: quay.io/projectquay/quay-operator:v3.12.15

--- a/operators/project-quay/3.9.19/manifests/quay-operator.clusterserviceversion.yaml
+++ b/operators/project-quay/3.9.19/manifests/quay-operator.clusterserviceversion.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    olm.skipRange: ">=3.6.x <v3.9.19"
+    olm.skipRange: ">=3.6.x <3.9.19"
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     containerImage: quay.io/projectquay/quay-operator:v3.9.19


### PR DESCRIPTION
## Summary
- Remove invalid `v` prefix from `olm.skipRange` annotation in project-quay versions 3.9.19, 3.10.19, and 3.12.15
- `<v3.x.x` → `<3.x.x` — the `v` prefix is not valid semver range syntax and causes parse errors

## Test plan
- [ ] Verify the catalog builds without skipRange parse warnings for this package

Generated with [Claude Code](https://claude.com/claude-code)