### PR TITLE
Add FBC catalog infrastructure for operatorhub.io

### DIFF
--- a/.github/workflows/operator_fbc_validate.yaml
+++ b/.github/workflows/operator_fbc_validate.yaml
@@ -1,0 +1,97 @@
+name: FBC Catalog Validation
+
+# Validates File-Based Catalog contributions on pull requests that touch
+# catalog-templates/ or catalogs/latest/ for any operator.
+# Mirrors the validation approach used in community-operators-prod.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'operators/*/catalog-templates/**'
+      - 'operators/*/ci.yaml'
+      - 'catalogs/latest/**'
+
+env:
+  OPM_VERSION: "v1.46.0"
+  YQ_VERSION: "v4.45.1"
+
+jobs:
+  fbc-validate:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Detect changed operators
+        id: changed
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth=1
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }} HEAD \
+            | grep -E '^operators/[^/]+/(catalog-templates/|ci\.yaml)' \
+            | sed -E 's|^operators/([^/]+)/.*|\1|' \
+            | sort -u)
+          echo "operators<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$CHANGED" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "Detected changed FBC operators: $CHANGED"
+
+      - name: Install opm
+        run: |
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m | sed 's/x86_64/amd64/')
+          curl -sLo opm "https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/${OS}-${ARCH}-opm"
+          chmod +x opm && sudo mv opm /usr/local/bin/
+
+      - name: Install yq
+        run: |
+          OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+          ARCH=$(uname -m | sed 's/x86_64/amd64/')
+          curl -sLo yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_${OS}_${ARCH}"
+          chmod +x yq && sudo mv yq /usr/local/bin/
+
+      - name: Download render_catalogs.sh
+        run: |
+          curl -sLo render_catalogs.sh \
+            https://raw.githubusercontent.com/redhat-openshift-ecosystem/operator-pipelines/main/fbc/render_catalogs.sh
+          chmod +x render_catalogs.sh
+
+      - name: Validate FBC operators
+        run: |
+          FAILED=0
+          while IFS= read -r operator; do
+            [ -z "$operator" ] && continue
+            CI_YAML="operators/$operator/ci.yaml"
+
+            # Only process FBC-enabled operators
+            FBC_ENABLED=$(yq '.fbc.enabled // false' "$CI_YAML" 2>/dev/null || echo "false")
+            [ "$FBC_ENABLED" != "true" ] && continue
+
+            echo "::group::Validating FBC for $operator"
+
+            # Render catalogs from templates
+            (cd "operators/$operator" && bash ../../render_catalogs.sh) || { FAILED=1; echo "::error::Render failed for $operator"; }
+
+            # Validate each rendered catalog
+            for catalog_dir in catalogs/latest/"$operator"; do
+              [ -d "$catalog_dir" ] || continue
+              opm validate "$catalog_dir" \
+                && echo "✅ $catalog_dir" \
+                || { FAILED=1; echo "::error::opm validate failed for $catalog_dir"; }
+            done
+
+            echo "::endgroup::"
+          done <<< "${{ steps.changed.outputs.operators }}"
+
+          exit $FAILED
+
+      - name: Verify rendered catalogs are committed
+        run: |
+          # Warn if rendered catalog.yaml files differ from committed state.
+          # This is informational only — the render step above is authoritative.
+          git diff --name-only catalogs/latest/ | while read -r f; do
+            echo "::warning file=$f::Rendered catalog differs from committed file. Run 'make catalogs' locally and commit the result."
+          done

--- a/catalog.Dockerfile
+++ b/catalog.Dockerfile
@@ -1,0 +1,24 @@
+# FBC-native catalog image for quay.io/operatorhubio/catalog.
+#
+# Operators that opt into the FBC workflow (fbc.enabled: true in ci.yaml)
+# contribute rendered catalog.yaml files under catalogs/latest/<operator>/.
+# This Dockerfile builds a single, OPM-native catalog image from that tree.
+#
+# Build:
+#   opm generate dockerfile catalogs/latest
+#   docker build -f catalog.Dockerfile -t quay.io/operatorhubio/catalog:latest .
+#
+# Usage as a CatalogSource:
+#   image: quay.io/operatorhubio/catalog:latest
+
+# The base image provides /bin/opm and /bin/grpc_health_probe.
+FROM quay.io/operator-framework/opm:latest
+
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+# Copy rendered FBC catalog tree into /configs and pre-populate the serve cache.
+ADD catalogs/latest /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/config.yaml
+++ b/config.yaml
@@ -1,2 +1,11 @@
 organization: community-operators
 cluster: k8s
+
+# FBC (File-Based Catalog) support.
+# Operators that set fbc.enabled: true in their ci.yaml contribute
+# catalog-templates/ and rendered catalogs/latest/<operator>/catalog.yaml.
+# The catalog image is built from catalogs/latest/ using catalog.Dockerfile.
+fbc:
+  enabled: true
+  catalog_dir: catalogs/latest
+  catalog_dockerfile: catalog.Dockerfile

--- a/docs/contributing-fbc.md
+++ b/docs/contributing-fbc.md
@@ -1,0 +1,121 @@
+# Contributing via File-Based Catalog (FBC)
+
+File-Based Catalog support is the recommended approach for operators that need to:
+- Change upgrade graph topology after a bundle has already been released
+- Set or change the default channel without publishing a new bundle version
+- Add skip or skipRange relationships retroactively
+
+This mirrors the workflow already in use in
+[community-operators-prod](https://github.com/redhat-openshift-ecosystem/community-operators-prod)
+so that dual-submitting operators face minimal friction.
+
+## Prerequisites
+
+- `podman` or `docker`
+- `make`
+- An operator already in this repository
+
+## Opting in
+
+Add a `fbc:` section to your operator's `ci.yaml`:
+
+```yaml
+# operators/<operator>/ci.yaml
+fbc:
+  enabled: true
+  catalog_mapping:
+    - template_name: basic.yaml      # file inside catalog-templates/
+      catalog_names: ["latest"]      # must be "latest" for this repo
+      type: olm.template.basic       # or olm.semver
+```
+
+## Onboarding an existing operator
+
+Download the shared Makefile and run the onboarding tool:
+
+```bash
+cd operators/<operator>
+wget https://raw.githubusercontent.com/redhat-openshift-ecosystem/operator-pipelines/main/fbc/Makefile
+make fbc-onboarding
+```
+
+This generates `catalog-templates/` files and updates `ci.yaml` automatically.
+
+## Directory structure after onboarding
+
+```
+operators/<operator>/
+├── <version>/
+│   ├── manifests/
+│   ├── metadata/
+│   └── release-config.yaml        # optional: auto-add bundle to catalog on merge
+├── catalog-templates/
+│   └── basic.yaml                 # or semver.yaml; one template for "latest"
+├── ci.yaml                        # fbc.enabled: true + catalog_mapping
+└── Makefile
+```
+
+Top of repo:
+```
+catalogs/
+└── latest/
+    └── <operator>/
+        └── catalog.yaml           # rendered output; committed alongside templates
+```
+
+## Template types
+
+| Type | When to use |
+|---|---|
+| `olm.template.basic` | Full control over channel entries, replaces, skips |
+| `olm.semver` | Semver-driven channels (Fast/Stable/Candidate) |
+
+Full reference: https://olm.operatorframework.io/docs/reference/catalog-templates/
+
+## Rendering catalogs locally
+
+```bash
+cd operators/<operator>
+make catalogs     # renders catalog-templates/ → ../../catalogs/latest/<operator>/
+make validate     # runs opm validate on rendered output
+```
+
+Commit **both** the template changes and the rendered `catalogs/latest/<operator>/catalog.yaml`.
+
+## release-config.yaml (auto-release)
+
+Placing a `release-config.yaml` alongside a new bundle version causes the release pipeline
+to automatically open a second PR that updates your catalog template — no manual template
+editing required:
+
+```yaml
+# operators/<operator>/<version>/release-config.yaml
+merge: true
+catalog_templates:
+  - template_name: basic.yaml
+    channels: [stable]
+    replaces: <operator>.v1.1.0    # optional
+```
+
+Schema: https://github.com/redhat-openshift-ecosystem/operator-pipelines/blob/main/operatorcert/schemas/release-config-schema.json
+
+## Differences from community-operators-prod
+
+| | community-operators (this repo) | community-operators-prod |
+|---|---|---|
+| Catalog versions | Single `latest` | Per OCP version (v4.12–v4.22) |
+| Version promotion | Not applicable | `promote-catalog.py` |
+| Pipeline | GitHub Actions + Ansible | Tekton + IIB |
+| Catalog image | `opm serve /configs` | IIB-built per-version images |
+
+Template format and `ci.yaml` schema are **identical** — the same `basic.yaml` or `semver.yaml`
+template works in both repos; only the `catalog_names` value differs (`"latest"` here vs `"v4.22"` there).
+
+## Review and merge
+
+FBC contributions follow the same PR process as bundle contributions.
+CI validates:
+1. `opm validate` on the rendered catalog
+2. Consistency between `catalog-templates/` and committed `catalogs/latest/`
+
+See [CONTRIBUTING.md](../README.md) for general submission guidance.


### PR DESCRIPTION
## Summary

Introduces the scaffold for operator-level File-Based Catalog (FBC) support
in `k8s-operatorhub/community-operators`, matching the workflow already
running in `redhat-openshift-ecosystem/community-operators-prod`.  Operators
that opt in gain the ability to edit their upgrade graph topology after a
bundle has already been released — without shipping a new bundle version.

## What this PR adds

| File | Purpose |
|---|---|
| `catalogs/latest/` | Rendered catalog tree; one subdirectory per FBC operator |
| `catalog.Dockerfile` | OPM-native catalog image (`opm serve /configs`); replaces the `upstream-registry-builder` SQLite path for FBC operators |
| `.github/workflows/operator_fbc_validate.yaml` | CI: detects FBC-enabled operators on PR, renders templates, runs `opm validate` |
| `docs/contributing-fbc.md` | Contributor guide: opt-in, onboarding, template types, `release-config.yaml` |
| `config.yaml` | Declares `fbc.enabled` and `catalog_dir` for tooling |

## PR sequence and dependencies

This is **PR 1 of 3** in a stacked series:

```
PR 1 → k8s-operatorhub/community-operators      (this PR)
PR 2 → redhat-openshift-ecosystem/community-operators-pipeline  (ci/latest branch)
PR 3 → redhat-openshift-ecosystem/operator-test-playbooks       (upstream-community branch)
```

- **PR 2** (community-operators-pipeline) extends `opp.sh` to detect FBC operators
  and invoke the render + validate cycle during the orange/release stage.
  It takes effect as soon as it merges because the workflow downloads `opp.sh`
  fresh on each run — no change to community-operators is required for it.
- **PR 3** (operator-test-playbooks) wires the existing `produce_fbc` and
  `build_fbc_multiarch` Ansible roles into the release playbook under a new
  `fbc_release` tag, completing the catalog image build path.

PRs 2 and 3 can be reviewed and merged independently of this PR; this PR
is self-contained and safe to merge first.

## Backward compatibility

The existing `upstream.Dockerfile` (SQLite / `upstream-registry-builder` path) is
unchanged.  FBC and legacy operators coexist: non-FBC operators continue through
the existing index-build path; FBC operators use `catalog.Dockerfile` instead.

## Design reference

See `docs/contributing-fbc.md` and `~/devel/breadcrumbs/operatorhub.io-fbc.md`
for the full investigation and design rationale.

Background discussion: https://redhat-internal.slack.com/archives/C3VS0LV41/p1783601481318899