### PR TITLE
operator [N] [CI] kollect (0.18.0)

### DIFF
--- a/operators/kollect/0.18.0/manifests/kollect.clusterserviceversion.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.clusterserviceversion.yaml
@@ -49,7 +49,7 @@ metadata:
       ]
     categories: Monitoring,Integration & Delivery
     capabilities: Full Lifecycle
-    containerImage: ghcr.io/platformrelay/kollect@sha256:cc63c330c6dcbc0c7de12a68c4aa74e81c8ac19a107178f0d3285946f16d6a75
+    containerImage: ghcr.io/platformrelay/kollect@sha256:9f116431941d1816bfdb22f574f3394c30cf41a348082e1028b2a16b5e0ccc5c
     createdAt: "2026-08-18T00:00:00Z"
     support: platformrelay
     repository: https://github.com/platformrelay/kollect
@@ -298,7 +298,7 @@ spec:
                     type: RuntimeDefault
                 containers:
                   - name: manager
-                    image: ghcr.io/platformrelay/kollect@sha256:cc63c330c6dcbc0c7de12a68c4aa74e81c8ac19a107178f0d3285946f16d6a75
+                    image: ghcr.io/platformrelay/kollect@sha256:9f116431941d1816bfdb22f574f3394c30cf41a348082e1028b2a16b5e0ccc5c
                     imagePullPolicy: IfNotPresent
                     command:
                       - /manager
@@ -402,4 +402,4 @@ spec:
 
   relatedImages:
     - name: kollect
-      image: ghcr.io/platformrelay/kollect@sha256:cc63c330c6dcbc0c7de12a68c4aa74e81c8ac19a107178f0d3285946f16d6a75
+      image: ghcr.io/platformrelay/kollect@sha256:9f116431941d1816bfdb22f574f3394c30cf41a348082e1028b2a16b5e0ccc5c

--- a/operators/kollect/0.18.0/manifests/kollect.clusterserviceversion.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.clusterserviceversion.yaml
@@ -1,0 +1,405 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kollect.v0.18.0
+  namespace: placeholder
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kollect.dev/v1alpha1",
+          "kind": "KollectProfile",
+          "metadata": {
+            "name": "deployment-images",
+            "namespace": "default"
+          },
+          "spec": {
+            "targetGVK": {
+              "group": "apps",
+              "version": "v1",
+              "kind": "Deployment"
+            },
+            "attributes": [
+              {
+                "name": "image",
+                "path": "$.spec.template.spec.containers[0].image",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "kollect.dev/v1alpha1",
+          "kind": "KollectTarget",
+          "metadata": {
+            "name": "nginx-deployments",
+            "namespace": "default"
+          },
+          "spec": {
+            "profileRef": "deployment-images",
+            "labelSelector": {
+              "matchLabels": {
+                "app.kubernetes.io/name": "nginx"
+              }
+            },
+            "suspend": false
+          }
+        }
+      ]
+    categories: Monitoring,Integration & Delivery
+    capabilities: Full Lifecycle
+    containerImage: ghcr.io/platformrelay/kollect@sha256:cc63c330c6dcbc0c7de12a68c4aa74e81c8ac19a107178f0d3285946f16d6a75
+    createdAt: "2026-08-18T00:00:00Z"
+    support: platformrelay
+    repository: https://github.com/platformrelay/kollect
+    description: Kubernetes inventory export operator — declare what to collect once and export durable rows to Git, databases, object storage, and event streams.
+    operators.operatorframework.io/builder: operator-sdk-v1.39.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+spec:
+  displayName: Kollect
+  description: |
+    ## Kollect
+
+    Kollect turns Kubernetes state into durable inventory. Declare what matters once
+    in `KollectProfile` and `KollectTarget` resources; the operator keeps rows current
+    with shared informers and exports the same canonical snapshot to Git, databases,
+    object storage, and event streams in parallel.
+
+    ### Features
+
+    * **Decoupled read model** — consumers query sinks, not the apiserver
+    * **Event-driven collection** — one shared informer per GVK, no polling
+    * **Schema-flexible extraction** — CEL and JSONPath attributes in profiles
+    * **Pluggable sinks** — snapshot, database, and event sink families
+    * **Multi-tenant governance** — `KollectScope` gates teams and sinks
+    * **Fleet-ready** — cluster-scoped targets fan in to shared sinks
+
+    ### Capability Level: Full Lifecycle
+
+    Kollect installs and manages its CRDs, reconciles inventory continuously, and
+    coordinates export to configured sinks.
+
+    ### Prerequisites
+
+    * Kubernetes 1.28+
+    * For validating webhooks outside this bundle, cert-manager and webhook TLS
+      configuration are required (Helm chart path documented upstream)
+
+  maturity: alpha
+  version: 0.18.0
+  minKubeVersion: "1.28.0"
+
+  keywords:
+    - kubernetes
+    - inventory
+    - operator
+    - gitops
+    - export
+    - observability
+    - multi-tenant
+    - fleet
+
+  maintainers:
+    - name: kollect contributors
+      email: maintainers@platformrelay.github.io
+
+  provider:
+    name: platformrelay
+
+  links:
+    - name: Documentation
+      url: https://platformrelay.github.io/Kollect/
+    - name: GitHub
+      url: https://github.com/platformrelay/kollect
+
+  icon:
+    - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgcm9sZT0iaW1nIiBhcmlhLWxhYmVsbGVkYnk9InRpdGxlIj4KICA8dGl0bGUgaWQ9InRpdGxlIj5Lb2xsZWN0PC90aXRsZT4KICA8cmVjdCB3aWR0aD0iNjQiIGhlaWdodD0iNjQiIHJ4PSIxMiIgZmlsbD0iIzA3MTQyNiIvPgogIDxnIGRhdGEtY29uY2VwdD0iY29sbGVjdG9yLWFwZXJ0dXJlIj4KICAgIDxwYXRoIGZpbGw9IiNlYWYwZmEiIGZpbGwtcnVsZT0iZXZlbm9kZCIgZD0iTTkgOGgxNHYxOEw0MyA4aDE1TDM2IDMybDIyIDI0SDQzTDIzIDM4djE4SDl6bTggMTYgMjEgOC0yMSA4eiIvPgogICAgPHBhdGggZmlsbD0iIzI1NjNlYiIgZD0iTTE5IDI2LjI1aDMuNXYzLjVIMTl6bTUuNzUgNGgzLjV2My41aC0zLjV6TTE5IDM0LjI1aDMuNXYzLjVIMTl6Ii8+CiAgICA8Y2lyY2xlIGN4PSIzOSIgY3k9IjMyIiByPSI0IiBmaWxsPSIjNWVlYWQ0Ii8+CiAgPC9nPgo8L3N2Zz4K
+      mediatype: image/svg+xml
+
+  # Kollect's controller watches cluster-wide: it never reads olm.targetNamespaces
+  # and sets no WATCH_NAMESPACE, so a namespace-scoped install would silently
+  # collect from the whole cluster. Advertise AllNamespaces only until that
+  # plumbing exists (ADR-0708 follow-up D9).
+  installModes:
+    - type: OwnNamespace
+      supported: false
+    - type: SingleNamespace
+      supported: false
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true
+
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+        - serviceAccountName: kollect-controller-manager
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - namespaces
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - authentication.k8s.io
+              resources:
+                - tokenreviews
+              verbs:
+                - create
+            - apiGroups:
+                - authorization.k8s.io
+              resources:
+                - selfsubjectaccessreviews
+                - subjectaccessreviews
+              verbs:
+                - create
+            - apiGroups:
+                - cert-manager.io
+              resources:
+                - certificates
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - kollect.dev
+              resources:
+                - kollectclusterinventories
+                - kollectclustertargets
+                - kollectconnectiontests
+                - kollectdatabasesinks
+                - kollecteventsinks
+                - kollectinventories
+                - kollectsnapshotsinks
+                - kollecttargets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - kollect.dev
+              resources:
+                - kollectclusterinventories/finalizers
+                - kollectclustertargets/finalizers
+                - kollectinventories/finalizers
+                - kollecttargets/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - kollect.dev
+              resources:
+                - kollectclusterinventories/status
+                - kollectclustertargets/status
+                - kollectconnectiontests/status
+                - kollectdatabasesinks/status
+                - kollecteventsinks/status
+                - kollectinventories/status
+                - kollectsnapshotsinks/status
+                - kollecttargets/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - kollect.dev
+              resources:
+                - kollectclusterscopes
+                - kollectprofiles
+                - kollectscopes
+              verbs:
+                - get
+                - list
+                - watch
+      permissions:
+        - serviceAccountName: kollect-controller-manager
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+      deployments:
+        - name: kollect-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+                app.kubernetes.io/name: kollect
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  control-plane: controller-manager
+                  app.kubernetes.io/name: kollect
+              spec:
+                serviceAccountName: kollect-controller-manager
+                terminationGracePeriodSeconds: 10
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                containers:
+                  - name: manager
+                    image: ghcr.io/platformrelay/kollect@sha256:cc63c330c6dcbc0c7de12a68c4aa74e81c8ac19a107178f0d3285946f16d6a75
+                    imagePullPolicy: IfNotPresent
+                    command:
+                      - /manager
+                    args:
+                      - --leader-elect
+                      - --health-probe-bind-address=:8081
+                      - --validating-webhooks-enabled=false
+                    ports:
+                      - containerPort: 8081
+                        name: health
+                        protocol: TCP
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 256Mi
+                      requests:
+                        cpu: 10m
+                        memory: 64Mi
+                    securityContext:
+                      readOnlyRootFilesystem: true
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                    volumeMounts:
+                      - name: tmp
+                        mountPath: /tmp
+                volumes:
+                  - name: tmp
+                    emptyDir: {}
+
+  customresourcedefinitions:
+    owned:
+      - name: kollectprofiles.kollect.dev
+        version: v1alpha1
+        kind: KollectProfile
+        displayName: Kollect Profile
+        description: Declares extraction schema and attributes for a target GVK.
+      - name: kollecttargets.kollect.dev
+        version: v1alpha1
+        kind: KollectTarget
+        displayName: Kollect Target
+        description: Selects Kubernetes resources and binds a profile for collection.
+      - name: kollectinventories.kollect.dev
+        version: v1alpha1
+        kind: KollectInventory
+        displayName: Kollect Inventory
+        description: Aggregates collected rows and schedules export to sinks.
+      - name: kollectsnapshotsinks.kollect.dev
+        version: v1alpha1
+        kind: KollectSnapshotSink
+        displayName: Kollect Snapshot Sink
+        description: State-store sink for Git, object storage, and similar backends.
+      - name: kollecteventsinks.kollect.dev
+        version: v1alpha1
+        kind: KollectEventSink
+        displayName: Kollect Event Sink
+        description: Event-stream sink for Kafka, NATS, and similar backends.
+      - name: kollectdatabasesinks.kollect.dev
+        version: v1alpha1
+        kind: KollectDatabaseSink
+        displayName: Kollect Database Sink
+        description: Database sink for Postgres, MongoDB, BigQuery, and similar backends.
+      - name: kollectconnectiontests.kollect.dev
+        version: v1alpha1
+        kind: KollectConnectionTest
+        displayName: Kollect Connection Test
+        description: Probes sink connectivity and records probe status.
+      - name: kollectscopes.kollect.dev
+        version: v1alpha1
+        kind: KollectScope
+        displayName: Kollect Scope
+        description: Namespaced governance boundary for targets, inventories, and sinks.
+      - name: kollectclustertargets.kollect.dev
+        version: v1alpha1
+        kind: KollectClusterTarget
+        displayName: Kollect Cluster Target
+        description: Cluster-scoped target for fleet inventory collection.
+      - name: kollectclusterinventories.kollect.dev
+        version: v1alpha1
+        kind: KollectClusterInventory
+        displayName: Kollect Cluster Inventory
+        description: Cluster-scoped inventory rollup for platform operators.
+      - name: kollectclusterscopes.kollect.dev
+        version: v1alpha1
+        kind: KollectClusterScope
+        displayName: Kollect Cluster Scope
+        description: Cluster-scoped governance boundary for fleet mode.
+
+  relatedImages:
+    - name: kollect
+      image: ghcr.io/platformrelay/kollect@sha256:cc63c330c6dcbc0c7de12a68c4aa74e81c8ac19a107178f0d3285946f16d6a75

--- a/operators/kollect/0.18.0/manifests/kollect.clusterserviceversion.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.clusterserviceversion.yaml
@@ -45,6 +45,229 @@ metadata:
             },
             "suspend": false
           }
+        },
+        {
+          "apiVersion": "kollect.dev/v1alpha1",
+          "kind": "KollectInventory",
+          "metadata": {
+            "name": "team-inventory",
+            "namespace": "default"
+          },
+          "spec": {
+            "exportMinInterval": "30s",
+            "snapshotSinkRefs": [
+              {
+                "name": "git-inventory",
+                "exportMinInterval": "1h"
+              }
+            ],
+            "databaseSinkRefs": [
+              {
+                "name": "postgres-inventory"
+              }
+            ],
+            "suspend": false
+          }
+        },
+        {
+          "apiVersion": "kollect.dev/v1alpha1",
+          "kind": "KollectSnapshotSink",
+          "metadata": {
+            "name": "git-inventory",
+            "namespace": "default"
+          },
+          "spec": {
+            "type": "git",
+            "endpoint": "https://github.com/platformrelay/kollect-inventory-demo.git",
+            "cluster": "prod-west",
+            "pathTemplate": "clusters/{cluster}/inventory/{namespace}/{name}.json",
+            "connectionTest": true,
+            "secretRef": {
+              "name": "git-push-credentials",
+              "namespace": "default"
+            },
+            "git": {
+              "branch": "main",
+              "pushPolicy": "Commit",
+              "auth": {
+                "type": "token"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "kollect.dev/v1alpha1",
+          "kind": "KollectEventSink",
+          "metadata": {
+            "name": "nats-inventory",
+            "namespace": "default"
+          },
+          "spec": {
+            "type": "nats",
+            "cluster": "prod-west",
+            "connectionTest": true,
+            "secretRef": {
+              "name": "nats-credentials",
+              "namespace": "default"
+            },
+            "nats": {
+              "url": "nats://nats.kollect-system.svc:4222",
+              "subject": "inventory.events",
+              "stream": "kollect_events"
+            }
+          }
+        },
+        {
+          "apiVersion": "kollect.dev/v1alpha1",
+          "kind": "KollectDatabaseSink",
+          "metadata": {
+            "name": "postgres-inventory",
+            "namespace": "default"
+          },
+          "spec": {
+            "type": "postgres",
+            "cluster": "prod-west",
+            "connectionTest": true,
+            "provisioning": {
+              "mode": "ensure"
+            },
+            "postgres": {
+              "databaseRef": {
+                "name": "inventory-postgres-dsn",
+                "namespace": "default"
+              },
+              "schema": "public",
+              "table": "inventory_items"
+            }
+          }
+        },
+        {
+          "apiVersion": "kollect.dev/v1alpha1",
+          "kind": "KollectConnectionTest",
+          "metadata": {
+            "name": "postgres-inventory-probe",
+            "namespace": "default"
+          },
+          "spec": {
+            "sinkRef": {
+              "databaseSinkRef": "postgres-inventory"
+            },
+            "ttlSecondsAfterFinished": 300
+          }
+        },
+        {
+          "apiVersion": "kollect.dev/v1alpha1",
+          "kind": "KollectScope",
+          "metadata": {
+            "name": "team-ceiling",
+            "namespace": "default"
+          },
+          "spec": {
+            "allowedGVKs": [
+              {
+                "group": "apps",
+                "version": "v1",
+                "kind": "Deployment"
+              },
+              {
+                "group": "",
+                "version": "v1",
+                "kind": "Service"
+              }
+            ],
+            "allowedNamespaces": [
+              "default"
+            ],
+            "snapshotSinkRefs": [
+              "git-inventory"
+            ],
+            "databaseSinkRefs": [
+              "postgres-inventory"
+            ],
+            "minExportInterval": "30s"
+          }
+        },
+        {
+          "apiVersion": "kollect.dev/v1alpha1",
+          "kind": "KollectClusterTarget",
+          "metadata": {
+            "name": "platform-deployments"
+          },
+          "spec": {
+            "profileRef": {
+              "name": "deployment-images",
+              "namespace": "default"
+            },
+            "namespaceSelector": {
+              "matchLabels": {
+                "kollect.dev/tenant": "platform"
+              }
+            },
+            "suspend": false
+          }
+        },
+        {
+          "apiVersion": "kollect.dev/v1alpha1",
+          "kind": "KollectClusterInventory",
+          "metadata": {
+            "name": "platform-rollup"
+          },
+          "spec": {
+            "targetRefs": [
+              "platform-deployments"
+            ],
+            "namespaceSelector": {
+              "matchLabels": {
+                "kollect.dev/tenant": "platform"
+              }
+            },
+            "sinkNamespace": "default",
+            "snapshotSinkRefs": [
+              {
+                "name": "git-inventory"
+              }
+            ],
+            "databaseSinkRefs": [
+              {
+                "name": "postgres-inventory"
+              }
+            ],
+            "suspend": false
+          }
+        },
+        {
+          "apiVersion": "kollect.dev/v1alpha1",
+          "kind": "KollectClusterScope",
+          "metadata": {
+            "name": "platform-ceiling"
+          },
+          "spec": {
+            "allowedGVKs": [
+              {
+                "group": "apps",
+                "version": "v1",
+                "kind": "Deployment"
+              },
+              {
+                "group": "",
+                "version": "v1",
+                "kind": "Service"
+              }
+            ],
+            "deniedNamespaces": [
+              "kube-system"
+            ],
+            "allowedStaticRefNamespaces": [
+              "default"
+            ],
+            "snapshotSinkRefs": [
+              "git-inventory"
+            ],
+            "databaseSinkRefs": [
+              "postgres-inventory"
+            ],
+            "minExportInterval": "30s"
+          }
         }
       ]
     categories: Monitoring,Integration & Delivery

--- a/operators/kollect/0.18.0/manifests/kollect.dev_kollectclusterinventories.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.dev_kollectclusterinventories.yaml
@@ -1,0 +1,516 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: kollectclusterinventories.kollect.dev
+spec:
+  group: kollect.dev
+  names:
+    kind: KollectClusterInventory
+    listKind: KollectClusterInventoryList
+    plural: kollectclusterinventories
+    shortNames:
+    - kcinv
+    singular: kollectclusterinventory
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KollectClusterInventory rolls up cluster targets for platform
+          operators.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of KollectClusterInventory
+            properties:
+              databaseSinkRefs:
+                description: |-
+                  databaseSinkRefs lists namespaced KollectDatabaseSink refs (ADR-0414, ADR-0208).
+                  Each ref resolves in its own namespace, or spec.sinkNamespace when omitted.
+                items:
+                  description: InventorySinkRef names a KollectSink with an optional
+                    per-ref export interval override.
+                  properties:
+                    exportMinInterval:
+                      description: |-
+                        exportMinInterval overrides the inventory default for this sink ref.
+                        Zero means material-change only (no periodic re-export of identical payload).
+                      type: string
+                    maxExportBytes:
+                      description: |-
+                        maxExportBytes overrides the inventory-wide export size ceiling for this sink
+                        ref (AR-01 / EC-P0-01). It may set a smaller or larger byte ceiling than
+                        spec.maxExportBytes; when omitted the inventory-wide ceiling (or the operator
+                        global cap) applies. The webhook rejects values above the operator global cap
+                        (ADR-0103). Payloads exceeding this ceiling are split into multiple export parts.
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the family sink object name.
+                      type: string
+                    namespace:
+                      description: |-
+                        namespace overrides where this sink resolves. Cluster inventory only:
+                        when omitted it inherits spec.sinkNamespace. Forbidden on namespaced inventories,
+                        which always resolve in the inventory's own namespace (ADR-0208).
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              dedupe:
+                default: keepAll
+                description: dedupe selects how overlapping target rows collapse on
+                  export (ADR-0305).
+                enum:
+                - keepAll
+                - byResourceUID
+                type: string
+              eventSinkRefs:
+                description: |-
+                  eventSinkRefs lists namespaced KollectEventSink refs (ADR-0414, ADR-0208).
+                  Each ref resolves in its own namespace, or spec.sinkNamespace when omitted.
+                items:
+                  description: InventorySinkRef names a KollectSink with an optional
+                    per-ref export interval override.
+                  properties:
+                    exportMinInterval:
+                      description: |-
+                        exportMinInterval overrides the inventory default for this sink ref.
+                        Zero means material-change only (no periodic re-export of identical payload).
+                      type: string
+                    maxExportBytes:
+                      description: |-
+                        maxExportBytes overrides the inventory-wide export size ceiling for this sink
+                        ref (AR-01 / EC-P0-01). It may set a smaller or larger byte ceiling than
+                        spec.maxExportBytes; when omitted the inventory-wide ceiling (or the operator
+                        global cap) applies. The webhook rejects values above the operator global cap
+                        (ADR-0103). Payloads exceeding this ceiling are split into multiple export parts.
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the family sink object name.
+                      type: string
+                    namespace:
+                      description: |-
+                        namespace overrides where this sink resolves. Cluster inventory only:
+                        when omitted it inherits spec.sinkNamespace. Forbidden on namespaced inventories,
+                        which always resolve in the inventory's own namespace (ADR-0208).
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              exportMinInterval:
+                default: 30s
+                description: |-
+                  exportMinInterval is the minimum time between identical exports for this inventory.
+                  It debounces identical payloads only: material changes (payload checksum or spec
+                  generation) always export immediately, regardless of the interval. Zero means
+                  material-change only (no periodic re-export of identical payloads).
+                type: string
+              namespaceSelector:
+                description: namespaceSelector restricts rollup to namespaces matching
+                  the selector.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              namespaces:
+                description: |-
+                  namespaces explicitly lists namespace names that may contribute to the rollup.
+                  When set with namespaceSelector, the effective rollup scope is their intersection.
+                items:
+                  maxLength: 63
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              profileRef:
+                description: |-
+                  profileRef optionally overrides the rollup extraction schema with a namespaced
+                  KollectProfile by name and namespace (ADR-0208). namespace is required when set.
+                properties:
+                  name:
+                    description: name is the referenced object's name.
+                    type: string
+                  namespace:
+                    description: |-
+                      namespace is the referenced object's namespace.
+                      Required on cluster-scoped kinds; optional where a default namespace applies.
+                    type: string
+                required:
+                - name
+                type: object
+              sinkNamespace:
+                default: kollect-system
+                description: sinkNamespace is the default namespace for family sink
+                  refs that omit a namespace.
+                type: string
+              snapshotSinkRefs:
+                description: |-
+                  snapshotSinkRefs lists namespaced KollectSnapshotSink refs (ADR-0414, ADR-0208).
+                  Each ref resolves in its own namespace, or spec.sinkNamespace when omitted.
+                items:
+                  description: InventorySinkRef names a KollectSink with an optional
+                    per-ref export interval override.
+                  properties:
+                    exportMinInterval:
+                      description: |-
+                        exportMinInterval overrides the inventory default for this sink ref.
+                        Zero means material-change only (no periodic re-export of identical payload).
+                      type: string
+                    maxExportBytes:
+                      description: |-
+                        maxExportBytes overrides the inventory-wide export size ceiling for this sink
+                        ref (AR-01 / EC-P0-01). It may set a smaller or larger byte ceiling than
+                        spec.maxExportBytes; when omitted the inventory-wide ceiling (or the operator
+                        global cap) applies. The webhook rejects values above the operator global cap
+                        (ADR-0103). Payloads exceeding this ceiling are split into multiple export parts.
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the family sink object name.
+                      type: string
+                    namespace:
+                      description: |-
+                        namespace overrides where this sink resolves. Cluster inventory only:
+                        when omitted it inherits spec.sinkNamespace. Forbidden on namespaced inventories,
+                        which always resolve in the inventory's own namespace (ADR-0208).
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              suspend:
+                description: suspend pauses reconciliation when set to true.
+                type: boolean
+              targetRefs:
+                description: |-
+                  targetRefs lists KollectClusterTarget names to aggregate.
+                  When empty, all cluster targets matching targetSelector are included; when targetSelector is
+                  also empty, all KollectClusterTarget objects contribute.
+                items:
+                  type: string
+                type: array
+              targetSelector:
+                description: targetSelector narrows which KollectClusterTarget objects
+                  contribute when targetRefs is empty.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+            type: object
+          status:
+            description: status defines the observed state of KollectClusterInventory
+            properties:
+              conditions:
+                description: conditions represent the current state of the KollectClusterInventory
+                  resource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              itemCount:
+                description: itemCount is the number of inventory rows in the last
+                  rollup.
+                type: integer
+              lastExportTime:
+                description: lastExportTime is the timestamp of the last successful
+                  export across all sinks.
+                format: date-time
+                type: string
+              namespaceShardCount:
+                description: namespaceShardCount is the number of namespace shards
+                  composed into the last rollup.
+                type: integer
+              namespaceShards:
+                description: namespaceShards holds per-namespace shard metadata used
+                  to compose the rollup.
+                items:
+                  description: InventoryNamespaceShardStatus tracks one namespace
+                    shard contributing to a rollup.
+                  properties:
+                    checksum:
+                      description: checksum is the canonical checksum of shard rows.
+                      type: string
+                    itemCount:
+                      description: itemCount is the number of rows in this namespace
+                        shard after dedupe.
+                      type: integer
+                    namespace:
+                      description: namespace is the namespace name represented by
+                        this shard.
+                      type: string
+                    targetCount:
+                      description: targetCount is the number of targets that contributed
+                        rows to this shard.
+                      type: integer
+                  required:
+                  - namespace
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - namespace
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  by a controller.
+                format: int64
+                type: integer
+              sinkExports:
+                description: sinkExports holds per-sink export timestamps and conditions.
+                items:
+                  description: InventorySinkExportStatus holds per-sink export observation
+                    on an inventory.
+                  properties:
+                    conditions:
+                      description: conditions report per-sink Synced / debounce state.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    lastChecksum:
+                      description: lastChecksum is the payload fingerprint from the
+                        last successful export.
+                      type: string
+                    lastExportTime:
+                      description: lastExportTime is when this sink last accepted
+                        an export successfully.
+                      format: date-time
+                      type: string
+                    name:
+                      description: name matches spec.sinkRefs[].name (keyed by family/name).
+                      type: string
+                    namespace:
+                      description: namespace is the resolved namespace the sink was
+                        exported to (ADR-0208).
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 20
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              targetCount:
+                description: targetCount is the number of KollectClusterTarget objects
+                  included in the last rollup.
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/kollect/0.18.0/manifests/kollect.dev_kollectclusterscopes.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.dev_kollectclusterscopes.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: kollectclusterscopes.kollect.dev
+spec:
+  group: kollect.dev
+  names:
+    kind: KollectClusterScope
+    listKind: KollectClusterScopeList
+    plural: kollectclusterscopes
+    shortNames:
+    - kcscope
+    singular: kollectclusterscope
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KollectClusterScope is a cluster governance boundary for cluster targets and inventories.
+          Static config only — no controller or status subresource (ADR-0202).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KollectClusterScopeSpec defines a cluster-scoped tenancy
+              ceiling (ADR-0207).
+            properties:
+              allowedGVKs:
+                description: allowedGVKs restricts which target resource kinds may
+                  be collected in this scope.
+                items:
+                  description: GroupVersionKind identifies the API group, version,
+                    and kind of a target resource.
+                  properties:
+                    group:
+                      description: group is the API group of the target resource (empty
+                        for the core group).
+                      type: string
+                    kind:
+                      description: kind is the API kind of the target resource.
+                      type: string
+                    version:
+                      description: version is the API version of the target resource.
+                      type: string
+                  required:
+                  - kind
+                  - version
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              allowedNamespaces:
+                description: |-
+                  allowedNamespaces restricts which workload namespaces may be collected.
+                  Empty means any namespace allowed by targets in the scope namespace.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              allowedStaticRefNamespaces:
+                description: |-
+                  allowedStaticRefNamespaces restricts namespaces cluster kinds may reference for
+                  profiles and family sinks (ADR-0208). Empty means any namespace is permitted.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              databaseSinkRefs:
+                description: databaseSinkRefs lists permitted KollectDatabaseSink
+                  names for this scope.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              deniedNamespaces:
+                description: deniedNamespaces is a platform blacklist; Target intent
+                  cannot override (D8).
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              eventSinkRefs:
+                description: eventSinkRefs lists permitted KollectEventSink names
+                  for this scope.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              minExportInterval:
+                description: minExportInterval is a tenancy floor — inventory and
+                  sink intervals below this value are rejected.
+                type: string
+              snapshotSinkRefs:
+                description: snapshotSinkRefs lists permitted KollectSnapshotSink
+                  names for this scope.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/operators/kollect/0.18.0/manifests/kollect.dev_kollectclustertargets.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.dev_kollectclustertargets.yaml
@@ -1,0 +1,394 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: kollectclustertargets.kollect.dev
+spec:
+  group: kollect.dev
+  names:
+    kind: KollectClusterTarget
+    listKind: KollectClusterTargetList
+    plural: kollectclustertargets
+    shortNames:
+    - kctgt
+    singular: kollectclustertarget
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KollectClusterTarget selects resources cluster-wide for platform
+          operators.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of KollectClusterTarget
+            properties:
+              excludedNamespaces:
+                description: excludedNamespaces is a static namespace denylist applied
+                  after include logic.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              includedNamespaces:
+                description: |-
+                  includedNamespaces is a static namespace allowlist. Empty means no extra restriction
+                  beyond namespaceSelector.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              namespaceExcludeSelector:
+                description: namespaceExcludeSelector excludes namespaces whose labels
+                  match the selector.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              namespaceSelector:
+                description: namespaceSelector restricts collection to namespaces
+                  matching the selector.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              profileRef:
+                description: |-
+                  profileRef points at a namespaced KollectProfile by name and namespace (ADR-0208).
+                  namespace is required at admission — there is no implicit platform-namespace fallback.
+                properties:
+                  name:
+                    description: name is the referenced object's name.
+                    type: string
+                  namespace:
+                    description: |-
+                      namespace is the referenced object's namespace.
+                      Required on cluster-scoped kinds; optional where a default namespace applies.
+                    type: string
+                required:
+                - name
+                type: object
+              resourceRules:
+                description: |-
+                  resourceRules declares GVK-scoped collection rules. When empty, collection falls back to
+                  Profile targetGVK plus legacy labelSelector/names on the Target.
+                items:
+                  description: |-
+                    ResourceRule selects objects of a GVK within optional namespace and resource label constraints.
+                    Multiple rules are OR-unioned (D7). Optional matchPolicy is a CEL expression evaluated pre-store.
+                  properties:
+                    gvk:
+                      description: gvk is the API group, version, and kind this rule
+                        applies to.
+                      properties:
+                        group:
+                          description: group is the API group of the target resource
+                            (empty for the core group).
+                          type: string
+                        kind:
+                          description: kind is the API kind of the target resource.
+                          type: string
+                        version:
+                          description: version is the API version of the target resource.
+                          type: string
+                      required:
+                      - kind
+                      - version
+                      type: object
+                    matchExpressions:
+                      description: matchExpressions requires resource metadata labels
+                        to match.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels requires resource metadata labels to
+                        match (AND with matchExpressions).
+                      type: object
+                    matchPolicy:
+                      description: |-
+                        matchPolicy is an optional CEL expression with `object` bound to the resource.
+                        Evaluated after label/GVK/namespace gates, before store insert (ADR-0207 Phase 3).
+                      type: string
+                    namespaceSelector:
+                      description: namespaceSelector further restricts this rule to
+                        namespaces matching the selector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - gvk
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              suspend:
+                description: suspend pauses reconciliation when set to true (reserved
+                  for future controller).
+                type: boolean
+            required:
+            - profileRef
+            type: object
+          status:
+            description: status defines the observed state of KollectClusterTarget
+            properties:
+              activeResourceRules:
+                description: activeResourceRules is the number of compiled resourceRules
+                  entries (0 when using legacy fallback).
+                type: integer
+              conditions:
+                description: conditions represent the current state of the KollectClusterTarget
+                  resource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              effectiveNamespaces:
+                description: |-
+                  effectiveNamespaces lists namespaces after intersecting Scope allowedNamespaces and subtracting
+                  Target/Scope deny lists.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              matchedNamespaces:
+                description: matchedNamespaces lists workload namespaces matched by
+                  Target intent (before Scope ceiling).
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  by a controller.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/kollect/0.18.0/manifests/kollect.dev_kollectconnectiontests.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.dev_kollectconnectiontests.yaml
@@ -1,0 +1,177 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: kollectconnectiontests.kollect.dev
+spec:
+  group: kollect.dev
+  names:
+    kind: KollectConnectionTest
+    listKind: KollectConnectionTestList
+    plural: kollectconnectiontests
+    shortNames:
+    - kconntest
+    singular: kollectconnectiontest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.sinkRef
+      name: Sink
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ConnectionVerified")].status
+      name: Verified
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KollectConnectionTest triggers an audited one-shot sink connectivity
+          probe.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KollectConnectionTestSpec defines a one-shot connectivity
+              probe (ADR-0703).
+            properties:
+              ownerSink:
+                description: ownerSink sets an ownerReference to the sink when true
+                  (default).
+                type: boolean
+              profileRef:
+                description: profileRef optionally names a KollectProfile for future
+                  composite probes.
+                type: string
+              sinkRef:
+                description: sinkRef identifies exactly one family sink to probe (ADR-0414).
+                properties:
+                  databaseSinkRef:
+                    description: databaseSinkRef names a KollectDatabaseSink in the
+                      test's namespace.
+                    type: string
+                  eventSinkRef:
+                    description: eventSinkRef names a KollectEventSink in the test's
+                      namespace.
+                    type: string
+                  snapshotSinkRef:
+                    description: snapshotSinkRef names a KollectSnapshotSink in the
+                      test's namespace.
+                    type: string
+                type: object
+              ttlSecondsAfterFinished:
+                default: 300
+                description: ttlSecondsAfterFinished deletes the CR after status.completed
+                  plus this TTL.
+                format: int32
+                minimum: 0
+                type: integer
+            required:
+            - sinkRef
+            type: object
+          status:
+            description: KollectConnectionTestStatus reports probe outcome.
+            properties:
+              completed:
+                description: completed is true after the probe has finished (success
+                  or failure).
+                type: boolean
+              completedAt:
+                description: completedAt is set when completed becomes true (used
+                  for TTL cleanup).
+                format: date-time
+                type: string
+              conditions:
+                description: conditions represent the current state of the connection
+                  test.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              latencyMs:
+                description: latencyMs is the duration of the last probe in milliseconds.
+                format: int64
+                type: integer
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/kollect/0.18.0/manifests/kollect.dev_kollectdatabasesinks.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.dev_kollectdatabasesinks.yaml
@@ -1,0 +1,502 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: kollectdatabasesinks.kollect.dev
+spec:
+  group: kollect.dev
+  names:
+    kind: KollectDatabaseSink
+    listKind: KollectDatabaseSinkList
+    plural: kollectdatabasesinks
+    shortNames:
+    - kdb
+    singular: kollectdatabasesink
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KollectDatabaseSink is the Schema for relational export sinks.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KollectDatabaseSinkSpec defines a relational database export
+              sink (ADR-0414).
+            properties:
+              bigquery:
+                description: bigquery configures BigQuery relational export (ADR-0420).
+                properties:
+                  dataset:
+                    description: dataset is the BigQuery dataset id; it must already
+                      exist.
+                    type: string
+                  location:
+                    description: location pins job placement (for example EU); defaults
+                      to the dataset location.
+                    type: string
+                  project:
+                    description: project is the GCP project id that owns the dataset.
+                    type: string
+                  secretRef:
+                    description: |-
+                      secretRef references a Secret holding a service-account JSON key
+                      (key credentials.json). When absent, Application Default Credentials are used.
+                    properties:
+                      name:
+                        description: name is the name of the referenced Secret.
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referenced
+                          Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  table:
+                    description: table is the destination table name.
+                    type: string
+                required:
+                - dataset
+                - project
+                - table
+                type: object
+              cluster:
+                description: cluster labels exported inventory in multi-cluster installs.
+                type: string
+              connectionTest:
+                description: connectionTest enables connectivity checks on create/update
+                  (default true).
+                type: boolean
+              endpoint:
+                description: endpoint is the backend-specific destination (URL, bucket,
+                  and so on).
+                type: string
+              exportMinInterval:
+                description: |-
+                  exportMinInterval is the default minimum time between identical exports when an inventory
+                  ref omits a per-ref override.
+                type: string
+              layout:
+                description: |-
+                  layout configures document shape and folder layout for snapshot Git/GitLab sinks (ADR-0419).
+                  The entire block is optional; omitting it yields a single readable inventory document.
+                properties:
+                  content:
+                    default: item
+                    description: |-
+                      content selects the per-file payload: item (full Item row, default),
+                      attributes (Item.attributes only), or manifest (native object, ADR-0306 Resource export).
+                    enum:
+                    - item
+                    - attributes
+                    - manifest
+                    type: string
+                  filename:
+                    description: filename tunes path-segment sanitization and grouping.
+                    properties:
+                      groupInPath:
+                        description: |-
+                          groupInPath controls the {group} segment: auto (omit for core types, default),
+                          always, or never.
+                        enum:
+                        - auto
+                        - always
+                        - never
+                        type: string
+                      lowercaseKind:
+                        description: lowercaseKind lowercases {kind} in paths (default
+                          true).
+                        type: boolean
+                      maxSegmentLength:
+                        description: maxSegmentLength caps each path segment for DNS
+                          safety (default 63).
+                        format: int32
+                        minimum: 1
+                        type: integer
+                    type: object
+                  index:
+                    description: index configures the split-mode index sidecar.
+                    properties:
+                      enabled:
+                        description: enabled toggles the index sidecar (default false;
+                          true in split mode).
+                        type: boolean
+                      pathTemplate:
+                        description: pathTemplate is the index file path (default
+                          inventory/{namespace}/{name}{extension}).
+                        type: string
+                    type: object
+                  mode:
+                    default: document
+                    description: |-
+                      mode selects the on-disk layout: document (one inventory file, default),
+                      perResource (one file per Item), or split (index sidecar + per-resource tree).
+                    enum:
+                    - document
+                    - perResource
+                    - split
+                    type: string
+                  pathTemplate:
+                    description: |-
+                      pathTemplate is the per-item path used when mode is perResource or split.
+                      Placeholders: {cluster}, {namespace}, {name}, {targetNamespace}, {targetName},
+                      {sourceNamespace}, {sourceName}, {group}, {kind}, {uid}, {generation}, {extension}.
+                      Default: {cluster}/{sourceNamespace}/{kind}/{sourceName}{extension}
+                    type: string
+                type: object
+              mongodb:
+                description: mongodb configures MongoDB document upsert export (ADR-0417).
+                properties:
+                  collection:
+                    description: collection is the destination collection name.
+                    type: string
+                  database:
+                    description: database is the destination MongoDB database name.
+                    type: string
+                  databaseRef:
+                    description: |-
+                      databaseRef references a Secret containing the connection URI
+                      (key uri, url, connectionString, or MONGODB_URI).
+                    properties:
+                      name:
+                        description: name is the name of the referenced Secret.
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referenced
+                          Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - collection
+                - database
+                - databaseRef
+                type: object
+              options:
+                additionalProperties:
+                  type: string
+                description: |-
+                  options carries non-secret, backend-specific pass-through settings (ADR-0416 §4, Option 2).
+                  Secret-like keys are rejected by the webhook; supply credentials via secretRef only.
+                type: object
+              pathTemplate:
+                description: pathTemplate selects the Git/object-store export path
+                  layout (ADR-0407).
+                type: string
+              postgres:
+                description: postgres configures PostgreSQL upsert export.
+                properties:
+                  databaseRef:
+                    description: databaseRef references a Secret containing the connection
+                      string (key dsn or url).
+                    properties:
+                      name:
+                        description: name is the name of the referenced Secret.
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referenced
+                          Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  schema:
+                    description: schema is the PostgreSQL schema (default public).
+                    type: string
+                  table:
+                    description: table is the destination table name.
+                    type: string
+                required:
+                - databaseRef
+                - table
+                type: object
+              provisioning:
+                description: |-
+                  provisioning configures destination resource ownership (ADR-0416 §5).
+                  mode ensure (default) creates resources if missing; existing never creates and preflights existence.
+                properties:
+                  mode:
+                    description: mode selects ensure (create-if-missing, default)
+                      or existing (never create; preflight verifies).
+                    enum:
+                    - ensure
+                    - existing
+                    type: string
+                  naming:
+                    description: naming optionally templates the destination resource
+                      name using the shared placeholder grammar.
+                    properties:
+                      template:
+                        description: |-
+                          template is the destination name template; placeholders match pathTemplate
+                          ({cluster}, {namespace}, {name}, {generation}).
+                        type: string
+                    type: object
+                type: object
+              secretRef:
+                description: secretRef references a Secret holding credentials for
+                  the sink.
+                properties:
+                  name:
+                    description: name is the name of the referenced Secret.
+                    type: string
+                  namespace:
+                    description: namespace is the namespace of the referenced Secret.
+                    type: string
+                required:
+                - name
+                type: object
+              serialization:
+                description: |-
+                  serialization configures the cross-cutting on-wire format and schema contract (ADR-0416 §4).
+                  json is the zero-config default; the backend capability matrix gates which formats are honored.
+                properties:
+                  compression:
+                    description: compression selects payload compression where the
+                      backend supports it (default none).
+                    enum:
+                    - none
+                    - gzip
+                    - snappy
+                    - zstd
+                    type: string
+                  format:
+                    description: format selects the on-wire serialization (default
+                      json; yaml default for git/gitlab).
+                    enum:
+                    - json
+                    - yaml
+                    - parquet
+                    - csv
+                    - ndjson
+                    type: string
+                type: object
+              tls:
+                description: tls configures TLS verification for HTTPS git and similar
+                  endpoints.
+                properties:
+                  caBundle:
+                    description: |-
+                      caBundle is an inline PEM-encoded CA certificate bundle.
+                      Prefer caSecretRef for production; do not set both caBundle and caSecretRef.
+                    format: byte
+                    type: string
+                  caSecretRef:
+                    description: caSecretRef references a Secret containing a PEM
+                      CA bundle (key tls.crt or ca.crt).
+                    properties:
+                      name:
+                        description: name is the name of the referenced Secret.
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referenced
+                          Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  insecureSkipVerify:
+                    description: insecureSkipVerify disables server certificate verification
+                      (not recommended).
+                    type: boolean
+                type: object
+              type:
+                description: type selects the database backend implementation.
+                enum:
+                - postgres
+                - bigquery
+                - mongodb
+                type: string
+            required:
+            - type
+            type: object
+          status:
+            description: FamilySinkStatus is the shared status shape for family sink
+              CRDs.
+            properties:
+              conditions:
+                description: conditions represent the current state of the sink resource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              preview:
+                description: |-
+                  preview is a read-only, side-effect-free preview of export implications, populated when the
+                  kollect.dev/preview annotation is set (ADR-0416 §8).
+                properties:
+                  git:
+                    description: git previews the commit subject/body for git and
+                      gitlab snapshot sinks.
+                    properties:
+                      sampleCommitBody:
+                        description: sampleCommitBody is the rendered commit body.
+                        type: string
+                      sampleCommitSubject:
+                        description: sampleCommitSubject is the rendered commit subject
+                          line.
+                        type: string
+                    type: object
+                  inputSampleSource:
+                    description: inputSampleSource names the sample input used to
+                      render the preview (e.g. synthetic).
+                    type: string
+                  kafka:
+                    description: kafka previews the destination topic for kafka sinks.
+                    properties:
+                      topic:
+                        description: topic is the destination topic events would be
+                          published to.
+                        type: string
+                    type: object
+                  layout:
+                    description: layout previews the resolved export layout for git
+                      and gitlab snapshot sinks (ADR-0419).
+                    properties:
+                      content:
+                        description: content is the resolved per-file content shape
+                          (item, attributes, or manifest).
+                        type: string
+                      mode:
+                        description: mode is the resolved layout mode (document, perResource,
+                          or split).
+                        type: string
+                      prune:
+                        description: prune reports whether stale files are removed
+                          on export (auto for perResource/split).
+                        type: boolean
+                      samplePaths:
+                        description: samplePaths lists example repo paths the layout
+                          would write for the synthetic sample.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  mongodb:
+                    description: mongodb previews the expected identity index for
+                      mongodb sinks.
+                    properties:
+                      expectedIndexKeys:
+                        description: expectedIndexKeys lists the fields of the unique
+                          identity index.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  objectPath:
+                    description: objectPath is the rendered destination path/object
+                      key for snapshot sinks.
+                    type: string
+                  postgres:
+                    description: postgres previews the expected CREATE TABLE DDL for
+                      postgres sinks.
+                    properties:
+                      expectedDDL:
+                        description: expectedDDL is the CREATE TABLE statement used
+                          in provisioning.mode=ensure.
+                        type: string
+                    type: object
+                  provisioningMode:
+                    description: provisioningMode is the effective provisioning mode
+                      (ensure or existing).
+                    type: string
+                  renderedAt:
+                    description: renderedAt is the time the preview was last computed.
+                    format: date-time
+                    type: string
+                  serializationFormat:
+                    description: serializationFormat is the effective on-wire format
+                      (json, parquet, ...).
+                    type: string
+                  warnings:
+                    description: warnings lists non-blocking implications surfaced
+                      by the preview.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/kollect/0.18.0/manifests/kollect.dev_kollecteventsinks.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.dev_kollecteventsinks.yaml
@@ -1,0 +1,470 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: kollecteventsinks.kollect.dev
+spec:
+  group: kollect.dev
+  names:
+    kind: KollectEventSink
+    listKind: KollectEventSinkList
+    plural: kollecteventsinks
+    shortNames:
+    - kevt
+    singular: kollecteventsink
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KollectEventSink is the Schema for event export sinks.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KollectEventSinkSpec defines an event-stream export sink
+              (ADR-0414).
+            properties:
+              cluster:
+                description: cluster labels exported inventory in multi-cluster installs.
+                type: string
+              connectionTest:
+                description: connectionTest enables connectivity checks on create/update
+                  (default true).
+                type: boolean
+              endpoint:
+                description: endpoint is the backend-specific destination (URL, bucket,
+                  and so on).
+                type: string
+              exportMinInterval:
+                description: |-
+                  exportMinInterval is the default minimum time between identical exports when an inventory
+                  ref omits a per-ref override.
+                type: string
+              kafka:
+                description: kafka configures Kafka inventory change events.
+                properties:
+                  brokers:
+                    description: brokers lists Kafka bootstrap addresses (host:port).
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  secretRef:
+                    description: secretRef references a Secret with optional SASL/TLS
+                      credentials.
+                    properties:
+                      name:
+                        description: name is the name of the referenced Secret.
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referenced
+                          Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  topic:
+                    description: topic is the destination topic for inventory events.
+                    type: string
+                required:
+                - brokers
+                - topic
+                type: object
+              layout:
+                description: |-
+                  layout configures document shape and folder layout for snapshot Git/GitLab sinks (ADR-0419).
+                  The entire block is optional; omitting it yields a single readable inventory document.
+                properties:
+                  content:
+                    default: item
+                    description: |-
+                      content selects the per-file payload: item (full Item row, default),
+                      attributes (Item.attributes only), or manifest (native object, ADR-0306 Resource export).
+                    enum:
+                    - item
+                    - attributes
+                    - manifest
+                    type: string
+                  filename:
+                    description: filename tunes path-segment sanitization and grouping.
+                    properties:
+                      groupInPath:
+                        description: |-
+                          groupInPath controls the {group} segment: auto (omit for core types, default),
+                          always, or never.
+                        enum:
+                        - auto
+                        - always
+                        - never
+                        type: string
+                      lowercaseKind:
+                        description: lowercaseKind lowercases {kind} in paths (default
+                          true).
+                        type: boolean
+                      maxSegmentLength:
+                        description: maxSegmentLength caps each path segment for DNS
+                          safety (default 63).
+                        format: int32
+                        minimum: 1
+                        type: integer
+                    type: object
+                  index:
+                    description: index configures the split-mode index sidecar.
+                    properties:
+                      enabled:
+                        description: enabled toggles the index sidecar (default false;
+                          true in split mode).
+                        type: boolean
+                      pathTemplate:
+                        description: pathTemplate is the index file path (default
+                          inventory/{namespace}/{name}{extension}).
+                        type: string
+                    type: object
+                  mode:
+                    default: document
+                    description: |-
+                      mode selects the on-disk layout: document (one inventory file, default),
+                      perResource (one file per Item), or split (index sidecar + per-resource tree).
+                    enum:
+                    - document
+                    - perResource
+                    - split
+                    type: string
+                  pathTemplate:
+                    description: |-
+                      pathTemplate is the per-item path used when mode is perResource or split.
+                      Placeholders: {cluster}, {namespace}, {name}, {targetNamespace}, {targetName},
+                      {sourceNamespace}, {sourceName}, {group}, {kind}, {uid}, {generation}, {extension}.
+                      Default: {cluster}/{sourceNamespace}/{kind}/{sourceName}{extension}
+                    type: string
+                type: object
+              nats:
+                description: nats configures NATS JetStream inventory change events.
+                properties:
+                  secretRef:
+                    description: secretRef references a Secret with optional auth
+                      credentials (token, username/password).
+                    properties:
+                      name:
+                        description: name is the name of the referenced Secret.
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referenced
+                          Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  stream:
+                    description: stream is the JetStream stream name (default kollect_events).
+                    type: string
+                  subject:
+                    description: subject is the JetStream publish subject for inventory
+                      events.
+                    type: string
+                  url:
+                    description: |-
+                      url is the NATS server connection URL (nats://host:4222).
+                      When empty, spec.endpoint is used.
+                    type: string
+                required:
+                - subject
+                type: object
+              options:
+                additionalProperties:
+                  type: string
+                description: |-
+                  options carries non-secret, backend-specific pass-through settings (ADR-0416 §4, Option 2).
+                  Secret-like keys are rejected by the webhook; supply credentials via secretRef only.
+                type: object
+              pathTemplate:
+                description: pathTemplate selects the Git/object-store export path
+                  layout (ADR-0407).
+                type: string
+              provisioning:
+                description: |-
+                  provisioning configures destination resource ownership (ADR-0416 §5).
+                  mode ensure (default) creates resources if missing; existing never creates and preflights existence.
+                properties:
+                  mode:
+                    description: mode selects ensure (create-if-missing, default)
+                      or existing (never create; preflight verifies).
+                    enum:
+                    - ensure
+                    - existing
+                    type: string
+                  naming:
+                    description: naming optionally templates the destination resource
+                      name using the shared placeholder grammar.
+                    properties:
+                      template:
+                        description: |-
+                          template is the destination name template; placeholders match pathTemplate
+                          ({cluster}, {namespace}, {name}, {generation}).
+                        type: string
+                    type: object
+                type: object
+              secretRef:
+                description: secretRef references a Secret holding credentials for
+                  the sink.
+                properties:
+                  name:
+                    description: name is the name of the referenced Secret.
+                    type: string
+                  namespace:
+                    description: namespace is the namespace of the referenced Secret.
+                    type: string
+                required:
+                - name
+                type: object
+              serialization:
+                description: |-
+                  serialization configures the cross-cutting on-wire format and schema contract (ADR-0416 §4).
+                  json is the zero-config default; the backend capability matrix gates which formats are honored.
+                properties:
+                  compression:
+                    description: compression selects payload compression where the
+                      backend supports it (default none).
+                    enum:
+                    - none
+                    - gzip
+                    - snappy
+                    - zstd
+                    type: string
+                  format:
+                    description: format selects the on-wire serialization (default
+                      json; yaml default for git/gitlab).
+                    enum:
+                    - json
+                    - yaml
+                    - parquet
+                    - csv
+                    - ndjson
+                    type: string
+                type: object
+              tls:
+                description: tls configures TLS verification for HTTPS git and similar
+                  endpoints.
+                properties:
+                  caBundle:
+                    description: |-
+                      caBundle is an inline PEM-encoded CA certificate bundle.
+                      Prefer caSecretRef for production; do not set both caBundle and caSecretRef.
+                    format: byte
+                    type: string
+                  caSecretRef:
+                    description: caSecretRef references a Secret containing a PEM
+                      CA bundle (key tls.crt or ca.crt).
+                    properties:
+                      name:
+                        description: name is the name of the referenced Secret.
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referenced
+                          Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  insecureSkipVerify:
+                    description: insecureSkipVerify disables server certificate verification
+                      (not recommended).
+                    type: boolean
+                type: object
+              type:
+                description: type selects the event backend implementation.
+                enum:
+                - nats
+                - kafka
+                type: string
+            required:
+            - type
+            type: object
+          status:
+            description: FamilySinkStatus is the shared status shape for family sink
+              CRDs.
+            properties:
+              conditions:
+                description: conditions represent the current state of the sink resource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              preview:
+                description: |-
+                  preview is a read-only, side-effect-free preview of export implications, populated when the
+                  kollect.dev/preview annotation is set (ADR-0416 §8).
+                properties:
+                  git:
+                    description: git previews the commit subject/body for git and
+                      gitlab snapshot sinks.
+                    properties:
+                      sampleCommitBody:
+                        description: sampleCommitBody is the rendered commit body.
+                        type: string
+                      sampleCommitSubject:
+                        description: sampleCommitSubject is the rendered commit subject
+                          line.
+                        type: string
+                    type: object
+                  inputSampleSource:
+                    description: inputSampleSource names the sample input used to
+                      render the preview (e.g. synthetic).
+                    type: string
+                  kafka:
+                    description: kafka previews the destination topic for kafka sinks.
+                    properties:
+                      topic:
+                        description: topic is the destination topic events would be
+                          published to.
+                        type: string
+                    type: object
+                  layout:
+                    description: layout previews the resolved export layout for git
+                      and gitlab snapshot sinks (ADR-0419).
+                    properties:
+                      content:
+                        description: content is the resolved per-file content shape
+                          (item, attributes, or manifest).
+                        type: string
+                      mode:
+                        description: mode is the resolved layout mode (document, perResource,
+                          or split).
+                        type: string
+                      prune:
+                        description: prune reports whether stale files are removed
+                          on export (auto for perResource/split).
+                        type: boolean
+                      samplePaths:
+                        description: samplePaths lists example repo paths the layout
+                          would write for the synthetic sample.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  mongodb:
+                    description: mongodb previews the expected identity index for
+                      mongodb sinks.
+                    properties:
+                      expectedIndexKeys:
+                        description: expectedIndexKeys lists the fields of the unique
+                          identity index.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  objectPath:
+                    description: objectPath is the rendered destination path/object
+                      key for snapshot sinks.
+                    type: string
+                  postgres:
+                    description: postgres previews the expected CREATE TABLE DDL for
+                      postgres sinks.
+                    properties:
+                      expectedDDL:
+                        description: expectedDDL is the CREATE TABLE statement used
+                          in provisioning.mode=ensure.
+                        type: string
+                    type: object
+                  provisioningMode:
+                    description: provisioningMode is the effective provisioning mode
+                      (ensure or existing).
+                    type: string
+                  renderedAt:
+                    description: renderedAt is the time the preview was last computed.
+                    format: date-time
+                    type: string
+                  serializationFormat:
+                    description: serializationFormat is the effective on-wire format
+                      (json, parquet, ...).
+                    type: string
+                  warnings:
+                    description: warnings lists non-blocking implications surfaced
+                      by the preview.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/kollect/0.18.0/manifests/kollect.dev_kollectinventories.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.dev_kollectinventories.yaml
@@ -1,0 +1,365 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: kollectinventories.kollect.dev
+spec:
+  group: kollect.dev
+  names:
+    kind: KollectInventory
+    listKind: KollectInventoryList
+    plural: kollectinventories
+    shortNames:
+    - kinv
+    singular: kollectinventory
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KollectInventory is the Schema for the kollectinventories API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of KollectInventory
+            properties:
+              databaseSinkRefs:
+                description: databaseSinkRefs lists KollectDatabaseSink names in this
+                  namespace (ADR-0414).
+                items:
+                  description: InventorySinkRef names a KollectSink with an optional
+                    per-ref export interval override.
+                  properties:
+                    exportMinInterval:
+                      description: |-
+                        exportMinInterval overrides the inventory default for this sink ref.
+                        Zero means material-change only (no periodic re-export of identical payload).
+                      type: string
+                    maxExportBytes:
+                      description: |-
+                        maxExportBytes overrides the inventory-wide export size ceiling for this sink
+                        ref (AR-01 / EC-P0-01). It may set a smaller or larger byte ceiling than
+                        spec.maxExportBytes; when omitted the inventory-wide ceiling (or the operator
+                        global cap) applies. The webhook rejects values above the operator global cap
+                        (ADR-0103). Payloads exceeding this ceiling are split into multiple export parts.
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the family sink object name.
+                      type: string
+                    namespace:
+                      description: |-
+                        namespace overrides where this sink resolves. Cluster inventory only:
+                        when omitted it inherits spec.sinkNamespace. Forbidden on namespaced inventories,
+                        which always resolve in the inventory's own namespace (ADR-0208).
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              eventSinkRefs:
+                description: eventSinkRefs lists KollectEventSink names in this namespace
+                  (ADR-0414).
+                items:
+                  description: InventorySinkRef names a KollectSink with an optional
+                    per-ref export interval override.
+                  properties:
+                    exportMinInterval:
+                      description: |-
+                        exportMinInterval overrides the inventory default for this sink ref.
+                        Zero means material-change only (no periodic re-export of identical payload).
+                      type: string
+                    maxExportBytes:
+                      description: |-
+                        maxExportBytes overrides the inventory-wide export size ceiling for this sink
+                        ref (AR-01 / EC-P0-01). It may set a smaller or larger byte ceiling than
+                        spec.maxExportBytes; when omitted the inventory-wide ceiling (or the operator
+                        global cap) applies. The webhook rejects values above the operator global cap
+                        (ADR-0103). Payloads exceeding this ceiling are split into multiple export parts.
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the family sink object name.
+                      type: string
+                    namespace:
+                      description: |-
+                        namespace overrides where this sink resolves. Cluster inventory only:
+                        when omitted it inherits spec.sinkNamespace. Forbidden on namespaced inventories,
+                        which always resolve in the inventory's own namespace (ADR-0208).
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              exportMinInterval:
+                default: 30s
+                description: |-
+                  exportMinInterval is the minimum time between identical exports for this inventory.
+                  It debounces identical payloads only: material changes (payload checksum or spec
+                  generation) always export immediately, regardless of the interval. Zero means
+                  material-change only (no periodic re-export of identical payloads).
+                type: string
+              httpEndpoint:
+                description: httpEndpoint exposes a read-only inventory summary over
+                  HTTP when enabled.
+                properties:
+                  enabled:
+                    description: enabled turns on GET /v1alpha1/inventory (aggregated
+                      summary JSON).
+                    type: boolean
+                  port:
+                    description: port is the listen port for the inventory HTTP server
+                      (default 8082).
+                    format: int32
+                    maximum: 65535
+                    minimum: 1
+                    type: integer
+                type: object
+              maxExportBytes:
+                description: |-
+                  maxExportBytes caps the marshalled namespace payload for export and HTTP (optional).
+                  Webhook rejects values above the operator global cap (ADR-0103).
+                format: int64
+                type: integer
+              snapshotSinkRefs:
+                description: snapshotSinkRefs lists KollectSnapshotSink names in this
+                  namespace (ADR-0414).
+                items:
+                  description: InventorySinkRef names a KollectSink with an optional
+                    per-ref export interval override.
+                  properties:
+                    exportMinInterval:
+                      description: |-
+                        exportMinInterval overrides the inventory default for this sink ref.
+                        Zero means material-change only (no periodic re-export of identical payload).
+                      type: string
+                    maxExportBytes:
+                      description: |-
+                        maxExportBytes overrides the inventory-wide export size ceiling for this sink
+                        ref (AR-01 / EC-P0-01). It may set a smaller or larger byte ceiling than
+                        spec.maxExportBytes; when omitted the inventory-wide ceiling (or the operator
+                        global cap) applies. The webhook rejects values above the operator global cap
+                        (ADR-0103). Payloads exceeding this ceiling are split into multiple export parts.
+                      format: int64
+                      type: integer
+                    name:
+                      description: name is the family sink object name.
+                      type: string
+                    namespace:
+                      description: |-
+                        namespace overrides where this sink resolves. Cluster inventory only:
+                        when omitted it inherits spec.sinkNamespace. Forbidden on namespaced inventories,
+                        which always resolve in the inventory's own namespace (ADR-0208).
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              suspend:
+                description: suspend pauses reconciliation of this inventory when
+                  set to true.
+                type: boolean
+            type: object
+          status:
+            description: status defines the observed state of KollectInventory
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the KollectInventory resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              itemCount:
+                description: itemCount is the number of inventory items collected
+                  in the last run.
+                type: integer
+              lastExportTime:
+                description: lastExportTime is the timestamp of the last successful
+                  export across all sinks.
+                format: date-time
+                type: string
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              sinkExports:
+                description: sinkExports holds per-sink export timestamps and conditions.
+                items:
+                  description: InventorySinkExportStatus holds per-sink export observation
+                    on an inventory.
+                  properties:
+                    conditions:
+                      description: conditions report per-sink Synced / debounce state.
+                      items:
+                        description: Condition contains details for one aspect of
+                          the current state of this API Resource.
+                        properties:
+                          lastTransitionTime:
+                            description: |-
+                              lastTransitionTime is the last time the condition transitioned from one status to another.
+                              This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                            format: date-time
+                            type: string
+                          message:
+                            description: |-
+                              message is a human readable message indicating details about the transition.
+                              This may be an empty string.
+                            maxLength: 32768
+                            type: string
+                          observedGeneration:
+                            description: |-
+                              observedGeneration represents the .metadata.generation that the condition was set based upon.
+                              For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                              with respect to the current state of the instance.
+                            format: int64
+                            minimum: 0
+                            type: integer
+                          reason:
+                            description: |-
+                              reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                              Producers of specific condition types may define expected values and meanings for this field,
+                              and whether the values are considered a guaranteed API.
+                              The value should be a CamelCase string.
+                              This field may not be empty.
+                            maxLength: 1024
+                            minLength: 1
+                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                            type: string
+                          status:
+                            description: status of the condition, one of True, False,
+                              Unknown.
+                            enum:
+                            - "True"
+                            - "False"
+                            - Unknown
+                            type: string
+                          type:
+                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                            maxLength: 316
+                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                            type: string
+                        required:
+                        - lastTransitionTime
+                        - message
+                        - reason
+                        - status
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
+                    lastChecksum:
+                      description: lastChecksum is the payload fingerprint from the
+                        last successful export.
+                      type: string
+                    lastExportTime:
+                      description: lastExportTime is when this sink last accepted
+                        an export successfully.
+                      format: date-time
+                      type: string
+                    name:
+                      description: name matches spec.sinkRefs[].name (keyed by family/name).
+                      type: string
+                    namespace:
+                      description: namespace is the resolved namespace the sink was
+                        exported to (ADR-0208).
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 20
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/kollect/0.18.0/manifests/kollect.dev_kollectprofiles.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.dev_kollectprofiles.yaml
@@ -1,0 +1,283 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: kollectprofiles.kollect.dev
+spec:
+  group: kollect.dev
+  names:
+    kind: KollectProfile
+    listKind: KollectProfileList
+    plural: kollectprofiles
+    shortNames:
+    - kprof
+    singular: kollectprofile
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KollectProfile is the Schema for the kollectprofiles API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of KollectProfile
+            properties:
+              attributes:
+                description: |-
+                  attributes lists the values to extract from each matching resource.
+                  Required when export.mode is Attributes (default); optional when export.mode is Resource.
+                items:
+                  description: AttributeSpec describes a single value extracted from
+                    a target resource.
+                  properties:
+                    name:
+                      description: name is the unique key under which the extracted
+                        value is stored.
+                      type: string
+                    optional:
+                      description: optional marks the attribute as non-fatal when
+                        extraction yields no value.
+                      type: boolean
+                    path:
+                      description: path is the JSONPath or CEL expression used to
+                        extract the value.
+                      type: string
+                    type:
+                      description: type is the expected value type (for example string,
+                        int, or bool).
+                      type: string
+                  required:
+                  - name
+                  - path
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              export:
+                description: |-
+                  export optionally enables full-resource export with path pruning (ADR-0306).
+                  When omitted, the profile behaves as export.mode: Attributes.
+                properties:
+                  as:
+                    default: resource
+                    description: as is the attribute key under which the embedded
+                      pruned object is stored.
+                    type: string
+                  dedupeIdentity:
+                    description: |-
+                      dedupeIdentity strips identity fields already carried on the Item envelope
+                      (uid, namespace, name, GVK) from the embedded object to avoid triple storage.
+                      Defaults to true.
+                    type: boolean
+                  include:
+                    default: SpecAndStatus
+                    description: include selects which top-level object sections survive
+                      pruning.
+                    enum:
+                    - MetadataOnly
+                    - SpecOnly
+                    - StatusOnly
+                    - SpecAndStatus
+                    - All
+                    type: string
+                  mode:
+                    default: Attributes
+                    description: |-
+                      mode selects between curated attribute extraction and full-resource export.
+                      Attributes (default) keeps current behaviour; Resource embeds a pruned object.
+                    enum:
+                    - Attributes
+                    - Resource
+                    type: string
+                  prune:
+                    description: prune declares path-based exclusions applied to the
+                      embedded object.
+                    properties:
+                      cel:
+                        description: |-
+                          cel lists CEL predicates evaluated against the object; true drops the matched
+                          value. Reserved for Phase 2 — not yet enforced by the collector.
+                        items:
+                          type: string
+                        type: array
+                      defaults:
+                        description: |-
+                          defaults applies built-in noise exclusions (managedFields, resourceVersion,
+                          generation, last-applied-configuration, argo tracking-id). Defaults to true.
+                        type: boolean
+                      jsonPaths:
+                        description: jsonPaths lists kubectl/JSONPath expressions
+                          to drop (warn-only parse in Phase 1).
+                        items:
+                          type: string
+                        type: array
+                      jsonPointers:
+                        description: jsonPointers lists RFC 6901 pointers to drop,
+                          matching Argo CD ignoreDifferences UX.
+                        items:
+                          type: string
+                        type: array
+                      scrubKeys:
+                        description: |-
+                          scrubKeys lists case-insensitive key names redacted at any depth, merging with
+                          the operator scrubKeys denylist (ADR-0303).
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              metrics:
+                description: |-
+                  metrics lists kube-state-metrics-style Prometheus series emitted on operator /metrics.
+                  Each path must reference an attribute name from spec.attributes (ADR-0304).
+                items:
+                  description: |-
+                    MetricSpec describes one kube-state-metrics-style Prometheus series from collected CR fields.
+                    Paths reference attribute names defined in spec.attributes (ADR-0304 spike).
+                  properties:
+                    labels:
+                      description: |-
+                        labels lists optional bounded label keys copied from extracted attributes.
+                        Each entry must match an attribute name; cardinality is bounded by distinct label tuples.
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: set
+                    name:
+                      description: name is the bounded Prometheus series identifier
+                        within a profile.
+                      type: string
+                    path:
+                      description: |-
+                        path is the attribute name whose numeric values are aggregated for this series.
+                        Must match an entry in spec.attributes[].name.
+                      type: string
+                  required:
+                  - name
+                  - path
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              targetGVK:
+                description: targetGVK selects the Kubernetes resource kind this profile
+                  applies to.
+                properties:
+                  group:
+                    description: group is the API group of the target resource (empty
+                      for the core group).
+                    type: string
+                  kind:
+                    description: kind is the API kind of the target resource.
+                    type: string
+                  version:
+                    description: version is the API version of the target resource.
+                    type: string
+                required:
+                - kind
+                - version
+                type: object
+            required:
+            - targetGVK
+            type: object
+          status:
+            description: status defines the observed state of KollectProfile
+            properties:
+              conditions:
+                description: |-
+                  conditions represent the current state of the KollectProfile resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/kollect/0.18.0/manifests/kollect.dev_kollectscopes.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.dev_kollectscopes.yaml
@@ -1,0 +1,116 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: kollectscopes.kollect.dev
+spec:
+  group: kollect.dev
+  names:
+    kind: KollectScope
+    listKind: KollectScopeList
+    plural: kollectscopes
+    shortNames:
+    - kscope
+    singular: kollectscope
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          KollectScope is a namespaced governance boundary for targets, inventories, and sinks.
+          Static config only — no controller or status subresource (ADR-0202).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KollectScopeSpec defines a namespaced tenancy boundary for
+              collection and sinks.
+            properties:
+              allowedGVKs:
+                description: allowedGVKs restricts which target resource kinds may
+                  be collected in this scope.
+                items:
+                  description: GroupVersionKind identifies the API group, version,
+                    and kind of a target resource.
+                  properties:
+                    group:
+                      description: group is the API group of the target resource (empty
+                        for the core group).
+                      type: string
+                    kind:
+                      description: kind is the API kind of the target resource.
+                      type: string
+                    version:
+                      description: version is the API version of the target resource.
+                      type: string
+                  required:
+                  - kind
+                  - version
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              allowedNamespaces:
+                description: |-
+                  allowedNamespaces restricts which workload namespaces may be collected.
+                  Empty means any namespace allowed by targets in the scope namespace.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              databaseSinkRefs:
+                description: databaseSinkRefs lists permitted KollectDatabaseSink
+                  names for this scope.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              deniedNamespaces:
+                description: deniedNamespaces is a platform blacklist; Target intent
+                  cannot override (D8).
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              eventSinkRefs:
+                description: eventSinkRefs lists permitted KollectEventSink names
+                  for this scope.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              minExportInterval:
+                description: minExportInterval is a tenancy floor — inventory and
+                  sink intervals below this value are rejected.
+                type: string
+              snapshotSinkRefs:
+                description: snapshotSinkRefs lists permitted KollectSnapshotSink
+                  names for this scope.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true

--- a/operators/kollect/0.18.0/manifests/kollect.dev_kollectsnapshotsinks.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.dev_kollectsnapshotsinks.yaml
@@ -1,0 +1,562 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: kollectsnapshotsinks.kollect.dev
+spec:
+  group: kollect.dev
+  names:
+    kind: KollectSnapshotSink
+    listKind: KollectSnapshotSinkList
+    plural: kollectsnapshotsinks
+    shortNames:
+    - ksnap
+    singular: kollectsnapshotsink
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KollectSnapshotSink is the Schema for snapshot export sinks.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KollectSnapshotSinkSpec defines a snapshot-store export sink
+              (ADR-0414).
+            properties:
+              cluster:
+                description: cluster labels exported inventory in multi-cluster installs.
+                type: string
+              connectionTest:
+                description: connectionTest enables connectivity checks on create/update
+                  (default true).
+                type: boolean
+              endpoint:
+                description: endpoint is the backend-specific destination (URL, bucket,
+                  and so on).
+                type: string
+              exportMinInterval:
+                description: |-
+                  exportMinInterval is the default minimum time between identical exports when an inventory
+                  ref omits a per-ref override.
+                type: string
+              git:
+                description: git configures git sink settings when type is git.
+                properties:
+                  auth:
+                    description: auth documents credential mode and optional secret
+                      override for git push.
+                    properties:
+                      secretRef:
+                        description: secretRef overrides spec.secretRef for git credentials
+                          when set.
+                        properties:
+                          name:
+                            description: name is the name of the referenced Secret.
+                            type: string
+                          namespace:
+                            description: namespace is the namespace of the referenced
+                              Secret.
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type:
+                        description: type selects HTTPS token/basic auth or SSH private-key
+                          auth.
+                        enum:
+                        - token
+                        - ssh
+                        type: string
+                    type: object
+                  author:
+                    description: author overrides the default kollect committer identity.
+                    properties:
+                      email:
+                        description: email is the commit author email (default kollect@kollect.dev).
+                        type: string
+                      name:
+                        description: name is the commit author display name (default
+                          kollect).
+                        type: string
+                    type: object
+                  branch:
+                    description: |-
+                      branch is the target branch for clone and push.
+                      Overrides the endpoint URL fragment (#branch=) when set.
+                    type: string
+                  cloneDepth:
+                    description: cloneDepth limits shallow clone depth (default 1).
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  commitBody:
+                    description: commitBody is an optional multi-line commit body
+                      template (same placeholders as commitMessage).
+                    type: string
+                  commitMessage:
+                    description: |-
+                      commitMessage is the git commit subject template.
+                      Placeholders: {namespace}, {name}, {cluster}, {generation}, {itemCount},
+                      {checksum}, {checksumShort}, {exportedAt}, {sink}, {path}.
+                    type: string
+                  commitTrailers:
+                    description: 'commitTrailers appends git commit trailers (e.g.
+                      Kollect-Checksum: {checksum}).'
+                    items:
+                      type: string
+                    type: array
+                  engine:
+                    description: |-
+                      engine selects the git implementation: go-git (default) or host git CLI.
+                      file:// remotes always use the CLI path regardless of this field.
+                    enum:
+                    - go-git
+                    - cli
+                    type: string
+                  forceBasicAuth:
+                    description: |-
+                      forceBasicAuth sends an explicit Authorization header on HTTPS remotes.
+                      Useful when git hosts ignore embedded URL credentials. May also be enabled
+                      via the KOLLECT_GIT_FORCE_BASIC_AUTH environment variable on the operator.
+                    type: boolean
+                  prune:
+                    description: prune stages deletions in the worktree before commit
+                      (git add -A semantics).
+                    type: boolean
+                  pushPolicy:
+                    description: pushPolicy selects append-only commits (Commit, default)
+                      or force-push snapshot mode (ForcePush).
+                    enum:
+                    - Commit
+                    - ForcePush
+                    type: string
+                type: object
+              gitlab:
+                description: gitlab configures GitLab-specific settings when type
+                  is gitlab.
+                properties:
+                  mergeRequest:
+                    description: mergeRequest configures optional branch + merge request
+                      workflow after git push.
+                    properties:
+                      autoMerge:
+                        description: autoMerge requests auto-merge when the MR pipeline
+                          succeeds (not yet implemented).
+                        type: boolean
+                      branchPrefix:
+                        description: branchPrefix prefixes feature branches (default
+                          kollect).
+                        type: string
+                      mode:
+                        description: mode selects direct push to the default branch
+                          or branch + merge request workflow.
+                        enum:
+                        - direct
+                        - merge_request
+                        type: string
+                      targetBranch:
+                        description: targetBranch is the MR target branch (required
+                          when mode is merge_request).
+                        type: string
+                      titleTemplate:
+                        description: titleTemplate is an optional MR title template
+                          with {namespace} and {name} placeholders.
+                        type: string
+                    type: object
+                type: object
+              http:
+                description: http configures webhook snapshot export when type is
+                  http.
+                properties:
+                  method:
+                    description: method is the HTTP verb for export requests (default
+                      POST).
+                    type: string
+                type: object
+              layout:
+                description: |-
+                  layout configures document shape and folder layout for snapshot Git/GitLab sinks (ADR-0419).
+                  The entire block is optional; omitting it yields a single readable inventory document.
+                properties:
+                  content:
+                    default: item
+                    description: |-
+                      content selects the per-file payload: item (full Item row, default),
+                      attributes (Item.attributes only), or manifest (native object, ADR-0306 Resource export).
+                    enum:
+                    - item
+                    - attributes
+                    - manifest
+                    type: string
+                  filename:
+                    description: filename tunes path-segment sanitization and grouping.
+                    properties:
+                      groupInPath:
+                        description: |-
+                          groupInPath controls the {group} segment: auto (omit for core types, default),
+                          always, or never.
+                        enum:
+                        - auto
+                        - always
+                        - never
+                        type: string
+                      lowercaseKind:
+                        description: lowercaseKind lowercases {kind} in paths (default
+                          true).
+                        type: boolean
+                      maxSegmentLength:
+                        description: maxSegmentLength caps each path segment for DNS
+                          safety (default 63).
+                        format: int32
+                        minimum: 1
+                        type: integer
+                    type: object
+                  index:
+                    description: index configures the split-mode index sidecar.
+                    properties:
+                      enabled:
+                        description: enabled toggles the index sidecar (default false;
+                          true in split mode).
+                        type: boolean
+                      pathTemplate:
+                        description: pathTemplate is the index file path (default
+                          inventory/{namespace}/{name}{extension}).
+                        type: string
+                    type: object
+                  mode:
+                    default: document
+                    description: |-
+                      mode selects the on-disk layout: document (one inventory file, default),
+                      perResource (one file per Item), or split (index sidecar + per-resource tree).
+                    enum:
+                    - document
+                    - perResource
+                    - split
+                    type: string
+                  pathTemplate:
+                    description: |-
+                      pathTemplate is the per-item path used when mode is perResource or split.
+                      Placeholders: {cluster}, {namespace}, {name}, {targetNamespace}, {targetName},
+                      {sourceNamespace}, {sourceName}, {group}, {kind}, {uid}, {generation}, {extension}.
+                      Default: {cluster}/{sourceNamespace}/{kind}/{sourceName}{extension}
+                    type: string
+                type: object
+              objectStore:
+                description: objectStore configures S3/GCS/Azure snapshot serialization.
+                properties:
+                  format:
+                    description: format selects the snapshot serialization (default
+                      json).
+                    enum:
+                    - json
+                    - parquet
+                    type: string
+                  hotAttributes:
+                    description: hotAttributes lists profile attribute keys promoted
+                      to typed Parquet columns (ADR-0401, Q11).
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+              options:
+                additionalProperties:
+                  type: string
+                description: |-
+                  options carries non-secret, backend-specific pass-through settings (ADR-0416 §4, Option 2).
+                  Secret-like keys are rejected by the webhook; supply credentials via secretRef only.
+                type: object
+              pathTemplate:
+                description: pathTemplate selects the Git/object-store export path
+                  layout (ADR-0407).
+                type: string
+              provisioning:
+                description: |-
+                  provisioning configures destination resource ownership (ADR-0416 §5).
+                  mode ensure (default) creates resources if missing; existing never creates and preflights existence.
+                properties:
+                  mode:
+                    description: mode selects ensure (create-if-missing, default)
+                      or existing (never create; preflight verifies).
+                    enum:
+                    - ensure
+                    - existing
+                    type: string
+                  naming:
+                    description: naming optionally templates the destination resource
+                      name using the shared placeholder grammar.
+                    properties:
+                      template:
+                        description: |-
+                          template is the destination name template; placeholders match pathTemplate
+                          ({cluster}, {namespace}, {name}, {generation}).
+                        type: string
+                    type: object
+                type: object
+              secretRef:
+                description: secretRef references a Secret holding credentials for
+                  the sink.
+                properties:
+                  name:
+                    description: name is the name of the referenced Secret.
+                    type: string
+                  namespace:
+                    description: namespace is the namespace of the referenced Secret.
+                    type: string
+                required:
+                - name
+                type: object
+              serialization:
+                description: |-
+                  serialization configures the cross-cutting on-wire format and schema contract (ADR-0416 §4).
+                  json is the zero-config default; the backend capability matrix gates which formats are honored.
+                properties:
+                  compression:
+                    description: compression selects payload compression where the
+                      backend supports it (default none).
+                    enum:
+                    - none
+                    - gzip
+                    - snappy
+                    - zstd
+                    type: string
+                  format:
+                    description: format selects the on-wire serialization (default
+                      json; yaml default for git/gitlab).
+                    enum:
+                    - json
+                    - yaml
+                    - parquet
+                    - csv
+                    - ndjson
+                    type: string
+                type: object
+              tls:
+                description: tls configures TLS verification for HTTPS git and similar
+                  endpoints.
+                properties:
+                  caBundle:
+                    description: |-
+                      caBundle is an inline PEM-encoded CA certificate bundle.
+                      Prefer caSecretRef for production; do not set both caBundle and caSecretRef.
+                    format: byte
+                    type: string
+                  caSecretRef:
+                    description: caSecretRef references a Secret containing a PEM
+                      CA bundle (key tls.crt or ca.crt).
+                    properties:
+                      name:
+                        description: name is the name of the referenced Secret.
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the referenced
+                          Secret.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  insecureSkipVerify:
+                    description: insecureSkipVerify disables server certificate verification
+                      (not recommended).
+                    type: boolean
+                type: object
+              type:
+                description: type selects the snapshot backend implementation.
+                enum:
+                - git
+                - gitlab
+                - s3
+                - gcs
+                type: string
+            required:
+            - type
+            type: object
+          status:
+            description: FamilySinkStatus is the shared status shape for family sink
+              CRDs.
+            properties:
+              conditions:
+                description: conditions represent the current state of the sink resource.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              preview:
+                description: |-
+                  preview is a read-only, side-effect-free preview of export implications, populated when the
+                  kollect.dev/preview annotation is set (ADR-0416 §8).
+                properties:
+                  git:
+                    description: git previews the commit subject/body for git and
+                      gitlab snapshot sinks.
+                    properties:
+                      sampleCommitBody:
+                        description: sampleCommitBody is the rendered commit body.
+                        type: string
+                      sampleCommitSubject:
+                        description: sampleCommitSubject is the rendered commit subject
+                          line.
+                        type: string
+                    type: object
+                  inputSampleSource:
+                    description: inputSampleSource names the sample input used to
+                      render the preview (e.g. synthetic).
+                    type: string
+                  kafka:
+                    description: kafka previews the destination topic for kafka sinks.
+                    properties:
+                      topic:
+                        description: topic is the destination topic events would be
+                          published to.
+                        type: string
+                    type: object
+                  layout:
+                    description: layout previews the resolved export layout for git
+                      and gitlab snapshot sinks (ADR-0419).
+                    properties:
+                      content:
+                        description: content is the resolved per-file content shape
+                          (item, attributes, or manifest).
+                        type: string
+                      mode:
+                        description: mode is the resolved layout mode (document, perResource,
+                          or split).
+                        type: string
+                      prune:
+                        description: prune reports whether stale files are removed
+                          on export (auto for perResource/split).
+                        type: boolean
+                      samplePaths:
+                        description: samplePaths lists example repo paths the layout
+                          would write for the synthetic sample.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  mongodb:
+                    description: mongodb previews the expected identity index for
+                      mongodb sinks.
+                    properties:
+                      expectedIndexKeys:
+                        description: expectedIndexKeys lists the fields of the unique
+                          identity index.
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  objectPath:
+                    description: objectPath is the rendered destination path/object
+                      key for snapshot sinks.
+                    type: string
+                  postgres:
+                    description: postgres previews the expected CREATE TABLE DDL for
+                      postgres sinks.
+                    properties:
+                      expectedDDL:
+                        description: expectedDDL is the CREATE TABLE statement used
+                          in provisioning.mode=ensure.
+                        type: string
+                    type: object
+                  provisioningMode:
+                    description: provisioningMode is the effective provisioning mode
+                      (ensure or existing).
+                    type: string
+                  renderedAt:
+                    description: renderedAt is the time the preview was last computed.
+                    format: date-time
+                    type: string
+                  serializationFormat:
+                    description: serializationFormat is the effective on-wire format
+                      (json, parquet, ...).
+                    type: string
+                  warnings:
+                    description: warnings lists non-blocking implications surfaced
+                      by the preview.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/kollect/0.18.0/manifests/kollect.dev_kollecttargets.yaml
+++ b/operators/kollect/0.18.0/manifests/kollect.dev_kollecttargets.yaml
@@ -1,0 +1,498 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.20.1
+  name: kollecttargets.kollect.dev
+spec:
+  group: kollect.dev
+  names:
+    kind: KollectTarget
+    listKind: KollectTargetList
+    plural: kollecttargets
+    shortNames:
+    - ktgt
+    singular: kollecttarget
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.collectedCount
+      name: Collected
+      type: integer
+    - jsonPath: .status.collectedCountUpdatedAt
+      name: Updated
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KollectTarget is the Schema for the kollecttargets API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the desired state of KollectTarget
+            properties:
+              excludedNamespaces:
+                description: excludedNamespaces is a static namespace denylist applied
+                  after include logic.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              includedNamespaces:
+                description: |-
+                  includedNamespaces is a static namespace allowlist. Empty means no extra restriction
+                  beyond namespaceSelector.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              labelSelector:
+                description: labelSelector restricts collection to resources matching
+                  the selector.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              names:
+                description: names optionally restricts collection to resources with
+                  these names.
+                items:
+                  type: string
+                type: array
+              namespaceExcludeSelector:
+                description: namespaceExcludeSelector excludes namespaces whose labels
+                  match the selector.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              namespaceSelector:
+                description: namespaceSelector restricts collection to namespaces
+                  matching the selector.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              profileRef:
+                description: profileRef is the name of a KollectProfile in the same
+                  namespace as this Target.
+                type: string
+              resourceRules:
+                description: |-
+                  resourceRules declares GVK-scoped collection rules. When empty, collection falls back to
+                  Profile targetGVK plus legacy labelSelector/names on the Target.
+                items:
+                  description: |-
+                    ResourceRule selects objects of a GVK within optional namespace and resource label constraints.
+                    Multiple rules are OR-unioned (D7). Optional matchPolicy is a CEL expression evaluated pre-store.
+                  properties:
+                    gvk:
+                      description: gvk is the API group, version, and kind this rule
+                        applies to.
+                      properties:
+                        group:
+                          description: group is the API group of the target resource
+                            (empty for the core group).
+                          type: string
+                        kind:
+                          description: kind is the API kind of the target resource.
+                          type: string
+                        version:
+                          description: version is the API version of the target resource.
+                          type: string
+                      required:
+                      - kind
+                      - version
+                      type: object
+                    matchExpressions:
+                      description: matchExpressions requires resource metadata labels
+                        to match.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies
+                              to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: matchLabels requires resource metadata labels to
+                        match (AND with matchExpressions).
+                      type: object
+                    matchPolicy:
+                      description: |-
+                        matchPolicy is an optional CEL expression with `object` bound to the resource.
+                        Evaluated after label/GVK/namespace gates, before store insert (ADR-0207 Phase 3).
+                      type: string
+                    namespaceSelector:
+                      description: namespaceSelector further restricts this rule to
+                        namespaces matching the selector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  required:
+                  - gvk
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              suspend:
+                description: suspend pauses reconciliation of this target when set
+                  to true.
+                type: boolean
+              watchMode:
+                default: All
+                description: |-
+                  watchMode controls namespace/resource watch opt-in vs opt-out (ADR-0205).
+                  All (default): collect matching selectors except resources/namespaces explicitly disabled.
+                  OptIn: only collect resources/namespaces explicitly enabled via kollect.dev/watch or
+                  kollect.dev/namespace-watch.
+                enum:
+                - All
+                - OptIn
+                type: string
+            required:
+            - profileRef
+            type: object
+          status:
+            description: status defines the observed state of KollectTarget
+            properties:
+              activeResourceRules:
+                description: activeResourceRules is the number of compiled resourceRules
+                  entries (0 when using legacy fallback).
+                type: integer
+              collectedCount:
+                description: |-
+                  collectedCount is the number of resources this target was collecting when the
+                  controller last refreshed the count. It is the machine-readable source of truth
+                  for collection scale; the Ready condition message restates it as prose for
+                  backward compatibility only.
+
+                  A null value means the controller has never computed a count for this target
+                  (it has not yet reached Ready). Zero means it computed a count and it was zero.
+                  A target that is Degraded, or whose reconciles are failing, keeps its last known
+                  count rather than silently reporting a fresh-looking number — see
+                  collectedCountUpdatedAt for when that measurement was taken.
+                format: int64
+                type: integer
+              collectedCountUpdatedAt:
+                description: |-
+                  collectedCountUpdatedAt is when collectedCount last *changed* — not when it was
+                  last checked. A steady target whose count has not moved keeps an old timestamp
+                  while still being re-derived every resync, so an old timestamp on its own does
+                  not mean the number is stale.
+
+                  Read it together with the conditions: a Ready target with an old timestamp has a
+                  count that genuinely has not moved, while a Degraded target keeps its last known
+                  count and the timestamp shows how long ago that measurement was taken.
+                format: date-time
+                type: string
+              conditions:
+                description: |-
+                  conditions represent the current state of the KollectTarget resource.
+                  Each condition has a unique type and reflects the status of a specific aspect of the resource.
+
+                  Standard condition types include:
+                  - "Available": the resource is fully functional
+                  - "Progressing": the resource is being created or updated
+                  - "Degraded": the resource failed to reach or maintain its desired state
+
+                  The status of each condition is one of True, False, or Unknown.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              effectiveNamespaces:
+                description: |-
+                  effectiveNamespaces lists namespaces after intersecting Scope allowedNamespaces and subtracting
+                  Target/Scope deny lists.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              extractionFailures:
+                description: |-
+                  extractionFailures is the count of resources currently failing CEL/JSONPath
+                  attribute extraction for this target.
+                type: integer
+              lastExtractionError:
+                description: lastExtractionError is the most recently observed extraction
+                  failure message.
+                type: string
+              matchedNamespaces:
+                description: matchedNamespaces lists workload namespaces matched by
+                  Target intent (before Scope ceiling).
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              observedGeneration:
+                description: observedGeneration is the most recent generation observed
+                  by the controller.
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/kollect/0.18.0/metadata/annotations.yaml
+++ b/operators/kollect/0.18.0/metadata/annotations.yaml
@@ -1,0 +1,8 @@
+---
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: kollect
+  operators.operatorframework.io.bundle.channels.v1: stable
+  operators.operatorframework.io.bundle.channel.default.v1: stable

--- a/operators/kollect/ci.yaml
+++ b/operators/kollect/ci.yaml
@@ -1,0 +1,3 @@
+updateGraph: semver-mode
+reviewers:
+  - konih


### PR DESCRIPTION
### New Submission

**Operator:** kollect · **Version:** 0.18.0 · **Channel:** stable · **Capability level:** Full Lifecycle

---

## What Kollect does

Kollect turns live Kubernetes state into **durable, queryable inventory**. Operators declare once
what matters -- via `KollectProfile` (which fields to extract) and `KollectTarget` (which resources
to watch) -- and Kollect keeps that inventory current, exporting the same canonical snapshot to Git,
relational databases, object storage, and event streams in parallel.

The motivating problem: everything that wants to know "what is running in this cluster" ends up
querying the apiserver. That couples every consumer to cluster RBAC, risks watch storms, and pushes
teams toward storing derived state in etcd, where it does not belong. Kollect inverts this --
consumers query a **sink**, never the apiserver.

## Features

* **Decoupled read model** -- consumers query a sink, not the apiserver: no RBAC blast radius, no
  watch-storm risk, no etcd size pressure.
* **Event-driven collection** -- one shared informer per GVK keeps inventory current as the cluster
  changes. No polling loops.
* **Schema-flexible extraction** -- declare the attributes you want with CEL expressions or
  JSONPath. No bespoke collector per resource kind.
* **Pluggable sinks** -- snapshot, database, and event sink families fan the same snapshot out to
  Git, Postgres, object stores, or event streams. No privileged backend tier.
* **Multi-tenant by design** -- `KollectScope` gates which teams, namespaces, and sinks each tenant
  may use, so inventory collection can be delegated safely.
* **Fleet-ready** -- N single-mode operators feed one shared sink, partitioned by `spec.cluster`.
  There is no central hub tier to operate.
* **Scale-aware** -- shared informers, export sharding, and tunable reconcile/dispatch concurrency.

## Security

**Runtime hardening.** The manager runs `runAsNonRoot` with a `RuntimeDefault` seccomp profile, a
read-only root filesystem, `allowPrivilegeEscalation: false`, and **all** Linux capabilities dropped.

**Least privilege and data handling.**

* Reads only the resources its RBAC allows, with **SubjectAccessReview** checks configurable per
  target -- collection cannot be used to escalate beyond what the requester may already read.
* Writes to external sinks using credentials sourced from **`Secret` references only**; credentials
  never appear in CR specs or logs.
* Stores **aggregated summaries** in CR `status`, not full resource payloads.
* Documented guidance to restrict egress with `NetworkPolicy` and require verified TLS to sinks.

**Supply chain.** Every release publishes multi-arch images with **cosign keyless signatures**,
**SPDX SBOMs**, and **SLSA provenance attestations**, plus `sha256sum` manifests for install YAML
and the chart tarball. The CSV deployment and `relatedImages` in this bundle are **digest-pinned**,
not tag-pinned.

**Assurance.** The project runs OpenSSF Scorecard, `govulncheck`, golangci-lint SAST, and dependency
and license (SCA) policy checks, publishes VEX statements for vulnerability exceptions, and accepts
private vulnerability reports. See `SECURITY.md` and the published security architecture for trust
boundaries, tenancy, redaction, and shared-responsibility detail.

## Notes for reviewers

* **Install mode:** `AllNamespaces` only. The controller watches cluster-wide and does not consume
  `olm.targetNamespaces`, so advertising a namespace-scoped mode would silently collect from the
  whole cluster. It is deliberately not offered.
* **Webhooks:** this bundle runs with validating webhooks disabled -- no webhook `Service` or
  certificate ships in it. CRD schema validation still applies. The Helm chart path offers the full
  admission stack for users who want it.
* **Prerequisites:** Kubernetes 1.28+.

Source: https://github.com/platformrelay/kollect ·
Docs: https://platformrelay.github.io/Kollect/ ·
Release notes: https://github.com/platformrelay/kollect/releases/tag/v0.18.0

---
*Submitted by the Kollect release workflow (`hack/operatorhub-pr.sh`).*
