### PR TITLE
operator [N] [CI] prompt-policy-operator (1.0.0)

### DIFF
--- a/operators/prompt-policy-operator/1.0.0/manifests/creative.foster.tools_promptpolicies.yaml
+++ b/operators/prompt-policy-operator/1.0.0/manifests/creative.foster.tools_promptpolicies.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: promptpolicies.creative.foster.tools
+spec:
+  group: creative.foster.tools
+  names:
+    kind: PromptPolicy
+    listKind: PromptPolicyList
+    plural: promptpolicies
+    singular: promptpolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.configMapName
+      name: ConfigMap
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PromptPolicy is the Schema for the promptpolicies API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PromptPolicySpec defines the desired state of PromptPolicy.
+            properties:
+              maxPromptCharacters:
+                default: 2000
+                description: MaxPromptCharacters is the maximum prompt size accepted
+                  by downstream tools.
+                format: int32
+                maximum: 8000
+                minimum: 256
+                type: integer
+              maxReferenceImages:
+                default: 4
+                description: MaxReferenceImages limits how many reference images a
+                  workflow may attach.
+                format: int32
+                maximum: 10
+                minimum: 1
+                type: integer
+              productGuideURL:
+                description: ProductGuideURL is an optional human-readable workflow
+                  reference.
+                format: uri
+                type: string
+              requiredLayers:
+                default:
+                - subject
+                - composition
+                - camera
+                - visual
+                description: RequiredLayers lists the sections every prompt brief
+                  must cover.
+                items:
+                  type: string
+                minItems: 1
+                type: array
+                uniqueItems: true
+            type: object
+          status:
+            description: PromptPolicyStatus defines the observed state of PromptPolicy.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              configMapName:
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/prompt-policy-operator/1.0.0/manifests/prompt-policy-operator.v1.0.0.clusterserviceversion.yaml
+++ b/operators/prompt-policy-operator/1.0.0/manifests/prompt-policy-operator.v1.0.0.clusterserviceversion.yaml
@@ -1,0 +1,125 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: prompt-policy-operator.v1.0.0
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "creative.foster.tools/v1alpha1",
+          "kind": "PromptPolicy",
+          "metadata": {
+            "name": "campaign-visuals"
+          },
+          "spec": {
+            "requiredLayers": ["subject", "composition", "camera", "visual"],
+            "maxPromptCharacters": 1600,
+            "maxReferenceImages": 4,
+            "productGuideURL": "https://muse-image.co/"
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Developer Tools
+    containerImage: ghcr.io/fostermartyn735/prompt-policy-operator:v1.0.0
+    createdAt: "2026-07-29T00:00:00Z"
+    description: Reconciles visual prompt review requirements into Kubernetes ConfigMaps.
+    repository: https://github.com/FosterMartyn735/prompt-policy-operator
+    support: Community
+spec:
+  displayName: Prompt Policy Operator
+  description: |
+    Prompt Policy Operator provides a namespaced API for visual prompt review
+    requirements. It reconciles required brief layers, prompt-size limits,
+    reference-image limits, and an optional workflow guide into an owned
+    ConfigMap for use by applications in the same namespace.
+  version: 1.0.0
+  maturity: alpha
+  provider:
+    name: FosterMartyn735
+  maintainers:
+    - name: FosterMartyn735
+      email: FosterMartyn735@gmail.com
+  links:
+    - name: Source
+      url: https://github.com/FosterMartyn735/prompt-policy-operator
+    - name: Documentation
+      url: https://github.com/FosterMartyn735/prompt-policy-operator#readme
+  keywords:
+    - prompt
+    - policy
+    - creative workflow
+    - configmap
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: false
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+        - name: prompt-policy-operator-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app.kubernetes.io/name: prompt-policy-operator
+                control-plane: controller-manager
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/name: prompt-policy-operator
+                  control-plane: controller-manager
+              spec:
+                serviceAccountName: prompt-policy-operator-controller-manager
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                containers:
+                  - name: manager
+                    image: ghcr.io/fostermartyn735/prompt-policy-operator:v1.0.0
+                    imagePullPolicy: IfNotPresent
+                    command: ["/manager"]
+                    args:
+                      - --leader-elect
+                      - --health-probe-bind-address=:8081
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop: ["ALL"]
+                    resources:
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                      limits:
+                        cpu: 500m
+                        memory: 128Mi
+      permissions:
+        - serviceAccountName: prompt-policy-operator-controller-manager
+          rules:
+            - apiGroups: [""]
+              resources: ["configmaps"]
+              verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+            - apiGroups: ["creative.foster.tools"]
+              resources: ["promptpolicies"]
+              verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+            - apiGroups: ["creative.foster.tools"]
+              resources: ["promptpolicies/finalizers"]
+              verbs: ["update"]
+            - apiGroups: ["creative.foster.tools"]
+              resources: ["promptpolicies/status"]
+              verbs: ["get", "patch", "update"]
+  customresourcedefinitions:
+    owned:
+      - name: promptpolicies.creative.foster.tools
+        version: v1alpha1
+        kind: PromptPolicy
+        displayName: Prompt Policy
+        description: Defines prompt review requirements reconciled into a ConfigMap.
+  minKubeVersion: 1.28.0-0

--- a/operators/prompt-policy-operator/1.0.0/metadata/annotations.yaml
+++ b/operators/prompt-policy-operator/1.0.0/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: prompt-policy-operator
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable

--- a/operators/prompt-policy-operator/ci.yaml
+++ b/operators/prompt-policy-operator/ci.yaml
@@ -1,0 +1,4 @@
+---
+updateGraph: semver-mode
+reviewers:
+  - FosterMartyn735


### PR DESCRIPTION
Adds the initial 1.0.0 bundle for Prompt Policy Operator.

- Source: https://github.com/FosterMartyn735/prompt-policy-operator
- Public image: ghcr.io/fostermartyn735/prompt-policy-operator:v1.0.0
- Local verification: `go test ./...` and `go vet ./...`
- Source CI: tests, vet, Operator SDK bundle validation, and container publishing all passed

The operator reconciles namespaced PromptPolicy resources into owned ConfigMaps containing visual prompt review requirements.