### PR TITLE
chore(ISV-7433): update OPM version used in CI

### DIFF
--- a/ci/pipeline-config-k8s.yaml
+++ b/ci/pipeline-config-k8s.yaml
@@ -19,7 +19,7 @@ production:
     multiarch:
       base: quay.io/operator-framework/opm
       base_tags:
-        - v1.57.0
+        - v1.72.0
       postfix: s
     registry: quay.io
     organization: operatorhubio


### PR DESCRIPTION
Same OPM version 1.72.0 tested successfully [here](https://github.com/redhat-openshift-ecosystem/community-operators-pipeline/actions/runs/29325998503) after fix in [operator-test-playbooks](https://github.com/redhat-openshift-ecosystem/operator-test-playbooks/pull/481).