### PR TITLE
operator [N] storage-based-remediation (0.3.0)

### DIFF
--- a/operators/storage-based-remediation/0.3.0/manifests/storage-based-remediation.clusterserviceversion.yaml
+++ b/operators/storage-based-remediation/0.3.0/manifests/storage-based-remediation.clusterserviceversion.yaml
@@ -53,7 +53,7 @@ metadata:
     containerImage: quay.io/medik8s/storage-based-remediation-operator:v0.3.0
     createdAt: "2026-06-18T09:43:30Z"
     description: Storage-Based Remediation Operator for remediating nodes using storage-based fencing (SBD/STONITH).
-    olm.skipRange: '>= <0.3.0'
+    olm.skipRange: '<0.3.0'
     operatorframework.io/suggested-namespace: openshift-workload-availability
     operatorframework.io/suggested-namespace-template: '{"kind":"Namespace","apiVersion":"v1","metadata":{"name":"openshift-workload-availability","annotations":{"openshift.io/node-selector":""}}}'
     operators.operatorframework.io/builder: operator-sdk-v1.42.2


### PR DESCRIPTION
## Summary
- Fix malformed `olm.skipRange` annotation in storage-based-remediation v0.3.0
- `>= <0.3.0` → `<0.3.0` — the bare `>=` with no version is not valid semver range syntax

## Test plan
- [ ] Verify the catalog builds without skipRange parse warnings for this package

Generated with [Claude Code](https://claude.com/claude-code)