### PR TITLE
operator openclaw-operator (0.40.0)

### DIFF
--- a/operators/openclaw-operator/0.40.0/manifests/openclaw-operator.v0.40.0.clusterserviceversion.yaml
+++ b/operators/openclaw-operator/0.40.0/manifests/openclaw-operator.v0.40.0.clusterserviceversion.yaml
@@ -1,0 +1,673 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: openclaw-operator.v0.40.0
+  namespace: placeholder
+  annotations:
+    capabilities: "Auto Pilot"
+    categories: "AI/Machine Learning, Developer Tools, Application Runtime"
+    containerImage: ghcr.io/paperclipinc/openclaw-operator@sha256:38e0da31c5205a95486bad1e321050263f2c11042f602245926e96f83fc1a152
+    createdAt: "2026-09-07T03:00:12Z"
+    support: Paperclip Inc.
+    repository: https://github.com/paperclipinc/openclaw-operator
+    description: "A production-grade Kubernetes operator for deploying and managing OpenClaw AI agent instances with auto-updates, backup/restore, and security hardening."
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "openclaw.rocks/v1alpha1",
+          "kind": "OpenClawInstance",
+          "metadata": {
+            "name": "my-openclaw",
+            "namespace": "default"
+          },
+          "spec": {
+            "envFrom": [
+              {
+                "secretRef": {
+                  "name": "openclaw-api-keys"
+                }
+              }
+            ],
+            "storage": {
+              "persistence": {
+                "enabled": true,
+                "size": "10Gi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "openclaw.rocks/v1alpha1",
+          "kind": "OpenClawInstance",
+          "metadata": {
+            "name": "production-openclaw",
+            "namespace": "openclaw"
+          },
+          "spec": {
+            "image": {
+              "repository": "ghcr.io/openclaw/openclaw",
+              "tag": "2026.2.3"
+            },
+            "config": {
+              "raw": {
+                "agents": {
+                  "defaults": {
+                    "model": {
+                      "primary": "anthropic/claude-sonnet-4-20250514"
+                    },
+                    "sandbox": true
+                  }
+                }
+              }
+            },
+            "envFrom": [
+              {
+                "secretRef": {
+                  "name": "openclaw-api-keys"
+                }
+              }
+            ],
+            "resources": {
+              "requests": {
+                "cpu": "500m",
+                "memory": "1Gi"
+              },
+              "limits": {
+                "cpu": "2000m",
+                "memory": "4Gi"
+              }
+            },
+            "chromium": {
+              "enabled": true,
+              "resources": {
+                "requests": {
+                  "cpu": "250m",
+                  "memory": "512Mi"
+                },
+                "limits": {
+                  "cpu": "1000m",
+                  "memory": "2Gi"
+                }
+              }
+            },
+            "storage": {
+              "persistence": {
+                "enabled": true,
+                "size": "50Gi"
+              }
+            },
+            "security": {
+              "networkPolicy": {
+                "enabled": true
+              }
+            },
+            "autoUpdate": {
+              "enabled": true,
+              "backupBeforeUpdate": true,
+              "rollbackOnFailure": true
+            },
+            "observability": {
+              "serviceMonitor": {
+                "enabled": true
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "openclaw.rocks/v1alpha1",
+          "kind": "OpenClawSelfConfig",
+          "metadata": {
+            "name": "add-image-gen-skill",
+            "namespace": "default"
+          },
+          "spec": {
+            "instanceRef": "my-openclaw",
+            "addSkills": [
+              "image-gen"
+            ]
+          }
+        },
+        {
+          "apiVersion": "openclaw.rocks/v1alpha1",
+          "kind": "OpenClawClusterDefaults",
+          "metadata": {
+            "name": "cluster"
+          },
+          "spec": {
+            "image": {
+              "tag": "v0.28.0"
+            },
+            "runtimeDeps": {
+              "python": true
+            }
+          }
+        }
+      ]
+    features.operators.openshift.io/disconnected: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+spec:
+  displayName: OpenClaw Operator
+  description: |
+    ## OpenClaw Kubernetes Operator
+
+    A production-grade Kubernetes operator for deploying and managing
+    [OpenClaw](https://openclaw.ai) AI agent instances.
+
+    ### What is OpenClaw?
+
+    OpenClaw is an open-source platform for running AI agents that can interact
+    with tools, browse the web, execute code, and automate complex workflows.
+    The operator manages the full lifecycle of OpenClaw instances on Kubernetes --
+    from initial deployment through upgrades, backups, and scaling.
+
+    ### Key Capabilities
+
+    - **Declarative Deployment**: Deploy OpenClaw instances using Kubernetes Custom Resources
+    - **Automatic Updates**: OCI registry-based auto-updates with health checks and automatic rollback
+    - **Backup and Restore**: Built-in backup/restore for stateful agent data
+    - **Security-First**: Built-in NetworkPolicies, RBAC, Pod Security Standards, and a validating webhook
+    - **Provider-Agnostic**: Support any AI provider (OpenAI, Anthropic, Google, etc.) via environment variables
+    - **High Availability**: PodDisruptionBudgets, health probes, and graceful rolling upgrades
+    - **Observability**: Prometheus ServiceMonitor, structured logging, and Kubernetes events
+    - **Browser Automation**: Optional Chromium sidecar for web automation capabilities
+    - **Skill Installation**: Install npm-based skills/plugins at startup via init containers
+
+    ### Default Security Posture
+
+    All containers run as non-root (UID 1000) with all Linux capabilities dropped,
+    RuntimeDefault seccomp profiles, default-deny NetworkPolicies, and minimal RBAC
+    permissions per instance.
+
+    ### Managed Resources
+
+    For each OpenClawInstance CR, the operator creates and manages:
+    StatefulSet, Service, ServiceAccount, ConfigMap, PVC, Role, RoleBinding,
+    NetworkPolicy, PodDisruptionBudget, and optionally Ingress and ServiceMonitor.
+    All resources are owned by the CR and garbage-collected on deletion.
+
+    ### Getting Started
+
+    1. Install the operator via OLM or Helm
+    2. Create a Secret with your AI provider API keys:
+       ```
+       kubectl create secret generic openclaw-api-keys \
+         --from-literal=ANTHROPIC_API_KEY=sk-...
+       ```
+    3. Create an OpenClawInstance custom resource referencing the secret
+    4. The operator handles the rest -- deployment, networking, security, and lifecycle management
+
+    ### Prerequisites
+
+    - Kubernetes 1.28+
+
+    For full documentation, visit the
+    [OpenClaw Operator docs](https://paperclip.inc/docs/operators/openclaw).
+  maturity: alpha
+  version: 0.40.0
+  minKubeVersion: 1.28.0
+  keywords:
+    - ai
+    - agent
+    - openclaw
+    - automation
+    - llm
+    - kubernetes
+    - ai-agent
+    - chatbot
+    - browser-automation
+    - chromium
+    - machine-learning
+  maintainers:
+    - name: Jannes Stubbemann
+      email: jannes@paperclip.inc
+  provider:
+    name: Paperclip Inc.
+    url: https://paperclip.inc
+  links:
+    - name: Website
+      url: https://paperclip.inc
+    - name: Operator Documentation
+      url: https://paperclip.inc/docs/operators/openclaw
+    - name: API Reference
+      url: https://github.com/paperclipinc/openclaw-operator/blob/main/docs/api-reference.md
+    - name: GitHub Repository
+      url: https://github.com/paperclipinc/openclaw-operator
+    - name: Changelog
+      url: https://github.com/paperclipinc/openclaw-operator/blob/main/CHANGELOG.md
+  icon:
+    - base64data: PHN2ZyB2aWV3Qm94PSIwIDAgMTIwIDEyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cGF0aCBkPSJNNjAgMTAgQzMwIDEwIDE1IDM1IDE1IDU1IEMxNSA3NSAzMCA5NSA0NSAxMDAgTDQ1IDExMCBMNTUgMTEwIEw1NSAxMDAgQzU1IDEwMCA2MCAxMDIgNjUgMTAwIEw2NSAxMTAgTDc1IDExMCBMNzUgMTAwIEM5MCA5NSAxMDUgNzUgMTA1IDU1IEMxMDUgMzUgOTAgMTAgNjAgMTBaIiBmaWxsPSJ1cmwoI2xvYnN0ZXItZ3JhZGllbnQpIi8+CiAgPHBhdGggZD0iTTIwIDQ1IEM1IDQwIDAgNTAgNSA2MCBDMTAgNzAgMjAgNjUgMjUgNTUgQzI4IDQ4IDI1IDQ1IDIwIDQ1WiIgZmlsbD0idXJsKCNsb2JzdGVyLWdyYWRpZW50KSIvPgogIDxwYXRoIGQ9Ik0xMDAgNDUgQzExNSA0MCAxMjAgNTAgMTE1IDYwIEMxMTAgNzAgMTAwIDY1IDk1IDU1IEM5MiA0OCA5NSA0NSAxMDAgNDVaIiBmaWxsPSJ1cmwoI2xvYnN0ZXItZ3JhZGllbnQpIi8+CiAgPHBhdGggZD0iTTQ1IDE1IFEzNSA1IDMwIDgiIHN0cm9rZT0iI2Y4NzE3MSIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICA8cGF0aCBkPSJNNzUgMTUgUTg1IDUgOTAgOCIgc3Ryb2tlPSIjZjg3MTcxIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgogIDxjaXJjbGUgY3g9IjQxIiBjeT0iMzkiIHI9IjkiIGZpbGw9IiNmYWZhZmEiLz4KICA8Y2lyY2xlIGN4PSI3OSIgY3k9IjM5IiByPSI5IiBmaWxsPSIjZmFmYWZhIi8+CiAgPGNpcmNsZSBjeD0iNDIiIGN5PSI0MCIgcj0iNC41IiBmaWxsPSIjMGEwYTBiIi8+CiAgPGNpcmNsZSBjeD0iNzgiIGN5PSI0MCIgcj0iNC41IiBmaWxsPSIjMGEwYTBiIi8+CiAgPGNpcmNsZSBjeD0iNDAiIGN5PSIzNyIgcj0iMS42IiBmaWxsPSIjZmZmZmZmIi8+CiAgPGNpcmNsZSBjeD0iNzYiIGN5PSIzNyIgcj0iMS42IiBmaWxsPSIjZmZmZmZmIi8+CiAgPGRlZnM+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImxvYnN0ZXItZ3JhZGllbnQiIHgxPSIwJSIgeTE9IjAlIiB4Mj0iMTAwJSIgeTI9IjEwMCUiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjZjg3MTcxIi8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3RvcC1jb2xvcj0iI2RjMjYyNiIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+Cjwvc3ZnPgo=
+      mediatype: image/svg+xml
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true
+  relatedImages:
+    - name: openclaw-operator
+      image: ghcr.io/paperclipinc/openclaw-operator@sha256:38e0da31c5205a95486bad1e321050263f2c11042f602245926e96f83fc1a152
+    - name: openclaw
+      image: ghcr.io/openclaw/openclaw:latest
+    - name: chromium-sidecar
+      image: docker.io/chromedp/headless-shell:stable
+  customresourcedefinitions:
+    owned:
+      - name: openclawinstances.openclaw.rocks
+        version: v1alpha1
+        kind: OpenClawInstance
+        displayName: OpenClaw Instance
+        description: Represents a managed OpenClaw AI agent instance with security, networking, storage, and observability configuration.
+        specDescriptors:
+          - path: image.repository
+            displayName: Image Repository
+            description: Container image repository for OpenClaw
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:text"
+          - path: image.tag
+            displayName: Image Tag
+            description: Container image tag
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:text"
+          - path: chromium.enabled
+            displayName: Chromium Sidecar
+            description: Enable Chromium browser automation sidecar
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+          - path: security.networkPolicy.enabled
+            displayName: Network Policy
+            description: Enable default-deny NetworkPolicy
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+          - path: storage.persistence.enabled
+            displayName: Persistent Storage
+            description: Enable persistent volume for agent data
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+          - path: storage.persistence.size
+            displayName: Storage Size
+            description: Size of the persistent volume
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:text"
+          - path: resources
+            displayName: Resource Requirements
+            description: CPU and memory requests/limits for the main container
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+          - path: networking.ingress.enabled
+            displayName: Ingress
+            description: Enable Ingress for external access
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+          - path: networking.ingress.className
+            displayName: Ingress Class
+            description: Name of the IngressClass to use
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:text"
+              - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:networking.ingress.enabled:true"
+          - path: networking.ingress.hosts
+            displayName: Ingress Hosts
+            description: Hosts to route traffic for
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:networking.ingress.enabled:true"
+          - path: observability.serviceMonitor.enabled
+            displayName: Prometheus ServiceMonitor
+            description: Enable Prometheus ServiceMonitor for metrics scraping
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+          - path: autoUpdate.enabled
+            displayName: Auto Update
+            description: Enable automatic version updates from the OCI registry
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+          - path: autoUpdate.backupBeforeUpdate
+            displayName: Backup Before Update
+            description: Create a backup before applying updates
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+              - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:autoUpdate.enabled:true"
+          - path: autoUpdate.rollbackOnFailure
+            displayName: Rollback on Failure
+            description: Automatically rollback if the update fails health checks
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
+              - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:autoUpdate.enabled:true"
+          - path: envFrom
+            displayName: Environment From
+            description: List of sources to populate environment variables (secrets, configmaps)
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:fieldGroup:Environment"
+          - path: availability.affinity
+            displayName: Pod Affinity
+            description: Pod scheduling affinity rules
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:podAffinity"
+          - path: chromium.resources
+            displayName: Chromium Resources
+            description: CPU and memory requests/limits for the Chromium sidecar
+            x-descriptors:
+              - "urn:alm:descriptor:com.tectonic.ui:resourceRequirements"
+              - "urn:alm:descriptor:com.tectonic.ui:fieldDependency:chromium.enabled:true"
+        statusDescriptors:
+          - path: phase
+            displayName: Phase
+            description: Current lifecycle phase of the OpenClaw instance
+            x-descriptors:
+              - "urn:alm:descriptor:io.kubernetes.phase"
+          - path: conditions
+            displayName: Conditions
+            description: Standard Kubernetes conditions for the instance
+            x-descriptors:
+              - "urn:alm:descriptor:io.kubernetes.conditions"
+          - path: gatewayEndpoint
+            displayName: Gateway Endpoint
+            description: Internal service endpoint for the OpenClaw gateway
+            x-descriptors:
+              - "urn:alm:descriptor:text"
+          - path: canvasEndpoint
+            displayName: Canvas Endpoint
+            description: Internal service endpoint for the OpenClaw canvas UI
+            x-descriptors:
+              - "urn:alm:descriptor:text"
+          - path: observedGeneration
+            displayName: Observed Generation
+            description: Most recent generation observed by the controller
+            x-descriptors:
+              - "urn:alm:descriptor:text"
+          - path: lastBackupTime
+            displayName: Last Backup
+            description: Timestamp of last successful backup
+            x-descriptors:
+              - "urn:alm:descriptor:text"
+          - path: lastBackupPath
+            displayName: Last Backup Path
+            description: Storage path of the last successful backup
+            x-descriptors:
+              - "urn:alm:descriptor:text"
+          - path: autoUpdate.latestVersion
+            displayName: Latest Available Version
+            description: Latest version available in the OCI registry
+            x-descriptors:
+              - "urn:alm:descriptor:text"
+        resources:
+          - kind: StatefulSet
+            version: v1
+          - kind: Service
+            version: v1
+          - kind: ServiceAccount
+            version: v1
+          - kind: ConfigMap
+            version: v1
+          - kind: PersistentVolumeClaim
+            version: v1
+          - kind: NetworkPolicy
+            version: v1
+          - kind: PodDisruptionBudget
+            version: v1
+          - kind: Ingress
+            version: v1
+          - kind: Role
+            version: v1
+          - kind: RoleBinding
+            version: v1
+          - kind: ServiceMonitor
+            version: v1
+          - kind: Job
+            version: v1
+      - name: openclawselfconfigs.openclaw.rocks
+        version: v1alpha1
+        kind: OpenClawSelfConfig
+        displayName: OpenClaw Self Config
+        description: Namespaced request that lets an OpenClaw agent propose scoped, operator-gated changes to its own OpenClawInstance (skills, env vars, workspace files, config patch).
+      - name: openclawclusterdefaults.openclaw.rocks
+        version: v1alpha1
+        kind: OpenClawClusterDefaults
+        displayName: OpenClaw Cluster Defaults
+        description: Cluster-scoped singleton (named "cluster") whose spec is merged into every OpenClawInstance at reconcile time; per-instance fields always win.
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+        - serviceAccountName: openclaw-operator-controller-manager
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - persistentvolumeclaims
+                - serviceaccounts
+                - services
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - events
+              verbs:
+                - create
+                - patch
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+              verbs:
+                - list
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+              verbs:
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - apps
+              resources:
+                - statefulsets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - batch
+              resources:
+                - jobs
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - monitoring.coreos.com
+              resources:
+                - servicemonitors
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - gateway.networking.k8s.io
+              resources:
+                - httproutes
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - networking.k8s.io
+              resources:
+                - ingresses
+                - networkpolicies
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - openclaw.rocks
+              resources:
+                - openclawinstances
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - openclaw.rocks
+              resources:
+                - openclawinstances/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - openclaw.rocks
+              resources:
+                - openclawinstances/status
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - policy
+              resources:
+                - poddisruptionbudgets
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - rbac.authorization.k8s.io
+              resources:
+                - rolebindings
+                - roles
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            # Leader election
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+            - apiGroups:
+                - coordination.k8s.io
+              resources:
+                - leases
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - patch
+                - delete
+      deployments:
+        - name: openclaw-operator-controller-manager
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                control-plane: controller-manager
+            template:
+              metadata:
+                annotations:
+                  kubectl.kubernetes.io/default-container: manager
+                labels:
+                  control-plane: controller-manager
+              spec:
+                securityContext:
+                  runAsNonRoot: true
+                  seccompProfile:
+                    type: RuntimeDefault
+                serviceAccountName: openclaw-operator-controller-manager
+                terminationGracePeriodSeconds: 10
+                containers:
+                  - name: manager
+                    image: ghcr.io/paperclipinc/openclaw-operator@sha256:38e0da31c5205a95486bad1e321050263f2c11042f602245926e96f83fc1a152
+                    command:
+                      - /manager
+                    args:
+                      - --leader-elect
+                      - --health-probe-bind-address=:8081
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      readOnlyRootFilesystem: true
+                      runAsNonRoot: true
+                    livenessProbe:
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 15
+                      periodSeconds: 20
+                    readinessProbe:
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                    resources:
+                      limits:
+                        cpu: 500m
+                        memory: 256Mi
+                      requests:
+                        cpu: 100m
+                        memory: 128Mi

--- a/operators/openclaw-operator/0.40.0/manifests/openclaw.rocks_openclawclusterdefaults.yaml
+++ b/operators/openclaw-operator/0.40.0/manifests/openclaw.rocks_openclawclusterdefaults.yaml
@@ -1,0 +1,367 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: openclawclusterdefaults.openclaw.rocks
+spec:
+  group: openclaw.rocks
+  names:
+    kind: OpenClawClusterDefaults
+    listKind: OpenClawClusterDefaultsList
+    plural: openclawclusterdefaults
+    shortNames:
+    - occd
+    singular: openclawclusterdefaults
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.registry
+      name: Registry
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          OpenClawClusterDefaults is a cluster-scoped singleton (name must be "cluster")
+          that provides default values merged into every OpenClawInstance at reconcile
+          time. It exists so platform operators managing air-gapped or restricted-network
+          environments can set a single source of truth for image registry mirrors,
+          shared environment variables (e.g. NPM_CONFIG_REGISTRY, PIP_INDEX_URL), and
+          runtime-dep init containers without duplicating the same boilerplate in every
+          OpenClawInstance manifest.
+
+          Precedence: per-instance fields always win over cluster defaults. A default
+          is only applied when the corresponding instance field is unset.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              OpenClawClusterDefaultsSpec defines cluster-wide defaults that the operator
+              applies to every OpenClawInstance at reconcile time. Per-instance fields
+              always win: a default is only applied when the instance field is unset.
+            properties:
+              env:
+                description: |-
+                  Env is a list of default environment variables merged into every
+                  instance's container env. Instance-level env entries with the same Name
+                  override the cluster default for that name. Defaults appear first in
+                  the resulting env list, followed by instance-only names.
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              image:
+                description: |-
+                  Image is the default container image configuration applied to instances
+                  where the corresponding instance fields are unset. Each sub-field is
+                  merged independently (e.g. a cluster-default tag still applies even when
+                  the instance sets its own repository).
+                properties:
+                  digest:
+                    description: Digest is the container image digest (overrides tag
+                      if specified)
+                    type: string
+                  pullPolicy:
+                    default: IfNotPresent
+                    description: PullPolicy specifies when to pull the image
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  pullSecrets:
+                    description: PullSecrets is a list of secret names for pulling
+                      from private registries
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  repository:
+                    default: ghcr.io/openclaw/openclaw
+                    description: Repository is the container image repository
+                    type: string
+                  tag:
+                    default: latest
+                    description: Tag is the container image tag
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: 'spec.image: one of tag or digest must be set (pinning
+                    to an empty tag is not supported, pick a specific upstream release
+                    tag or a digest)'
+                  rule: (has(self.tag) && size(self.tag) > 0) || (has(self.digest)
+                    && size(self.digest) > 0)
+              registry:
+                description: |-
+                  Registry is the default container image registry override applied to
+                  instances where spec.registry is unset. Replaces the registry prefix of
+                  all container images (main, sidecars, init containers).
+                  Example: "my-registry.example.com".
+                type: string
+              runtimeDeps:
+                description: |-
+                  RuntimeDeps configures the default set of built-in init containers
+                  (pnpm, Python) applied to instances where the corresponding fields are
+                  unset. A cluster default of true for a runtime dep is always applied
+                  unless the instance explicitly opts out (sets the field to false).
+                  NOTE: because the enablement fields are plain booleans, "unset" and
+                  "false" are indistinguishable; those fields are OR-merged here. UVImage
+                  follows normal precedence and applies only when the instance omits it.
+                properties:
+                  pnpm:
+                    description: Pnpm installs pnpm via corepack for npm-based MCP
+                      servers and skills.
+                    type: boolean
+                  python:
+                    description: Python installs Python 3.12 and uv for Python-based
+                      MCP servers and skills.
+                    type: boolean
+                  uvImage:
+                    description: |-
+                      UVImage configures the uv bootstrap image used by the built-in init-uv
+                      and init-python containers.
+                    properties:
+                      digest:
+                        description: |-
+                          Digest is the container image digest for supply chain security.
+                          When set, it takes precedence over Tag.
+                        type: string
+                      repository:
+                        default: ghcr.io/astral-sh/uv
+                        description: Repository is the container image repository.
+                        type: string
+                      tag:
+                        default: 0.6-bookworm-slim
+                        description: Tag is the container image tag.
+                        type: string
+                    type: object
+                type: object
+            type: object
+          status:
+            description: |-
+              OpenClawClusterDefaultsStatus reports which singleton (if any) is currently
+              being applied by the operator.
+            properties:
+              conditions:
+                description: |-
+                  Conditions describes the current state of the singleton, including
+                  whether the name matches the expected "cluster" singleton.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                description: |-
+                  ObservedGeneration is the generation of the spec most recently
+                  processed by the operator.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/openclaw-operator/0.40.0/manifests/openclaw.rocks_openclawinstances.yaml
+++ b/operators/openclaw-operator/0.40.0/manifests/openclaw.rocks_openclawinstances.yaml
@@ -1,0 +1,10431 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: openclawinstances.openclaw.rocks
+spec:
+  group: openclaw.rocks
+  names:
+    kind: OpenClawInstance
+    listKind: OpenClawInstanceList
+    plural: openclawinstances
+    singular: openclawinstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .status.gatewayEndpoint
+      name: Gateway
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpenClawInstance is the Schema for the openclawinstances API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenClawInstanceSpec defines the desired state of OpenClawInstance
+            properties:
+              autoUpdate:
+                description: AutoUpdate configures automatic version updates from
+                  the OCI registry
+                properties:
+                  backupBeforeUpdate:
+                    default: true
+                    description: BackupBeforeUpdate creates a backup before applying
+                      updates
+                    type: boolean
+                  checkInterval:
+                    default: 24h
+                    description: |-
+                      CheckInterval is how often to check for new versions (Go duration, e.g. "24h")
+                      Minimum: 1h, Maximum: 168h (7 days)
+                    type: string
+                  enabled:
+                    default: false
+                    description: Enabled enables automatic version updates
+                    type: boolean
+                  healthCheckTimeout:
+                    default: 10m
+                    description: |-
+                      HealthCheckTimeout is how long to wait for the updated pod to become ready
+                      before triggering a rollback (Go duration, e.g. "10m")
+                      Minimum: 2m, Maximum: 30m
+                    type: string
+                  rollbackOnFailure:
+                    default: true
+                    description: |-
+                      RollbackOnFailure automatically reverts to the previous version if the
+                      updated pod fails to become ready within HealthCheckTimeout
+                    type: boolean
+                type: object
+              availability:
+                description: Availability configures high availability settings
+                properties:
+                  affinity:
+                    description: Affinity specifies affinity scheduling rules
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for
+                          the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the
+                                    corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g.
+                          co-locate this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules
+                          (e.g. avoid putting this pod in the same node, zone, etc.
+                          as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
+                  autoScaling:
+                    description: AutoScaling configures horizontal pod auto-scaling
+                    properties:
+                      enabled:
+                        default: false
+                        description: Enabled enables HorizontalPodAutoscaler creation
+                        type: boolean
+                      maxReplicas:
+                        default: 5
+                        description: MaxReplicas is the upper limit for the number
+                          of replicas
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      minReplicas:
+                        default: 1
+                        description: MinReplicas is the lower limit for the number
+                          of replicas
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      targetCPUUtilization:
+                        default: 80
+                        description: TargetCPUUtilization is the target average CPU
+                          utilization (percentage)
+                        format: int32
+                        maximum: 100
+                        minimum: 1
+                        type: integer
+                      targetMemoryUtilization:
+                        description: |-
+                          TargetMemoryUtilization is the target average memory utilization (percentage).
+                          When not set, only CPU-based scaling is used.
+                        format: int32
+                        maximum: 100
+                        minimum: 1
+                        type: integer
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector is a selector which must match a node's
+                      labels for the pod to be scheduled
+                    type: object
+                  podDisruptionBudget:
+                    description: PodDisruptionBudget configures the PDB
+                    properties:
+                      enabled:
+                        default: true
+                        description: Enabled enables PDB creation
+                        type: boolean
+                      maxUnavailable:
+                        default: 1
+                        description: MaxUnavailable is the maximum number of pods
+                          that can be unavailable during disruption
+                        format: int32
+                        type: integer
+                    type: object
+                  runtimeClassName:
+                    description: |-
+                      RuntimeClassName refers to a RuntimeClass object in the cluster,
+                      which should be used to run this pod.
+                      If no RuntimeClass resource matches the named class, the pod will not be run.
+                      If unset or empty, the default container runtime is used.
+                      More info: https://kubernetes.io/docs/concepts/containers/runtime-class/
+                    type: string
+                  tolerations:
+                    description: Tolerations are tolerations for pod scheduling
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    description: TopologySpreadConstraints describes how pods should
+                      spread across topology domains
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread
+                        matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: |-
+                            LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine the number of pods
+                            in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        matchLabelKeys:
+                          description: |-
+                            MatchLabelKeys is a set of pod label keys to select the pods over which
+                            spreading will be calculated. The keys are used to lookup values from the
+                            incoming pod labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading will be calculated
+                            for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                            MatchLabelKeys cannot be set when LabelSelector isn't set.
+                            Keys that don't exist in the incoming pod labels will
+                            be ignored. A null or empty list means only match against labelSelector.
+
+                            This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          description: |-
+                            MaxSkew describes the degree to which pods may be unevenly distributed.
+                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                            between the number of matching pods in the target topology and the global minimum.
+                            The global minimum is the minimum number of matching pods in an eligible domain
+                            or zero if the number of eligible domains is less than MinDomains.
+                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                            labelSelector spread as 2/2/1:
+                            In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 |
+                            |  P P  |  P P  |   P   |
+                            - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                            scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                            violate MaxSkew(1).
+                            - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                            When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                            to topologies that satisfy it.
+                            It's a required field. Default value is 1 and 0 is not allowed.
+                          format: int32
+                          type: integer
+                        minDomains:
+                          description: |-
+                            MinDomains indicates a minimum number of eligible domains.
+                            When the number of eligible domains with matching topology keys is less than minDomains,
+                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                            And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                            this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less than minDomains,
+                            scheduler won't schedule more than maxSkew Pods to those domains.
+                            If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                            Valid values are integers greater than 0.
+                            When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                            For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                            labelSelector spread as 2/2/2:
+                            | zone1 | zone2 | zone3 |
+                            |  P P  |  P P  |  P P  |
+                            The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                            In this situation, new pod with the same labelSelector cannot be scheduled,
+                            because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew.
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: |-
+                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                            when calculating pod topology spread skew. Options are:
+                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                            If this value is nil, the behavior is equivalent to the Honor policy.
+                            This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                          type: string
+                        nodeTaintsPolicy:
+                          description: |-
+                            NodeTaintsPolicy indicates how we will treat node taints when calculating
+                            pod topology spread skew. Options are:
+                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                            has a toleration, are included.
+                            - Ignore: node taints are ignored. All nodes are included.
+
+                            If this value is nil, the behavior is equivalent to the Ignore policy.
+                            This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                          type: string
+                        topologyKey:
+                          description: |-
+                            TopologyKey is the key of node labels. Nodes that have a label with this key
+                            and identical values are considered to be in the same topology.
+                            We consider each <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket.
+                            We define a domain as a particular instance of a topology.
+                            Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                            nodeAffinityPolicy and nodeTaintsPolicy.
+                            e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                            And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                            It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: |-
+                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                            the spread constraint.
+                            - DoNotSchedule (default) tells the scheduler not to schedule it.
+                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                              but giving higher precedence to topologies that would help reduce the
+                              skew.
+                            A constraint is considered "Unsatisfiable" for an incoming pod
+                            if and only if every possible node assignment for that pod would violate
+                            "MaxSkew" on some topology.
+                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                            labelSelector spread as 3/1/1:
+                            | zone1 | zone2 | zone3 |
+                            | P P P |   P   |   P   |
+                            If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                            to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                            MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                            won't make it *more* imbalanced.
+                            It's a required field.
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                type: object
+              backup:
+                description: |-
+                  Backup configures periodic scheduled backups to S3-compatible storage.
+                  Requires the s3-backup-credentials Secret in the operator namespace and persistence enabled.
+                properties:
+                  failedHistoryLimit:
+                    default: 1
+                    description: FailedHistoryLimit is the number of failed CronJob
+                      runs to retain.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  historyLimit:
+                    default: 3
+                    description: HistoryLimit is the number of successful CronJob
+                      runs to retain.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  retentionDays:
+                    default: 7
+                    description: |-
+                      RetentionDays is the number of days to keep daily snapshots in S3.
+                      The periodic backup syncs incrementally to a fixed "latest" path and
+                      takes a daily snapshot. Snapshots older than RetentionDays are pruned
+                      after each successful backup.
+                    format: int32
+                    maximum: 365
+                    minimum: 1
+                    type: integer
+                  schedule:
+                    description: |-
+                      Schedule is a cron expression for periodic backups (e.g., "0 2 * * *" for daily at 2 AM).
+                      When set, the operator creates a CronJob that runs rclone to sync PVC data to S3.
+                      Requires persistence to be enabled and the s3-backup-credentials Secret
+                      in the operator namespace.
+                    type: string
+                  serviceAccountName:
+                    description: |-
+                      ServiceAccountName is the name of the ServiceAccount to use for backup and restore Jobs.
+                      Use this to assign a cloud-provider workload identity ServiceAccount (e.g., AWS IRSA,
+                      GKE Workload Identity, AKS Workload Identity) so backup Jobs can authenticate to the
+                      storage backend without static credentials.
+                      When set, all backup Jobs (pre-delete, pre-update, periodic, and restore) use this SA.
+                    type: string
+                  timeout:
+                    description: |-
+                      Timeout is the maximum duration to wait for a pre-delete backup to complete
+                      before giving up and proceeding with deletion (Go duration string, e.g. "30m", "1h").
+                      Covers all phases: StatefulSet scale-down, pod termination, Job execution, and
+                      Job failure retries. When the timeout elapses the operator logs a warning,
+                      emits a BackupTimedOut event, and removes the finalizer so deletion can proceed.
+                      Minimum: 5m, Maximum: 24h, Default: 30m.
+                    type: string
+                type: object
+              chromium:
+                description: Chromium enables the Chromium sidecar for browser automation
+                properties:
+                  enabled:
+                    default: false
+                    description: Enabled enables the Chromium sidecar for browser
+                      automation
+                    type: boolean
+                  extraArgs:
+                    description: |-
+                      ExtraArgs specifies additional command-line arguments passed to the
+                      Chromium process. These are appended to the default arguments.
+                      Example: ["--disable-blink-features=AutomationControlled", "--user-agent=Mozilla/5.0 ..."]
+                    items:
+                      type: string
+                    type: array
+                  extraEnv:
+                    description: |-
+                      ExtraEnv specifies additional environment variables for the Chromium
+                      sidecar container, merged with the operator-managed variables.
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a
+                            C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Image configures the Chromium container image
+                    properties:
+                      digest:
+                        description: Digest is the container image digest for supply
+                          chain security
+                        type: string
+                      repository:
+                        default: docker.io/chromedp/headless-shell
+                        description: Repository is the container image repository
+                        type: string
+                      tag:
+                        default: stable
+                        description: Tag is the container image tag
+                        type: string
+                    type: object
+                  persistence:
+                    description: |-
+                      Persistence configures persistent storage for the Chromium browser profile.
+                      When enabled, browser state (cookies, localStorage, session tokens) survives
+                      pod restarts. When disabled (default), an emptyDir is used and all browser
+                      state is lost on restart.
+                    properties:
+                      enabled:
+                        default: false
+                        description: |-
+                          Enabled enables persistent storage for the Chromium browser profile.
+                          When true, a PVC is created (or an existing one is used) and mounted at
+                          /chromium-data. The --user-data-dir flag is set automatically so that
+                          cookies, localStorage, session tokens, and cached credentials survive
+                          pod restarts.
+                        type: boolean
+                      existingClaim:
+                        description: |-
+                          ExistingClaim is the name of a pre-existing PVC to use instead of
+                          creating a new one. When set, storageClass and size are ignored.
+                        type: string
+                      size:
+                        default: 1Gi
+                        description: Size is the requested storage size for the Chromium
+                          profile PVC.
+                        type: string
+                      storageClass:
+                        description: |-
+                          StorageClass is the name of the StorageClass to use for the PVC.
+                          If empty, the cluster default StorageClass is used.
+                        type: string
+                    type: object
+                  resources:
+                    description: Resources specifies compute resources for the Chromium
+                      container
+                    properties:
+                      limits:
+                        description: Limits describes the maximum amount of compute
+                          resources allowed
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                      requests:
+                        description: Requests describes the minimum amount of compute
+                          resources required
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              config:
+                description: Config specifies the OpenClaw configuration
+                properties:
+                  configMapRef:
+                    description: ConfigMapRef references a ConfigMap containing the
+                      openclaw.json configuration
+                    properties:
+                      key:
+                        default: openclaw.json
+                        description: Key in the ConfigMap to use
+                        type: string
+                      name:
+                        description: Name of the ConfigMap
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  forcePaths:
+                    description: |-
+                      ForcePaths is a list of dot-separated config paths (e.g. "gateway",
+                      "models.providers", "agents.defaults.sandbox") that the init container
+                      force-overwrites from the operator-managed config on every pod restart,
+                      even under mergeMode=merge. For each listed path, the subtree is first
+                      deleted from the existing PVC config and then re-applied via deep merge
+                      from spec.config.raw, so the final value matches the CR exactly.
+
+                      Use case: a managed deployer (operator of a multi-tenant openclaw
+                      service) wants tenants to persist user-owned config across restarts
+                      (channels.telegram.botToken, settings, etc -- requires mergeMode=merge)
+                      but must guarantee that operator-owned paths (gateway auth tokens,
+                      allowed model providers, sandbox image) are always rebuilt from the CR.
+                      Without forcePaths, a tenant could persist e.g.
+                      models.providers.<rogue>.apiKey via the Control UI and route inference
+                      through their own third-party key while consuming the deployer's
+                      compute -- a verified attack path.
+
+                      Only applies when mergeMode=merge. Ignored (and rejected by the
+                      validating webhook) under mergeMode=overwrite, which already overwrites
+                      the entire config file on every restart.
+                    items:
+                      type: string
+                    maxItems: 20
+                    type: array
+                    x-kubernetes-list-type: set
+                  format:
+                    default: json
+                    description: |-
+                      Format specifies the config file format.
+                      "json" (default) expects standard JSON. "json5" accepts JSON5 (comments, trailing commas).
+                      JSON5 is converted to standard JSON by the init container using npx json5.
+                      JSON5 requires configMapRef (inline raw config must be valid JSON).
+                    enum:
+                    - json
+                    - json5
+                    type: string
+                  mergeMode:
+                    default: overwrite
+                    description: |-
+                      MergeMode controls how operator-managed config is applied to the PVC.
+                      "overwrite" replaces the config file on every pod restart.
+                      "merge" deep-merges operator config with existing PVC config, preserving runtime changes.
+                    enum:
+                    - overwrite
+                    - merge
+                    type: string
+                  raw:
+                    description: Raw is inline openclaw.json configuration (used if
+                      ConfigMapRef is not set)
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+              env:
+                description: Env is a list of environment variables to set in the
+                  container
+                items:
+                  description: EnvVar represents an environment variable present in
+                    a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: |-
+                        Variable references $(VAR_NAME) are expanded
+                        using the previously defined environment variables in the container and
+                        any service environment variables. If a variable cannot be resolved,
+                        the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                        Escaped references will never be expanded, regardless of whether the variable
+                        exists or not.
+                        Defaults to "".
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot
+                        be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key
+                                must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        fieldRef:
+                          description: |-
+                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is
+                                written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified
+                                API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        resourceFieldRef:
+                          description: |-
+                            Selects a resource of the container: only resources limits and requests
+                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes,
+                                optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed
+                                resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must
+                                be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              envFrom:
+                description: |-
+                  EnvFrom is a list of sources to populate environment variables from
+                  Use this for API keys and other secrets (e.g., ANTHROPIC_API_KEY, OPENAI_API_KEY)
+                items:
+                  description: EnvFromSource represents the source of a set of ConfigMaps
+                  properties:
+                    configMapRef:
+                      description: The ConfigMap to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the ConfigMap must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    prefix:
+                      description: An optional identifier to prepend to each key in
+                        the ConfigMap. Must be a C_IDENTIFIER.
+                      type: string
+                    secretRef:
+                      description: The Secret to select from
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: Specify whether the Secret must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                type: array
+              extraVolumeMounts:
+                description: |-
+                  ExtraVolumeMounts adds additional volume mounts to the main container.
+                  Use with ExtraVolumes to mount ConfigMaps, Secrets, NFS shares, or CSI volumes.
+                items:
+                  description: VolumeMount describes a mounting of a Volume within
+                    a container.
+                  properties:
+                    mountPath:
+                      description: |-
+                        Path within the container at which the volume should be mounted.  Must
+                        not contain ':'.
+                      type: string
+                    mountPropagation:
+                      description: |-
+                        mountPropagation determines how mounts are propagated from the host
+                        to container and the other way around.
+                        When not set, MountPropagationNone is used.
+                        This field is beta in 1.10.
+                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                        (which defaults to None).
+                      type: string
+                    name:
+                      description: This must match the Name of a Volume.
+                      type: string
+                    readOnly:
+                      description: |-
+                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                        Defaults to false.
+                      type: boolean
+                    recursiveReadOnly:
+                      description: |-
+                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                        recursively.
+
+                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                        recursively read-only, if it is supported by the container runtime.  If this
+                        field is set to Enabled, the mount is made recursively read-only if it is
+                        supported by the container runtime, otherwise the pod will not be started and
+                        an error will be generated to indicate the reason.
+
+                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                        None (or be unspecified, which defaults to None).
+
+                        If this field is not specified, it is treated as an equivalent of Disabled.
+                      type: string
+                    subPath:
+                      description: |-
+                        Path within the volume from which the container's volume should be mounted.
+                        Defaults to "" (volume's root).
+                      type: string
+                    subPathExpr:
+                      description: |-
+                        Expanded path within the volume from which the container's volume should be mounted.
+                        Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                        Defaults to "" (volume's root).
+                        SubPathExpr and SubPath are mutually exclusive.
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                maxItems: 10
+                type: array
+              extraVolumes:
+                description: |-
+                  ExtraVolumes adds additional volumes to the pod.
+                  These volumes are available to the main container via ExtraVolumeMounts.
+                items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
+                  properties:
+                    awsElasticBlockStore:
+                      description: |-
+                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          type: string
+                        partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
+                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: |-
+                            readOnly value true will force the readOnly setting in VolumeMounts.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          type: boolean
+                        volumeID:
+                          description: |-
+                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      description: azureDisk represents an Azure Data Disk mount on
+                        the host and bind mount to the pod.
+                      properties:
+                        cachingMode:
+                          description: 'cachingMode is the Host Caching mode: None,
+                            Read Only, Read Write.'
+                          type: string
+                        diskName:
+                          description: diskName is the Name of the data disk in the
+                            blob storage
+                          type: string
+                        diskURI:
+                          description: diskURI is the URI of data disk in the blob
+                            storage
+                          type: string
+                        fsType:
+                          default: ext4
+                          description: |-
+                            fsType is Filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        kind:
+                          description: 'kind expected values are Shared: multiple
+                            blob disks per storage account  Dedicated: single blob
+                            disk per storage account  Managed: azure managed data
+                            disk (only in managed availability set). defaults to shared'
+                          type: string
+                        readOnly:
+                          default: false
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      description: azureFile represents an Azure File Service mount
+                        on the host and bind mount to the pod.
+                      properties:
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretName:
+                          description: secretName is the  name of secret that contains
+                            Azure Storage Account Name and Key
+                          type: string
+                        shareName:
+                          description: shareName is the azure share Name
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    cephfs:
+                      description: cephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime
+                      properties:
+                        monitors:
+                          description: |-
+                            monitors is Required: Monitors is a collection of Ceph monitors
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        path:
+                          description: 'path is Optional: Used as the mounted root,
+                            rather than the full Ceph tree, default is /'
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          type: boolean
+                        secretFile:
+                          description: |-
+                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          type: string
+                        secretRef:
+                          description: |-
+                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          description: |-
+                            user is optional: User is the rados user name, default is admin
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      description: |-
+                        cinder represents a cinder volume attached and mounted on kubelets host machine.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef is optional: points to a secret object containing parameters used to connect
+                            to OpenStack.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeID:
+                          description: |-
+                            volumeID used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    configMap:
+                      description: configMap represents a configMap that should populate
+                        this volume
+                      properties:
+                        defaultMode:
+                          description: |-
+                            defaultMode is optional: mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                            Defaults to 0644.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        items:
+                          description: |-
+                            items if unspecified, each key-value pair in the Data field of the referenced
+                            ConfigMap will be projected into the volume as a file whose name is the
+                            key and content is the value. If specified, the listed keys will be
+                            projected into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in the ConfigMap,
+                            the volume setup will error unless it is marked optional. Paths must be
+                            relative and may not contain the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: key is the key to project.
+                                type: string
+                              mode:
+                                description: |-
+                                  mode is Optional: mode bits used to set permissions on this file.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  If not specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
+                                  May not start with the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: optional specify whether the ConfigMap or its
+                            keys must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    csi:
+                      description: csi (Container Storage Interface) represents ephemeral
+                        storage that is handled by certain external CSI drivers (Beta
+                        feature).
+                      properties:
+                        driver:
+                          description: |-
+                            driver is the name of the CSI driver that handles this volume.
+                            Consult with your admin for the correct name as registered in the cluster.
+                          type: string
+                        fsType:
+                          description: |-
+                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                            If not provided, the empty value is passed to the associated CSI driver
+                            which will determine the default filesystem to apply.
+                          type: string
+                        nodePublishSecretRef:
+                          description: |-
+                            nodePublishSecretRef is a reference to the secret object containing
+                            sensitive information to pass to the CSI driver to complete the CSI
+                            NodePublishVolume and NodeUnpublishVolume calls.
+                            This field is optional, and  may be empty if no secret is required. If the
+                            secret object contains more than one secret, all secret references are passed.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        readOnly:
+                          description: |-
+                            readOnly specifies a read-only configuration for the volume.
+                            Defaults to false (read/write).
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            volumeAttributes stores driver-specific properties that are passed to the CSI
+                            driver. Consult your driver's documentation for supported values.
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    downwardAPI:
+                      description: downwardAPI represents downward API about the pod
+                        that should populate this volume
+                      properties:
+                        defaultMode:
+                          description: |-
+                            Optional: mode bits to use on created files by default. Must be a
+                            Optional: mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                            Defaults to 0644.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        items:
+                          description: Items is a list of downward API volume file
+                          items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
+                            properties:
+                              fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name, namespace and uid
+                                  are supported.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              mode:
+                                description: |-
+                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                  between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  If not specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path. Must be utf-8 encoded.
+                                  The first item of the relative path must not start
+                                  with ''..'''
+                                type: string
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - path
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    emptyDir:
+                      description: |-
+                        emptyDir represents a temporary directory that shares a pod's lifetime.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                      properties:
+                        medium:
+                          description: |-
+                            medium represents what type of storage medium should back this directory.
+                            The default is "" which means to use the node's default medium.
+                            Must be an empty string (default) or Memory.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                            The size limit is also applicable for memory medium.
+                            The maximum usage on memory medium EmptyDir would be the minimum value between
+                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                            The default is nil which means that the limit is undefined.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    ephemeral:
+                      description: |-
+                        ephemeral represents a volume that is handled by a cluster storage driver.
+                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                        and deleted when the pod is removed.
+
+                        Use this if:
+                        a) the volume is only needed while the pod runs,
+                        b) features of normal volumes like restoring from snapshot or capacity
+                           tracking are needed,
+                        c) the storage driver is specified through a storage class, and
+                        d) the storage driver supports dynamic volume provisioning through
+                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                           information on the connection between this volume type
+                           and PersistentVolumeClaim).
+
+                        Use PersistentVolumeClaim or one of the vendor-specific
+                        APIs for volumes that persist for longer than the lifecycle
+                        of an individual pod.
+
+                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                        be used that way - see the documentation of the driver for
+                        more information.
+
+                        A pod can use both types of ephemeral volumes and
+                        persistent volumes at the same time.
+                      properties:
+                        volumeClaimTemplate:
+                          description: |-
+                            Will be used to create a stand-alone PVC to provision the volume.
+                            The pod in which this EphemeralVolumeSource is embedded will be the
+                            owner of the PVC, i.e. the PVC will be deleted together with the
+                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                            `<volume name>` is the name from the `PodSpec.Volumes` array
+                            entry. Pod validation will reject the pod if the concatenated name
+                            is not valid for a PVC (for example, too long).
+
+                            An existing PVC with that name that is not owned by the pod
+                            will *not* be used for the pod to avoid using an unrelated
+                            volume by mistake. Starting the pod is then blocked until
+                            the unrelated PVC is removed. If such a pre-created PVC is
+                            meant to be used by the pod, the PVC has to updated with an
+                            owner reference to the pod once the pod exists. Normally
+                            this should not be necessary, but it may be useful when
+                            manually reconstructing a broken cluster.
+
+                            This field is read-only and no changes will be made by Kubernetes
+                            to the PVC after it has been created.
+
+                            Required, must not be nil.
+                          properties:
+                            metadata:
+                              description: |-
+                                May contain labels and annotations that will be copied into the PVC
+                                when creating it. No other fields are allowed and will be rejected during
+                                validation.
+                              type: object
+                            spec:
+                              description: |-
+                                The specification for the PersistentVolumeClaim. The entire content is
+                                copied unchanged into the PVC that gets created from this
+                                template. The same fields as in a PersistentVolumeClaim
+                                are also valid here.
+                              properties:
+                                accessModes:
+                                  description: |-
+                                    accessModes contains the desired access modes the volume should have.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                dataSource:
+                                  description: |-
+                                    dataSource field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                    * An existing PVC (PersistentVolumeClaim)
+                                    If the provisioner or an external controller can support the specified data source,
+                                    it will create a new volume based on the contents of the specified data source.
+                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                  properties:
+                                    apiGroup:
+                                      description: |-
+                                        APIGroup is the group for the resource being referenced.
+                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                dataSourceRef:
+                                  description: |-
+                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                    volume is desired. This may be any object from a non-empty API group (non
+                                    core object) or a PersistentVolumeClaim object.
+                                    When this field is specified, volume binding will only succeed if the type of
+                                    the specified object matches some installed volume populator or dynamic
+                                    provisioner.
+                                    This field will replace the functionality of the dataSource field and as such
+                                    if both fields are non-empty, they must have the same value. For backwards
+                                    compatibility, when namespace isn't specified in dataSourceRef,
+                                    both fields (dataSource and dataSourceRef) will be set to the same
+                                    value automatically if one of them is empty and the other is non-empty.
+                                    When namespace is specified in dataSourceRef,
+                                    dataSource isn't set to the same value and must be empty.
+                                    There are three important differences between dataSource and dataSourceRef:
+                                    * While dataSource only allows two specific types of objects, dataSourceRef
+                                      allows any non-core object, as well as PersistentVolumeClaim objects.
+                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                      preserves all values, and generates an error if a disallowed value is
+                                      specified.
+                                    * While dataSource only allows local objects, dataSourceRef allows objects
+                                      in any namespaces.
+                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  properties:
+                                    apiGroup:
+                                      description: |-
+                                        APIGroup is the group for the resource being referenced.
+                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace of resource being referenced
+                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                resources:
+                                  description: |-
+                                    resources represents the minimum resources the volume should have.
+                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                    that are lower than previous value but must still be higher than capacity recorded in the
+                                    status field of the claim.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                  type: object
+                                selector:
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                storageClassName:
+                                  description: |-
+                                    storageClassName is the name of the StorageClass required by the claim.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                  type: string
+                                volumeAttributesClassName:
+                                  description: |-
+                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                    If specified, the CSI driver will create or update the volume with the attributes defined
+                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                    will be set by the persistentvolume controller if it exists.
+                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                    exists.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                                  type: string
+                                volumeMode:
+                                  description: |-
+                                    volumeMode defines what type of volume is required by the claim.
+                                    Value of Filesystem is implied when not included in claim spec.
+                                  type: string
+                                volumeName:
+                                  description: volumeName is the binding reference
+                                    to the PersistentVolume backing this claim.
+                                  type: string
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                      type: object
+                    fc:
+                      description: fc represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        lun:
+                          description: 'lun is Optional: FC target lun number'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        targetWWNs:
+                          description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        wwids:
+                          description: |-
+                            wwids Optional: FC volume world wide identifiers (wwids)
+                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    flexVolume:
+                      description: |-
+                        flexVolume represents a generic volume resource that is
+                        provisioned/attached using an exec based plugin.
+                      properties:
+                        driver:
+                          description: driver is the name of the driver to use for
+                            this volume.
+                          type: string
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: 'options is Optional: this field holds extra
+                            command options if any.'
+                          type: object
+                        readOnly:
+                          description: |-
+                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef is Optional: secretRef is reference to the secret object containing
+                            sensitive information to pass to the plugin scripts. This may be
+                            empty if no secret object is specified. If the secret object
+                            contains more than one secret, all secrets are passed to the plugin
+                            scripts.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      description: flocker represents a Flocker volume attached to
+                        a kubelet's host machine. This depends on the Flocker control
+                        service being running
+                      properties:
+                        datasetName:
+                          description: |-
+                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                            should be considered as deprecated
+                          type: string
+                        datasetUUID:
+                          description: datasetUUID is the UUID of the dataset. This
+                            is unique identifier of a Flocker dataset
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      description: |-
+                        gcePersistentDisk represents a GCE Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          type: string
+                        partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
+                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          format: int32
+                          type: integer
+                        pdName:
+                          description: |-
+                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    gitRepo:
+                      description: |-
+                        gitRepo represents a git repository at a particular revision.
+                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                        into the Pod's container.
+                      properties:
+                        directory:
+                          description: |-
+                            directory is the target directory name.
+                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                            git repository.  Otherwise, if specified, the volume will contain the git repository in
+                            the subdirectory with the given name.
+                          type: string
+                        repository:
+                          description: repository is the URL
+                          type: string
+                        revision:
+                          description: revision is the commit hash for the specified
+                            revision.
+                          type: string
+                      required:
+                      - repository
+                      type: object
+                    glusterfs:
+                      description: |-
+                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                      properties:
+                        endpoints:
+                          description: |-
+                            endpoints is the endpoint name that details Glusterfs topology.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                          type: string
+                        path:
+                          description: |-
+                            path is the Glusterfs volume path.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                            Defaults to false.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      description: |-
+                        hostPath represents a pre-existing file or directory on the host
+                        machine that is directly exposed to the container. This is generally
+                        used for system agents or other privileged things that are allowed
+                        to see the host machine. Most containers will NOT need this.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                      properties:
+                        path:
+                          description: |-
+                            path of the directory on the host.
+                            If the path is a symlink, it will follow the link to the real path.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          type: string
+                        type:
+                          description: |-
+                            type for HostPath Volume
+                            Defaults to ""
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    image:
+                      description: |-
+                        image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                        The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                        - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                        - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                        - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                        The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                        A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                        The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                        The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                        The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                      properties:
+                        pullPolicy:
+                          description: |-
+                            Policy for pulling OCI objects. Possible values are:
+                            Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                            Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                            IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          type: string
+                        reference:
+                          description: |-
+                            Required: Image or artifact reference to be used.
+                            Behaves in the same way as pod.spec.containers[*].image.
+                            Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                            More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management to default or override
+                            container images in workload controllers like Deployments and StatefulSets.
+                          type: string
+                      type: object
+                    iscsi:
+                      description: |-
+                        iscsi represents an ISCSI Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
+                        More info: https://examples.k8s.io/volumes/iscsi/README.md
+                      properties:
+                        chapAuthDiscovery:
+                          description: chapAuthDiscovery defines whether support iSCSI
+                            Discovery CHAP authentication
+                          type: boolean
+                        chapAuthSession:
+                          description: chapAuthSession defines whether support iSCSI
+                            Session CHAP authentication
+                          type: boolean
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          type: string
+                        initiatorName:
+                          description: |-
+                            initiatorName is the custom iSCSI Initiator Name.
+                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                            <target portal>:<volume name> will be created for the connection.
+                          type: string
+                        iqn:
+                          description: iqn is the target iSCSI Qualified Name.
+                          type: string
+                        iscsiInterface:
+                          default: default
+                          description: |-
+                            iscsiInterface is the interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
+                          type: string
+                        lun:
+                          description: lun represents iSCSI Target Lun number.
+                          format: int32
+                          type: integer
+                        portals:
+                          description: |-
+                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                            is other than default (typically TCP ports 860 and 3260).
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                          type: boolean
+                        secretRef:
+                          description: secretRef is the CHAP Secret for iSCSI target
+                            and initiator authentication
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        targetPortal:
+                          description: |-
+                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                            is other than default (typically TCP ports 860 and 3260).
+                          type: string
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      type: object
+                    name:
+                      description: |-
+                        name of the volume.
+                        Must be a DNS_LABEL and unique within the pod.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    nfs:
+                      description: |-
+                        nfs represents an NFS mount on the host that shares a pod's lifetime
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                      properties:
+                        path:
+                          description: |-
+                            path that is exported by the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the NFS export to be mounted with read-only permissions.
+                            Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          type: boolean
+                        server:
+                          description: |-
+                            server is the hostname or IP address of the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          type: string
+                      required:
+                      - path
+                      - server
+                      type: object
+                    persistentVolumeClaim:
+                      description: |-
+                        persistentVolumeClaimVolumeSource represents a reference to a
+                        PersistentVolumeClaim in the same namespace.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                      properties:
+                        claimName:
+                          description: |-
+                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    photonPersistentDisk:
+                      description: photonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        pdID:
+                          description: pdID is the ID that identifies Photon Controller
+                            persistent disk
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      description: portworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: |-
+                            fSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        volumeID:
+                          description: volumeID uniquely identifies a Portworx volume
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    projected:
+                      description: projected items for all in one resources secrets,
+                        configmaps, and downward API
+                      properties:
+                        defaultMode:
+                          description: |-
+                            defaultMode are the mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        sources:
+                          description: |-
+                            sources is the list of volume projections. Each entry in this list
+                            handles one source.
+                          items:
+                            description: |-
+                              Projection that may be projected along with other supported volume types.
+                              Exactly one of these fields must be set.
+                            properties:
+                              clusterTrustBundle:
+                                description: |-
+                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                  of ClusterTrustBundle objects in an auto-updating file.
+
+                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                  ClusterTrustBundle objects can either be selected by name, or by the
+                                  combination of signer name and a label selector.
+
+                                  Kubelet performs aggressive normalization of the PEM contents written
+                                  into the pod filesystem.  Esoteric PEM features such as inter-block
+                                  comments and block headers are stripped.  Certificates are deduplicated.
+                                  The ordering of certificates within the file is arbitrary, and Kubelet
+                                  may change the order over time.
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this label selector.  Only has
+                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                      interpreted as "match nothing".  If set but empty, interpreted as "match
+                                      everything".
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  name:
+                                    description: |-
+                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                      with signerName and labelSelector.
+                                    type: string
+                                  optional:
+                                    description: |-
+                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                      aren't available.  If using name, then the named ClusterTrustBundle is
+                                      allowed not to exist.  If using signerName, then the combination of
+                                      signerName and labelSelector is allowed to match zero
+                                      ClusterTrustBundles.
+                                    type: boolean
+                                  path:
+                                    description: Relative path from the volume root
+                                      to write the bundle.
+                                    type: string
+                                  signerName:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this signer name.
+                                      Mutually-exclusive with name.  The contents of all selected
+                                      ClusterTrustBundles will be unified and deduplicated.
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              configMap:
+                                description: configMap information about the configMap
+                                  data to project
+                                properties:
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              downwardAPI:
+                                description: downwardAPI information about the downwardAPI
+                                  data to project
+                                properties:
+                                  items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name, namespace and uid are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          description: |-
+                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                            between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              secret:
+                                description: secret information about the secret data
+                                  to project
+                                properties:
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: optional field specify whether the
+                                      Secret or its key must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              serviceAccountToken:
+                                description: serviceAccountToken is information about
+                                  the serviceAccountToken data to project
+                                properties:
+                                  audience:
+                                    description: |-
+                                      audience is the intended audience of the token. A recipient of a token
+                                      must identify itself with an identifier specified in the audience of the
+                                      token, and otherwise should reject the token. The audience defaults to the
+                                      identifier of the apiserver.
+                                    type: string
+                                  expirationSeconds:
+                                    description: |-
+                                      expirationSeconds is the requested duration of validity of the service
+                                      account token. As the token approaches expiration, the kubelet volume
+                                      plugin will proactively rotate the service account token. The kubelet will
+                                      start trying to rotate the token if the token is older than 80 percent of
+                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                      and must be at least 10 minutes.
+                                    format: int64
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the path relative to the mount point of the file to project the
+                                      token into.
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    quobyte:
+                      description: quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime
+                      properties:
+                        group:
+                          description: |-
+                            group to map volume access to
+                            Default is no group
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                            Defaults to false.
+                          type: boolean
+                        registry:
+                          description: |-
+                            registry represents a single or multiple Quobyte Registry services
+                            specified as a string as host:port pair (multiple entries are separated with commas)
+                            which acts as the central registry for volumes
+                          type: string
+                        tenant:
+                          description: |-
+                            tenant owning the given Quobyte volume in the Backend
+                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                          type: string
+                        user:
+                          description: |-
+                            user to map volume access to
+                            Defaults to serivceaccount user
+                          type: string
+                        volume:
+                          description: volume is a string that references an already
+                            created Quobyte volume by name.
+                          type: string
+                      required:
+                      - registry
+                      - volume
+                      type: object
+                    rbd:
+                      description: |-
+                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          type: string
+                        image:
+                          description: |-
+                            image is the rados image name.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                        keyring:
+                          default: /etc/ceph/keyring
+                          description: |-
+                            keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                        monitors:
+                          description: |-
+                            monitors is a collection of Ceph monitors.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        pool:
+                          default: rbd
+                          description: |-
+                            pool is the rados pool name.
+                            Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef is name of the authentication secret for RBDUser. If provided
+                            overrides keyring.
+                            Default is nil.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          default: admin
+                          description: |-
+                            user is the rados user name.
+                            Default is admin.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                      required:
+                      - image
+                      - monitors
+                      type: object
+                    scaleIO:
+                      description: scaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          default: xfs
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs".
+                            Default is "xfs".
+                          type: string
+                        gateway:
+                          description: gateway is the host address of the ScaleIO
+                            API Gateway.
+                          type: string
+                        protectionDomain:
+                          description: protectionDomain is the name of the ScaleIO
+                            Protection Domain for the configured storage.
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef references to the secret for ScaleIO user and other
+                            sensitive information. If this is not provided, Login operation will fail.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        sslEnabled:
+                          description: sslEnabled Flag enable/disable SSL communication
+                            with Gateway, default false
+                          type: boolean
+                        storageMode:
+                          default: ThinProvisioned
+                          description: |-
+                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                            Default is ThinProvisioned.
+                          type: string
+                        storagePool:
+                          description: storagePool is the ScaleIO Storage Pool associated
+                            with the protection domain.
+                          type: string
+                        system:
+                          description: system is the name of the storage system as
+                            configured in ScaleIO.
+                          type: string
+                        volumeName:
+                          description: |-
+                            volumeName is the name of a volume already created in the ScaleIO system
+                            that is associated with this volume source.
+                          type: string
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      type: object
+                    secret:
+                      description: |-
+                        secret represents a secret that should populate this volume.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                      properties:
+                        defaultMode:
+                          description: |-
+                            defaultMode is Optional: mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values
+                            for mode bits. Defaults to 0644.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        items:
+                          description: |-
+                            items If unspecified, each key-value pair in the Data field of the referenced
+                            Secret will be projected into the volume as a file whose name is the
+                            key and content is the value. If specified, the listed keys will be
+                            projected into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in the Secret,
+                            the volume setup will error unless it is marked optional. Paths must be
+                            relative and may not contain the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: key is the key to project.
+                                type: string
+                              mode:
+                                description: |-
+                                  mode is Optional: mode bits used to set permissions on this file.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  If not specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
+                                  May not start with the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        optional:
+                          description: optional field specify whether the Secret or
+                            its keys must be defined
+                          type: boolean
+                        secretName:
+                          description: |-
+                            secretName is the name of the secret in the pod's namespace to use.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                          type: string
+                      type: object
+                    storageos:
+                      description: storageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef specifies the secret to use for obtaining the StorageOS API
+                            credentials.  If not specified, default values will be attempted.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeName:
+                          description: |-
+                            volumeName is the human-readable name of the StorageOS volume.  Volume
+                            names are only unique within a namespace.
+                          type: string
+                        volumeNamespace:
+                          description: |-
+                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                            namespace is specified then the Pod's namespace will be used.  This allows the
+                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                            Set VolumeName to any name to override the default behaviour.
+                            Set to "default" if you are not using namespaces within StorageOS.
+                            Namespaces that do not pre-exist within StorageOS will be created.
+                          type: string
+                      type: object
+                    vsphereVolume:
+                      description: vsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        storagePolicyID:
+                          description: storagePolicyID is the storage Policy Based
+                            Management (SPBM) profile ID associated with the StoragePolicyName.
+                          type: string
+                        storagePolicyName:
+                          description: storagePolicyName is the storage Policy Based
+                            Management (SPBM) profile name.
+                          type: string
+                        volumePath:
+                          description: volumePath is the path that identifies vSphere
+                            volume vmdk
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  required:
+                  - name
+                  type: object
+                maxItems: 10
+                type: array
+              gateway:
+                description: Gateway configures the gateway reverse proxy and authentication
+                  token
+                properties:
+                  controlUiOrigins:
+                    description: |-
+                      ControlUiOrigins is a list of additional allowed origins for the Control UI.
+                      The operator always auto-injects localhost origins (http://localhost:18789,
+                      http://127.0.0.1:18789) and derives origins from ingress hosts. Use this
+                      field to add extra origins (e.g., custom reverse proxy URLs).
+                    items:
+                      type: string
+                    maxItems: 20
+                    type: array
+                  enabled:
+                    default: true
+                    description: |-
+                      Enabled controls whether the built-in gateway reverse proxy sidecar is
+                      injected into the pod. When false, no proxy container is added and health
+                      probes target the OpenClaw gateway directly on port 18789.
+                      Defaults to true.
+                    type: boolean
+                  existingSecret:
+                    description: |-
+                      ExistingSecret is the name of a user-managed Secret containing the gateway token.
+                      The Secret must have a key named "token". When set, the operator skips
+                      auto-generating a gateway token Secret and uses this Secret instead.
+                    type: string
+                  image:
+                    description: Image configures the built-in gateway proxy container
+                      image.
+                    properties:
+                      digest:
+                        description: |-
+                          Digest is the container image digest for supply chain security.
+                          When set, it takes precedence over Tag.
+                        type: string
+                      repository:
+                        default: docker.io/library/nginx
+                        description: Repository is the container image repository.
+                        type: string
+                      tag:
+                        default: 1.27-alpine
+                        description: Tag is the container image tag.
+                        type: string
+                    type: object
+                  resources:
+                    description: Resources specifies compute resources for the built-in
+                      gateway proxy.
+                    properties:
+                      limits:
+                        description: Limits describes the maximum amount of compute
+                          resources allowed
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                      requests:
+                        description: Requests describes the minimum amount of compute
+                          resources required
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              image:
+                description: Image configuration for the OpenClaw container
+                properties:
+                  digest:
+                    description: Digest is the container image digest (overrides tag
+                      if specified)
+                    type: string
+                  pullPolicy:
+                    default: IfNotPresent
+                    description: PullPolicy specifies when to pull the image
+                    enum:
+                    - Always
+                    - IfNotPresent
+                    - Never
+                    type: string
+                  pullSecrets:
+                    description: PullSecrets is a list of secret names for pulling
+                      from private registries
+                    items:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  repository:
+                    default: ghcr.io/openclaw/openclaw
+                    description: Repository is the container image repository
+                    type: string
+                  tag:
+                    default: latest
+                    description: Tag is the container image tag
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: 'spec.image: one of tag or digest must be set (pinning
+                    to an empty tag is not supported, pick a specific upstream release
+                    tag or a digest)'
+                  rule: (has(self.tag) && size(self.tag) > 0) || (has(self.digest)
+                    && size(self.digest) > 0)
+              initContainers:
+                description: |-
+                  InitContainers is a list of additional init containers to run before the main container.
+                  They run after the operator-managed init-config and init-skills containers.
+                items:
+                  description: A single application container that you want to run
+                    within a pod.
+                  properties:
+                    args:
+                      description: |-
+                        Arguments to the entrypoint.
+                        The container image's CMD is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Cannot be updated.
+                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    command:
+                      description: |-
+                        Entrypoint array. Not executed within a shell.
+                        The container image's ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Cannot be updated.
+                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    env:
+                      description: |-
+                        List of environment variables to set in the container.
+                        Cannot be updated.
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any service environment variables. If a variable cannot be resolved,
+                              the reference in the input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                              Escaped references will never be expanded, regardless of whether the variable
+                              exists or not.
+                              Defaults to "".
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: |-
+                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    envFrom:
+                      description: |-
+                        List of sources to populate environment variables in the container.
+                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                        will be reported as an event when the container is starting. When a key exists in multiple
+                        sources, the value associated with the last source will take precedence.
+                        Values defined by an Env with a duplicate key will take precedence.
+                        Cannot be updated.
+                      items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          prefix:
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    image:
+                      description: |-
+                        Container image name.
+                        More info: https://kubernetes.io/docs/concepts/containers/images
+                        This field is optional to allow higher level config management to default or override
+                        container images in workload controllers like Deployments and StatefulSets.
+                      type: string
+                    imagePullPolicy:
+                      description: |-
+                        Image pull policy.
+                        One of Always, Never, IfNotPresent.
+                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                        Cannot be updated.
+                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                      type: string
+                    lifecycle:
+                      description: |-
+                        Actions that the management system should take in response to container lifecycle events.
+                        Cannot be updated.
+                      properties:
+                        postStart:
+                          description: |-
+                            PostStart is called immediately after a container is created. If the handler fails,
+                            the container is terminated and restarted according to its restart policy.
+                            Other management of the container blocks until the hook completes.
+                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            sleep:
+                              description: Sleep represents the duration that the
+                                container should sleep before being terminated.
+                              properties:
+                                seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - seconds
+                              type: object
+                            tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for the backward compatibility. There are no validation of this field and
+                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                          type: object
+                        preStop:
+                          description: |-
+                            PreStop is called immediately before a container is terminated due to an
+                            API request or management event such as liveness/startup probe failure,
+                            preemption, resource contention, etc. The handler is not called if the
+                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                            container will eventually terminate within the Pod's termination grace
+                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                            or until the termination grace period is reached.
+                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            sleep:
+                              description: Sleep represents the duration that the
+                                container should sleep before being terminated.
+                              properties:
+                                seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - seconds
+                              type: object
+                            tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for the backward compatibility. There are no validation of this field and
+                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                          type: object
+                      type: object
+                    livenessProbe:
+                      description: |-
+                        Periodic probe of container liveness.
+                        Container will be restarted if the probe fails.
+                        Cannot be updated.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                a shell, you need to explicitly call out to that shell.
+                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                If this is not specified, the default behavior is defined by gRPC.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: |-
+                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                            The grace period is the duration in seconds after the processes running in the pod are sent
+                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                            Set this value longer than the expected cleanup time for your process.
+                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                            value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates stop immediately via
+                            the kill signal (no opportunity to shut down).
+                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                      type: object
+                    name:
+                      description: |-
+                        Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
+                      type: string
+                    ports:
+                      description: |-
+                        List of ports to expose from the container. Not specifying a port here
+                        DOES NOT prevent that port from being exposed. Any port which is
+                        listening on the default "0.0.0.0" address inside a container will be
+                        accessible from the network.
+                        Modifying this array with strategic merge patch may corrupt the data.
+                        For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                        Cannot be updated.
+                      items:
+                        description: ContainerPort represents a network port in a
+                          single container.
+                        properties:
+                          containerPort:
+                            description: |-
+                              Number of port to expose on the pod's IP address.
+                              This must be a valid port number, 0 < x < 65536.
+                            format: int32
+                            type: integer
+                          hostIP:
+                            description: What host IP to bind the external port to.
+                            type: string
+                          hostPort:
+                            description: |-
+                              Number of port to expose on the host.
+                              If specified, this must be a valid port number, 0 < x < 65536.
+                              If HostNetwork is specified, this must match ContainerPort.
+                              Most containers do not need this.
+                            format: int32
+                            type: integer
+                          name:
+                            description: |-
+                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                              named port in a pod must have a unique name. Name for the port that can be
+                              referred to by services.
+                            type: string
+                          protocol:
+                            default: TCP
+                            description: |-
+                              Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
+                            type: string
+                        required:
+                        - containerPort
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - containerPort
+                      - protocol
+                      x-kubernetes-list-type: map
+                    readinessProbe:
+                      description: |-
+                        Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe fails.
+                        Cannot be updated.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                a shell, you need to explicitly call out to that shell.
+                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                If this is not specified, the default behavior is defined by gRPC.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: |-
+                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                            The grace period is the duration in seconds after the processes running in the pod are sent
+                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                            Set this value longer than the expected cleanup time for your process.
+                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                            value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates stop immediately via
+                            the kill signal (no opportunity to shut down).
+                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                      type: object
+                    resizePolicy:
+                      description: Resources resize policy for the container.
+                      items:
+                        description: ContainerResizePolicy represents resource resize
+                          policy for the container.
+                        properties:
+                          resourceName:
+                            description: |-
+                              Name of the resource to which this resource resize policy applies.
+                              Supported values: cpu, memory.
+                            type: string
+                          restartPolicy:
+                            description: |-
+                              Restart policy to apply when specified resource is resized.
+                              If not specified, it defaults to NotRequired.
+                            type: string
+                        required:
+                        - resourceName
+                        - restartPolicy
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    resources:
+                      description: |-
+                        Compute Resources required by this container.
+                        Cannot be updated.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This is an alpha field and requires enabling the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                    restartPolicy:
+                      description: |-
+                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                        This field may only be set for init containers, and the only allowed value is "Always".
+                        For non-init containers or when this field is not specified,
+                        the restart behavior is defined by the Pod's restart policy and the container type.
+                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                        this init container will be continually restarted on
+                        exit until all regular containers have terminated. Once all regular
+                        containers have completed, all init containers with restartPolicy "Always"
+                        will be shut down. This lifecycle differs from normal init containers and
+                        is often referred to as a "sidecar" container. Although this init
+                        container still starts in the init container sequence, it does not wait
+                        for the container to complete before proceeding to the next init
+                        container. Instead, the next init container starts immediately after this
+                        init container is started, or after any startupProbe has successfully
+                        completed.
+                      type: string
+                    securityContext:
+                      description: |-
+                        SecurityContext defines the security options the container should be run with.
+                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: |-
+                            AllowPrivilegeEscalation controls whether a process can gain more
+                            privileges than its parent process. This bool directly controls if
+                            the no_new_privs flag will be set on the container process.
+                            AllowPrivilegeEscalation is true always when the container is:
+                            1) run as Privileged
+                            2) has CAP_SYS_ADMIN
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                            overrides the pod's appArmorProfile.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile loaded on the node that should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must match the loaded name of the profile.
+                                Must be set if and only if type is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of AppArmor profile will be applied.
+                                Valid options are:
+                                  Localhost - a profile pre-loaded on the node.
+                                  RuntimeDefault - the container runtime's default profile.
+                                  Unconfined - no AppArmor enforcement.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        capabilities:
+                          description: |-
+                            The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by the container runtime.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        privileged:
+                          description: |-
+                            Run container in privileged mode.
+                            Processes in privileged containers are essentially equivalent to root on the host.
+                            Defaults to false.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        procMount:
+                          description: |-
+                            procMount denotes the type of proc mount to use for the containers.
+                            The default value is Default which uses the container runtime defaults for
+                            readonly paths and masked paths.
+                            This requires the ProcMountType feature flag to be enabled.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: |-
+                            Whether this container has a read-only root filesystem.
+                            Default is false.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: |-
+                            Indicates that the container must run as a non-root user.
+                            If true, the Kubelet will validate the image at runtime to ensure that it
+                            does not run as UID 0 (root) and fail to start the container if it does.
+                            If unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: |-
+                            The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a random SELinux context for each
+                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: |-
+                            The seccomp options to use by this container. If seccomp options are
+                            provided at both the pod & container level, the container options
+                            override the pod options.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied.
+                                Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used.
+                                RuntimeDefault - the container runtime default profile should be used.
+                                Unconfined - no profile should be applied.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options from the PodSecurityContext will be used.
+                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                GMSA credential spec named by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: |-
+                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                All of a Pod's containers must have the same effective HostProcess value
+                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: |-
+                                The UserName in Windows to run the entrypoint of the container process.
+                                Defaults to the user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    startupProbe:
+                      description: |-
+                        StartupProbe indicates that the Pod has successfully initialized.
+                        If specified, no other probes are executed until this completes successfully.
+                        If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                        This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                        when it might take a long time to load data or warm a cache, than during steady-state operation.
+                        This cannot be updated.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                a shell, you need to explicitly call out to that shell.
+                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                If this is not specified, the default behavior is defined by gRPC.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: |-
+                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                            The grace period is the duration in seconds after the processes running in the pod are sent
+                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                            Set this value longer than the expected cleanup time for your process.
+                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                            value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates stop immediately via
+                            the kill signal (no opportunity to shut down).
+                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                      type: object
+                    stdin:
+                      description: |-
+                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                        is not set, reads from stdin in the container will always result in EOF.
+                        Default is false.
+                      type: boolean
+                    stdinOnce:
+                      description: |-
+                        Whether the container runtime should close the stdin channel after it has been opened by
+                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                        at which time stdin is closed and remains closed until the container is restarted. If this
+                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                        Default is false
+                      type: boolean
+                    terminationMessagePath:
+                      description: |-
+                        Optional: Path at which the file to which the container's termination message
+                        will be written is mounted into the container's filesystem.
+                        Message written is intended to be brief final status, such as an assertion failure message.
+                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                        all containers will be limited to 12kb.
+                        Defaults to /dev/termination-log.
+                        Cannot be updated.
+                      type: string
+                    terminationMessagePolicy:
+                      description: |-
+                        Indicate how the termination message should be populated. File will use the contents of
+                        terminationMessagePath to populate the container status message on both success and failure.
+                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                        message file is empty and the container exited with an error.
+                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                        Defaults to File.
+                        Cannot be updated.
+                      type: string
+                    tty:
+                      description: |-
+                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                        Default is false.
+                      type: boolean
+                    volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
+                      items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
+                        properties:
+                          devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
+                            type: string
+                          name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
+                            type: string
+                        required:
+                        - devicePath
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - devicePath
+                      x-kubernetes-list-type: map
+                    volumeMounts:
+                      description: |-
+                        Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
+                      items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
+                        properties:
+                          mountPath:
+                            description: |-
+                              Path within the container at which the volume should be mounted.  Must
+                              not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: |-
+                              mountPropagation determines how mounts are propagated from the host
+                              to container and the other way around.
+                              When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
+                              When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                              (which defaults to None).
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: |-
+                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                              Defaults to false.
+                            type: boolean
+                          recursiveReadOnly:
+                            description: |-
+                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                              recursively.
+
+                              If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                              If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                              recursively read-only.  If this field is set to IfPossible, the mount is made
+                              recursively read-only, if it is supported by the container runtime.  If this
+                              field is set to Enabled, the mount is made recursively read-only if it is
+                              supported by the container runtime, otherwise the pod will not be started and
+                              an error will be generated to indicate the reason.
+
+                              If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                              None (or be unspecified, which defaults to None).
+
+                              If this field is not specified, it is treated as an equivalent of Disabled.
+                            type: string
+                          subPath:
+                            description: |-
+                              Path within the volume from which the container's volume should be mounted.
+                              Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: |-
+                              Expanded path within the volume from which the container's volume should be mounted.
+                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                              Defaults to "" (volume's root).
+                              SubPathExpr and SubPath are mutually exclusive.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - mountPath
+                      x-kubernetes-list-type: map
+                    workingDir:
+                      description: |-
+                        Container's working directory.
+                        If not specified, the container runtime's default will be used, which
+                        might be configured in the container image.
+                        Cannot be updated.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 10
+                type: array
+              netbird:
+                description: |-
+                  NetBird configures NetBird overlay network integration, a self-hostable
+                  alternative to Tailscale. At most one mesh provider (tailscale, netbird)
+                  may be enabled per instance.
+                properties:
+                  enabled:
+                    default: false
+                    description: Enabled enables the NetBird sidecar.
+                    type: boolean
+                  hostname:
+                    description: Hostname sets the NetBird peer name (defaults to
+                      the instance name).
+                    type: string
+                  image:
+                    description: Image configures the NetBird sidecar container image.
+                    properties:
+                      digest:
+                        description: Digest is the container image digest for supply
+                          chain security
+                        type: string
+                      repository:
+                        default: docker.io/netbirdio/netbird
+                        description: Repository is the container image repository
+                        type: string
+                      tag:
+                        default: latest
+                        description: Tag is the container image tag
+                        type: string
+                    type: object
+                  managementURL:
+                    description: |-
+                      ManagementURL points at a self-hosted NetBird management server, e.g.
+                      "https://netbird.example.com:33073". Defaults to NetBird's hosted
+                      control plane when unset.
+                    type: string
+                  resources:
+                    description: Resources specifies compute resources for the NetBird
+                      sidecar container.
+                    properties:
+                      limits:
+                        description: Limits describes the maximum amount of compute
+                          resources allowed
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                      requests:
+                        description: Requests describes the minimum amount of compute
+                          resources required
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                    type: object
+                  setupKeySecretKey:
+                    default: setupkey
+                    description: SetupKeySecretKey is the key in the referenced Secret.
+                    type: string
+                  setupKeySecretRef:
+                    description: |-
+                      SetupKeySecretRef references a Secret containing the NetBird setup key
+                      used to enroll this peer. The Secret must have a key matching
+                      SetupKeySecretKey (default: "setupkey"). Use a reusable, ephemeral setup
+                      key from the NetBird dashboard.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+              networking:
+                description: Networking specifies network-related configuration
+                properties:
+                  httpRoute:
+                    description: |-
+                      HTTPRoute configures a Gateway API HTTPRoute.
+                      This is an alternative to Ingress for clusters using the Gateway API
+                      (gateway.networking.k8s.io). The Gateway API CRDs must be installed.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations to add to the HTTPRoute
+                        type: object
+                      enabled:
+                        default: false
+                        description: Enabled enables HTTPRoute creation
+                        type: boolean
+                      hostnames:
+                        description: Hostnames specifies the hostnames matched by
+                          this HTTPRoute.
+                        items:
+                          type: string
+                        type: array
+                      parentRefs:
+                        description: |-
+                          ParentRefs specifies the Gateways this HTTPRoute attaches to.
+                          Each ref identifies a Gateway by name (and optionally namespace and sectionName).
+                        items:
+                          description: HTTPRouteParentRef identifies a Gateway that
+                            the HTTPRoute attaches to
+                          properties:
+                            name:
+                              description: Name is the name of the Gateway
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace is the namespace of the Gateway.
+                                Defaults to the same namespace as the HTTPRoute.
+                              type: string
+                            sectionName:
+                              description: SectionName is the name of a specific listener
+                                on the Gateway to attach to.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      port:
+                        description: |-
+                          Port is the backend Service port number to route traffic to.
+                          Defaults to the gateway port (18789) when not set.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                    type: object
+                  ingress:
+                    description: Ingress configures the Kubernetes Ingress
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations to add to the Ingress
+                        type: object
+                      className:
+                        description: ClassName is the name of the IngressClass to
+                          use
+                        type: string
+                      enabled:
+                        default: false
+                        description: Enabled enables Ingress creation
+                        type: boolean
+                      hosts:
+                        description: Hosts is a list of hosts to route traffic for
+                        items:
+                          description: IngressHost defines a host for the Ingress
+                          properties:
+                            host:
+                              description: Host is the fully qualified domain name
+                              type: string
+                            paths:
+                              description: Paths is a list of paths to route
+                              items:
+                                description: IngressPath defines a path for the Ingress
+                                properties:
+                                  path:
+                                    default: /
+                                    description: Path is the path to route
+                                    type: string
+                                  pathType:
+                                    default: Prefix
+                                    description: PathType determines how the path
+                                      should be matched
+                                    enum:
+                                    - Prefix
+                                    - Exact
+                                    - ImplementationSpecific
+                                    type: string
+                                  port:
+                                    description: |-
+                                      Port is the backend service port number to route traffic to.
+                                      Defaults to the gateway port (18789) when not set.
+                                    format: int32
+                                    maximum: 65535
+                                    minimum: 1
+                                    type: integer
+                                type: object
+                              type: array
+                          required:
+                          - host
+                          type: object
+                        type: array
+                      security:
+                        description: Security configures ingress security settings
+                        properties:
+                          basicAuth:
+                            description: |-
+                              BasicAuth configures HTTP Basic Authentication for the Ingress.
+                              Disabled by default. When enabled without an existingSecret, the operator
+                              auto-generates a random password and stores it in a managed Secret.
+                            properties:
+                              enabled:
+                                default: false
+                                description: Enabled enables basic authentication.
+                                type: boolean
+                              existingSecret:
+                                description: |-
+                                  ExistingSecret is the name of an existing Secret that already contains
+                                  htpasswd-formatted content in a key named "auth".
+                                  When set, the operator uses this Secret instead of generating one.
+                                type: string
+                              realm:
+                                default: OpenClaw
+                                description: Realm is the authentication realm shown
+                                  in browser prompts.
+                                type: string
+                              username:
+                                default: openclaw
+                                description: |-
+                                  Username for the auto-generated htpasswd Secret.
+                                  Ignored when existingSecret is set.
+                                maxLength: 64
+                                type: string
+                            type: object
+                          enableHSTS:
+                            default: true
+                            description: EnableHSTS enables HTTP Strict Transport
+                              Security
+                            type: boolean
+                          forceHTTPS:
+                            default: true
+                            description: ForceHTTPS redirects all HTTP traffic to
+                              HTTPS
+                            type: boolean
+                          rateLimiting:
+                            description: RateLimiting configures rate limiting
+                            properties:
+                              enabled:
+                                default: true
+                                description: Enabled enables rate limiting
+                                type: boolean
+                              requestsPerSecond:
+                                default: 10
+                                description: RequestsPerSecond is the maximum requests
+                                  per second
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      tls:
+                        description: TLS configuration
+                        items:
+                          description: IngressTLS defines TLS configuration for the
+                            Ingress
+                          properties:
+                            hosts:
+                              description: Hosts are a list of hosts included in the
+                                TLS certificate
+                              items:
+                                type: string
+                              type: array
+                            secretName:
+                              description: SecretName is the name of the secret containing
+                                the TLS certificate
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  metricsIngress:
+                    description: |-
+                      MetricsIngress controls who may reach the metrics port in the generated
+                      NetworkPolicy, independently of application traffic. When unset, the
+                      metrics port stays reachable from the instance's own namespace, which is
+                      the pre-existing behavior.
+                    properties:
+                      allowedCIDRs:
+                        description: |-
+                          AllowedCIDRs lists IP ranges allowed to reach the metrics port when From
+                          is AllowedPeers, for collectors that live outside the cluster.
+                        items:
+                          type: string
+                        type: array
+                      allowedNamespaces:
+                        description: |-
+                          AllowedNamespaces lists namespaces allowed to reach the metrics port when
+                          From is AllowedPeers.
+                        items:
+                          type: string
+                        type: array
+                      from:
+                        default: SameNamespace
+                        description: |-
+                          From selects which peers may reach the metrics port.
+
+                          SameNamespace (the default) allows the instance's own namespace, matching
+                          the behavior from before this field existed. AllowedPeers restricts access
+                          to the namespaces and CIDRs named below, which is the setting to use when
+                          only a Prometheus workload should scrape. None emits no metrics ingress
+                          rule at all, for setups where a sidecar or node agent collects locally.
+
+                          None is not an absolute deny: Kubernetes NetworkPolicies are additive, so
+                          another policy in the namespace can still grant access.
+                        enum:
+                        - SameNamespace
+                        - AllowedPeers
+                        - None
+                        type: string
+                      podSelector:
+                        description: |-
+                          PodSelector further narrows the namespace peers to specific pods, e.g. the
+                          Prometheus workload itself. It applies only to namespace peers, never to
+                          CIDR peers, and is ignored unless From is AllowedPeers.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  service:
+                    description: Service configures the Kubernetes Service
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations to add to the Service
+                        type: object
+                      ports:
+                        description: |-
+                          Ports defines custom ports exposed on the Service.
+                          When set, these replace the default gateway and canvas ports.
+                          When empty, the operator creates default gateway (18789) and canvas (18793) ports.
+                        items:
+                          description: ServicePortSpec defines a port exposed by the
+                            Service
+                          properties:
+                            name:
+                              description: Name is the name of the port
+                              minLength: 1
+                              type: string
+                            port:
+                              description: Port is the port number exposed on the
+                                Service
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            protocol:
+                              default: TCP
+                              description: Protocol is the protocol for the port
+                              enum:
+                              - TCP
+                              - UDP
+                              - SCTP
+                              type: string
+                            targetPort:
+                              description: TargetPort is the port on the container
+                                to route to (defaults to Port)
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                          required:
+                          - name
+                          - port
+                          type: object
+                        maxItems: 20
+                        type: array
+                      type:
+                        default: ClusterIP
+                        description: Type is the Kubernetes Service type
+                        enum:
+                        - ClusterIP
+                        - LoadBalancer
+                        - NodePort
+                        type: string
+                    type: object
+                type: object
+              observability:
+                description: Observability configures metrics and logging
+                properties:
+                  logging:
+                    description: Logging configures logging
+                    properties:
+                      format:
+                        default: json
+                        description: Format is the log format
+                        enum:
+                        - json
+                        - text
+                        type: string
+                      level:
+                        default: info
+                        description: Level is the log level
+                        enum:
+                        - debug
+                        - info
+                        - warn
+                        - error
+                        type: string
+                    type: object
+                  metrics:
+                    description: Metrics configures Prometheus metrics
+                    properties:
+                      collector:
+                        description: |-
+                          Collector configures the OpenTelemetry Collector sidecar that receives
+                          OTLP metrics from OpenClaw and exposes them for Prometheus scraping.
+                        properties:
+                          image:
+                            description: Image configures the OpenTelemetry Collector
+                              container image.
+                            properties:
+                              digest:
+                                description: |-
+                                  Digest is the container image digest for supply chain security.
+                                  When set, it takes precedence over Tag.
+                                type: string
+                              repository:
+                                default: otel/opentelemetry-collector
+                                description: Repository is the container image repository.
+                                type: string
+                              tag:
+                                default: 0.120.0
+                                description: Tag is the container image tag.
+                                type: string
+                            type: object
+                          resources:
+                            description: Resources specifies compute resources for
+                              the OpenTelemetry Collector.
+                            properties:
+                              limits:
+                                description: Limits describes the maximum amount of
+                                  compute resources allowed
+                                properties:
+                                  cpu:
+                                    description: CPU resource (e.g., "500m", "2")
+                                    type: string
+                                  memory:
+                                    description: Memory resource (e.g., "512Mi", "2Gi")
+                                    type: string
+                                type: object
+                              requests:
+                                description: Requests describes the minimum amount
+                                  of compute resources required
+                                properties:
+                                  cpu:
+                                    description: CPU resource (e.g., "500m", "2")
+                                    type: string
+                                  memory:
+                                    description: Memory resource (e.g., "512Mi", "2Gi")
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      enabled:
+                        default: true
+                        description: Enabled enables metrics endpoint
+                        type: boolean
+                      grafanaDashboard:
+                        description: GrafanaDashboard configures auto-provisioned
+                          Grafana dashboard ConfigMaps
+                        properties:
+                          enabled:
+                            default: false
+                            description: Enabled enables Grafana dashboard ConfigMap
+                              creation
+                            type: boolean
+                          folder:
+                            default: OpenClaw
+                            description: Folder is the Grafana folder to place the
+                              dashboards in
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: 'Labels to add to the dashboard ConfigMaps
+                              (in addition to grafana_dashboard: "1")'
+                            type: object
+                        type: object
+                      port:
+                        default: 9090
+                        description: Port is the port to expose metrics on
+                        format: int32
+                        type: integer
+                      prometheusRule:
+                        description: PrometheusRule configures auto-provisioned PrometheusRule
+                          alerts
+                        properties:
+                          enabled:
+                            default: false
+                            description: Enabled enables PrometheusRule creation with
+                              operator alerts
+                            type: boolean
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels to add to the PrometheusRule (e.g.,
+                              for Prometheus rule selector matching)
+                            type: object
+                          runbookBaseURL:
+                            default: https://paperclip.inc/docs/operators/openclaw/runbooks
+                            description: RunbookBaseURL is the base URL for alert
+                              runbook links
+                            type: string
+                        type: object
+                      serviceMonitor:
+                        description: ServiceMonitor configures the Prometheus ServiceMonitor
+                        properties:
+                          enabled:
+                            default: false
+                            description: Enabled enables ServiceMonitor creation
+                            type: boolean
+                          interval:
+                            default: 30s
+                            description: Interval is the scrape interval
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels to add to the ServiceMonitor
+                            type: object
+                        type: object
+                    type: object
+                type: object
+              ollama:
+                description: Ollama enables the Ollama sidecar for local LLM inference
+                properties:
+                  enabled:
+                    default: false
+                    description: Enabled enables the Ollama sidecar
+                    type: boolean
+                  gpu:
+                    description: GPU is the number of NVIDIA GPUs to allocate (sets
+                      nvidia.com/gpu resource limit)
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  image:
+                    description: Image configures the Ollama container image
+                    properties:
+                      digest:
+                        description: Digest is the container image digest for supply
+                          chain security
+                        type: string
+                      repository:
+                        default: docker.io/ollama/ollama
+                        description: Repository is the container image repository
+                        type: string
+                      tag:
+                        default: latest
+                        description: Tag is the container image tag
+                        type: string
+                    type: object
+                  models:
+                    description: Models is a list of models to pre-pull during pod
+                      init (e.g. ["llama3.2", "nomic-embed-text"])
+                    items:
+                      type: string
+                    maxItems: 10
+                    type: array
+                  resources:
+                    description: Resources specifies compute resources for the Ollama
+                      container
+                    properties:
+                      limits:
+                        description: Limits describes the maximum amount of compute
+                          resources allowed
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                      requests:
+                        description: Requests describes the minimum amount of compute
+                          resources required
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                    type: object
+                  storage:
+                    description: Storage configures the model cache volume
+                    properties:
+                      existingClaim:
+                        description: ExistingClaim is the name of an existing PVC
+                          for persistent model storage
+                        type: string
+                      sizeLimit:
+                        default: 20Gi
+                        description: SizeLimit is the size limit for the emptyDir
+                          model cache (default "20Gi")
+                        type: string
+                    type: object
+                type: object
+              plugins:
+                description: |-
+                  Plugins is a list of plugins to install via init container.
+                  Each entry is an npm package name (e.g., "@openclaw/matrix" or
+                  "@martian-engineering/lossless-claw"). An optional "npm:" prefix is
+                  accepted and stripped before installation.
+                  Installation goes through the OpenClaw CLI's ClawHub installer
+                  ("openclaw plugins install clawhub:<pkg>") rather than raw npm install
+                  so packages published with workspace:* dependency markers resolve
+                  correctly. npm lifecycle scripts are disabled for security.
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+              podAnnotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PodAnnotations are extra annotations merged into the pod template metadata.
+                  Operator-managed annotations (e.g. config-hash) take precedence on conflict.
+                type: object
+              probes:
+                description: Probes configures health probes for the OpenClaw container
+                nullable: true
+                properties:
+                  diskReadiness:
+                    description: |-
+                      DiskReadiness configures an optional, opt-in defense-in-depth readiness
+                      guard for PVC-backed workspaces. When enabled, the readiness probe is
+                      rendered as an exec probe that also verifies the workspace volume is
+                      writable and has free space above a threshold, so a full or read-only
+                      PVC marks the pod NotReady (draining it from Service endpoints) instead
+                      of silently accepting traffic it cannot persist. Liveness and startup
+                      probes are unaffected, so a full PVC does not turn into a CrashLoopBackOff.
+                      The application-level /readyz endpoint remains the primary readiness
+                      signal; this guard is secondary. Defaults to disabled.
+                    properties:
+                      enabled:
+                        default: false
+                        description: |-
+                          Enabled turns on the disk-aware readiness guard. Defaults to false, so
+                          existing deployments are unaffected unless they explicitly opt in.
+                        type: boolean
+                      minFree:
+                        description: |-
+                          MinFree is the minimum free space the workspace volume must have for the
+                          pod to be considered Ready, expressed as a Kubernetes quantity
+                          (e.g. "100Mi", "1Gi"). Defaults to "64Mi".
+                        type: string
+                      path:
+                        description: |-
+                          Path is the workspace mount path checked for writability and free space.
+                          Defaults to the OpenClaw workspace data mount (/home/openclaw/.openclaw).
+                        type: string
+                    type: object
+                  liveness:
+                    description: Liveness probe configuration
+                    properties:
+                      enabled:
+                        default: true
+                        description: Enabled enables the probe
+                        type: boolean
+                      failureThreshold:
+                        description: FailureThreshold is the number of times to retry
+                          before giving up
+                        format: int32
+                        type: integer
+                      initialDelaySeconds:
+                        description: InitialDelaySeconds is the number of seconds
+                          after the container starts before the probe is initiated
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: PeriodSeconds is how often (in seconds) to perform
+                          the probe
+                        format: int32
+                        type: integer
+                      timeoutSeconds:
+                        description: TimeoutSeconds is the number of seconds after
+                          which the probe times out
+                        format: int32
+                        type: integer
+                    type: object
+                  readiness:
+                    description: Readiness probe configuration
+                    properties:
+                      enabled:
+                        default: true
+                        description: Enabled enables the probe
+                        type: boolean
+                      failureThreshold:
+                        description: FailureThreshold is the number of times to retry
+                          before giving up
+                        format: int32
+                        type: integer
+                      initialDelaySeconds:
+                        description: InitialDelaySeconds is the number of seconds
+                          after the container starts before the probe is initiated
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: PeriodSeconds is how often (in seconds) to perform
+                          the probe
+                        format: int32
+                        type: integer
+                      timeoutSeconds:
+                        description: TimeoutSeconds is the number of seconds after
+                          which the probe times out
+                        format: int32
+                        type: integer
+                    type: object
+                  startup:
+                    description: Startup probe configuration
+                    properties:
+                      enabled:
+                        default: true
+                        description: Enabled enables the probe
+                        type: boolean
+                      failureThreshold:
+                        description: FailureThreshold is the number of times to retry
+                          before giving up
+                        format: int32
+                        type: integer
+                      initialDelaySeconds:
+                        description: InitialDelaySeconds is the number of seconds
+                          after the container starts before the probe is initiated
+                        format: int32
+                        type: integer
+                      periodSeconds:
+                        description: PeriodSeconds is how often (in seconds) to perform
+                          the probe
+                        format: int32
+                        type: integer
+                      timeoutSeconds:
+                        description: TimeoutSeconds is the number of seconds after
+                          which the probe times out
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+              registry:
+                description: |-
+                  Registry is the global container image registry override.
+                  When set, this registry replaces the registry part of all container images
+                  used by the instance (main container, sidecars, init containers).
+                  Example: "my-registry.example.com" will change "ghcr.io/openclaw/openclaw:latest"
+                  to "my-registry.example.com/openclaw/openclaw:latest".
+                type: string
+              resources:
+                description: Resources specifies the compute resources for the OpenClaw
+                  container
+                properties:
+                  limits:
+                    description: Limits describes the maximum amount of compute resources
+                      allowed
+                    properties:
+                      cpu:
+                        description: CPU resource (e.g., "500m", "2")
+                        type: string
+                      memory:
+                        description: Memory resource (e.g., "512Mi", "2Gi")
+                        type: string
+                    type: object
+                  requests:
+                    description: Requests describes the minimum amount of compute
+                      resources required
+                    properties:
+                      cpu:
+                        description: CPU resource (e.g., "500m", "2")
+                        type: string
+                      memory:
+                        description: Memory resource (e.g., "512Mi", "2Gi")
+                        type: string
+                    type: object
+                type: object
+              restoreFrom:
+                description: |-
+                  RestoreFrom is the remote backup path to restore data from (e.g. "backups/{tenantId}/{instanceId}/{timestamp}").
+                  When set, the operator restores PVC data from this path before creating the StatefulSet.
+                  Cleared automatically after successful restore.
+                type: string
+              runtimeDeps:
+                description: |-
+                  RuntimeDeps configures built-in init containers that install runtime
+                  dependencies (pnpm, Python) for MCP servers and skills.
+                properties:
+                  pnpm:
+                    description: Pnpm installs pnpm via corepack for npm-based MCP
+                      servers and skills.
+                    type: boolean
+                  python:
+                    description: Python installs Python 3.12 and uv for Python-based
+                      MCP servers and skills.
+                    type: boolean
+                  uvImage:
+                    description: |-
+                      UVImage configures the uv bootstrap image used by the built-in init-uv
+                      and init-python containers.
+                    properties:
+                      digest:
+                        description: |-
+                          Digest is the container image digest for supply chain security.
+                          When set, it takes precedence over Tag.
+                        type: string
+                      repository:
+                        default: ghcr.io/astral-sh/uv
+                        description: Repository is the container image repository.
+                        type: string
+                      tag:
+                        default: 0.6-bookworm-slim
+                        description: Tag is the container image tag.
+                        type: string
+                    type: object
+                type: object
+              security:
+                description: Security specifies security-related configuration
+                properties:
+                  caBundle:
+                    description: |-
+                      CABundle injects a custom CA certificate bundle into all containers.
+                      Use this in environments with TLS-intercepting proxies or private CAs.
+                    properties:
+                      configMapName:
+                        description: |-
+                          ConfigMapName is the name of a ConfigMap containing the CA bundle.
+                          The ConfigMap should have a key matching the Key field.
+                        type: string
+                      key:
+                        default: ca-bundle.crt
+                        description: Key is the key in the ConfigMap or Secret containing
+                          the CA bundle.
+                        type: string
+                      secretName:
+                        description: |-
+                          SecretName is the name of a Secret containing the CA bundle.
+                          The Secret should have a key matching the Key field.
+                          Only one of ConfigMapName or SecretName should be set.
+                        type: string
+                    type: object
+                  containerSecurityContext:
+                    description: ContainerSecurityContext holds container-level security
+                      attributes
+                    properties:
+                      allowPrivilegeEscalation:
+                        default: false
+                        description: AllowPrivilegeEscalation controls whether a process
+                          can gain more privileges
+                        type: boolean
+                      capabilities:
+                        description: Capabilities to add/drop
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      readOnlyRootFilesystem:
+                        default: true
+                        description: |-
+                          ReadOnlyRootFilesystem mounts the container's root filesystem as read-only
+                          The PVC at ~/.openclaw/ provides writable home, and a /tmp emptyDir handles temp files
+                        type: boolean
+                      runAsNonRoot:
+                        description: |-
+                          RunAsNonRoot indicates that the container must run as a non-root user.
+                          When not set, inherits from podSecurityContext.runAsNonRoot.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          RunAsUser is the UID to run the entrypoint of the container process.
+                          When not set, inherits from podSecurityContext.runAsUser.
+                        format: int64
+                        type: integer
+                    type: object
+                  networkPolicy:
+                    description: NetworkPolicy configures network isolation
+                    properties:
+                      additionalEgress:
+                        description: |-
+                          AdditionalEgress appends custom egress rules to the default DNS + HTTPS rules.
+                          Use this to allow traffic to cluster-internal services on non-standard ports.
+                        items:
+                          description: |-
+                            NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods
+                            matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to.
+                            This type is beta-level in 1.8
+                          properties:
+                            ports:
+                              description: |-
+                                ports is a list of destination ports for outgoing traffic.
+                                Each item in this list is combined using a logical OR. If this field is
+                                empty or missing, this rule matches all ports (traffic not restricted by port).
+                                If this field is present and contains at least one item, then this rule allows
+                                traffic only if the traffic matches at least one port in the list.
+                              items:
+                                description: NetworkPolicyPort describes a port to
+                                  allow traffic on
+                                properties:
+                                  endPort:
+                                    description: |-
+                                      endPort indicates that the range of ports from port to endPort if set, inclusive,
+                                      should be allowed by the policy. This field cannot be defined if the port field
+                                      is not defined or if the port field is defined as a named (string) port.
+                                      The endPort must be equal or greater than port.
+                                    format: int32
+                                    type: integer
+                                  port:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      port represents the port on the given protocol. This can either be a numerical or named
+                                      port on a pod. If this field is not provided, this matches all port names and
+                                      numbers.
+                                      If present, only traffic on the specified protocol AND port will be matched.
+                                    x-kubernetes-int-or-string: true
+                                  protocol:
+                                    description: |-
+                                      protocol represents the protocol (TCP, UDP, or SCTP) which traffic must match.
+                                      If not specified, this field defaults to TCP.
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            to:
+                              description: |-
+                                to is a list of destinations for outgoing traffic of pods selected for this rule.
+                                Items in this list are combined using a logical OR operation. If this field is
+                                empty or missing, this rule matches all destinations (traffic not restricted by
+                                destination). If this field is present and contains at least one item, this rule
+                                allows traffic only if the traffic matches at least one item in the to list.
+                              items:
+                                description: |-
+                                  NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of
+                                  fields are allowed
+                                properties:
+                                  ipBlock:
+                                    description: |-
+                                      ipBlock defines policy on a particular IPBlock. If this field is set then
+                                      neither of the other fields can be.
+                                    properties:
+                                      cidr:
+                                        description: |-
+                                          cidr is a string representing the IPBlock
+                                          Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                        type: string
+                                      except:
+                                        description: |-
+                                          except is a slice of CIDRs that should not be included within an IPBlock
+                                          Valid examples are "192.168.1.0/24" or "2001:db8::/64"
+                                          Except values will be rejected if they are outside the cidr range
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - cidr
+                                    type: object
+                                  namespaceSelector:
+                                    description: |-
+                                      namespaceSelector selects namespaces using cluster-scoped labels. This field follows
+                                      standard label selector semantics; if present but empty, it selects all namespaces.
+
+                                      If podSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                      the pods matching podSelector in the namespaces selected by namespaceSelector.
+                                      Otherwise it selects all pods in the namespaces selected by namespaceSelector.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  podSelector:
+                                    description: |-
+                                      podSelector is a label selector which selects pods. This field follows standard label
+                                      selector semantics; if present but empty, it selects all pods.
+
+                                      If namespaceSelector is also set, then the NetworkPolicyPeer as a whole selects
+                                      the pods matching podSelector in the Namespaces selected by NamespaceSelector.
+                                      Otherwise it selects the pods matching podSelector in the policy's own namespace.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        type: array
+                      allowDNS:
+                        default: true
+                        description: AllowDNS allows DNS resolution (port 53)
+                        type: boolean
+                      allowSameNamespaceIngress:
+                        default: true
+                        description: |-
+                          AllowSameNamespaceIngress allows application traffic from all pods in the instance namespace.
+                          Disable this when application ingress is fully described by the explicit namespace or CIDR lists.
+                          Metrics ingress is configured independently through networking.metricsIngress.
+                        type: boolean
+                      allowedEgressCIDRs:
+                        description: |-
+                          AllowedEgressCIDRs is a list of CIDRs this instance can reach
+                          Default allows all egress on port 443 for AI APIs
+                        items:
+                          type: string
+                        type: array
+                      allowedIngressCIDRs:
+                        description: AllowedIngressCIDRs is a list of CIDRs allowed
+                          to access this instance
+                        items:
+                          type: string
+                        type: array
+                      allowedIngressNamespaces:
+                        description: AllowedIngressNamespaces is a list of namespace
+                          names allowed to access this instance
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        default: true
+                        description: Enabled enables network policy creation
+                        type: boolean
+                    type: object
+                  podSecurityContext:
+                    description: PodSecurityContext holds pod-level security attributes
+                    properties:
+                      fsGroup:
+                        default: 1000
+                        description: FSGroup is a special supplemental group that
+                          applies to all containers
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: |-
+                          FSGroupChangePolicy defines the behavior of changing ownership and permission of the volume.
+                          "OnRootMismatch" skips recursive chown when ownership already matches, improving startup
+                          time for large PVCs. "Always" recursively chowns on every mount (Kubernetes default).
+                        enum:
+                        - OnRootMismatch
+                        - Always
+                        type: string
+                      runAsGroup:
+                        default: 1000
+                        description: RunAsGroup is the GID to run the entrypoint of
+                          the container process
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        default: true
+                        description: RunAsNonRoot indicates that the container must
+                          run as a non-root user
+                        type: boolean
+                      runAsUser:
+                        default: 1000
+                        description: RunAsUser is the UID to run the entrypoint of
+                          the container process
+                        format: int64
+                        type: integer
+                    type: object
+                  rbac:
+                    description: RBAC configures role-based access control
+                    properties:
+                      additionalRules:
+                        description: AdditionalRules adds custom RBAC rules to the
+                          generated Role
+                        items:
+                          description: RBACRule represents a RBAC rule
+                          properties:
+                            apiGroups:
+                              description: APIGroups is the name of the APIGroup that
+                                contains the resources
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: Resources is a list of resources this rule
+                                applies to
+                              items:
+                                type: string
+                              type: array
+                            verbs:
+                              description: Verbs is a list of verbs that apply to
+                                the resources
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - apiGroups
+                          - resources
+                          - verbs
+                          type: object
+                        type: array
+                      createServiceAccount:
+                        default: true
+                        description: CreateServiceAccount creates a dedicated ServiceAccount
+                          for the instance
+                        type: boolean
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ServiceAccountAnnotations are annotations to add to the managed ServiceAccount.
+                          Use this for cloud provider integrations like AWS IRSA or GCP Workload Identity.
+                        type: object
+                      serviceAccountName:
+                        description: |-
+                          ServiceAccountName is the name of an existing ServiceAccount to use
+                          Only used if CreateServiceAccount is false
+                        type: string
+                    type: object
+                type: object
+              selfConfigure:
+                description: |-
+                  SelfConfigure enables agents to modify their own instance via OpenClawSelfConfig resources.
+                  When enabled, the operator injects RBAC, env vars, and a helper skill into the workspace.
+                properties:
+                  allowedActions:
+                    description: |-
+                      AllowedActions restricts which action categories the agent can perform.
+                      If empty and enabled is true, no actions are allowed (fail-safe).
+                    items:
+                      description: SelfConfigAction represents an action category
+                        that can be allowed for self-configuration.
+                      enum:
+                      - skills
+                      - config
+                      - workspaceFiles
+                      - envVars
+                      type: string
+                    maxItems: 4
+                    type: array
+                  enabled:
+                    default: false
+                    description: |-
+                      Enabled enables self-configuration for this instance.
+                      When true, the agent can create OpenClawSelfConfig resources to modify its own spec.
+                    type: boolean
+                type: object
+              shareProcessNamespace:
+                default: true
+                description: |-
+                  ShareProcessNamespace enables PID namespace sharing between all containers
+                  in the pod. When true, the infrastructure (pause) container becomes PID 1
+                  and reaps zombie processes, which prevents accumulation of defunct helper
+                  processes (git, plugins, QMD memory, shells) under a Node.js gateway that
+                  does not call waitpid(). Defaults to true.
+
+                  Security note: enabling this lets every container in the pod see and signal
+                  every other container's processes. A compromised sidecar (Tailscale, Ollama,
+                  browser, custom) could send signals to the gateway and vice versa. Set to
+                  false to keep per-container PID isolation; you are then responsible for
+                  reaping zombies (e.g. by baking tini or dumb-init into the image).
+                type: boolean
+              sidecarVolumes:
+                description: SidecarVolumes is a list of additional volumes to make
+                  available to sidecar containers.
+                items:
+                  description: Volume represents a named volume in a pod that may
+                    be accessed by any container in the pod.
+                  properties:
+                    awsElasticBlockStore:
+                      description: |-
+                        awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          type: string
+                        partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
+                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: |-
+                            readOnly value true will force the readOnly setting in VolumeMounts.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          type: boolean
+                        volumeID:
+                          description: |-
+                            volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    azureDisk:
+                      description: azureDisk represents an Azure Data Disk mount on
+                        the host and bind mount to the pod.
+                      properties:
+                        cachingMode:
+                          description: 'cachingMode is the Host Caching mode: None,
+                            Read Only, Read Write.'
+                          type: string
+                        diskName:
+                          description: diskName is the Name of the data disk in the
+                            blob storage
+                          type: string
+                        diskURI:
+                          description: diskURI is the URI of data disk in the blob
+                            storage
+                          type: string
+                        fsType:
+                          default: ext4
+                          description: |-
+                            fsType is Filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        kind:
+                          description: 'kind expected values are Shared: multiple
+                            blob disks per storage account  Dedicated: single blob
+                            disk per storage account  Managed: azure managed data
+                            disk (only in managed availability set). defaults to shared'
+                          type: string
+                        readOnly:
+                          default: false
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                      required:
+                      - diskName
+                      - diskURI
+                      type: object
+                    azureFile:
+                      description: azureFile represents an Azure File Service mount
+                        on the host and bind mount to the pod.
+                      properties:
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretName:
+                          description: secretName is the  name of secret that contains
+                            Azure Storage Account Name and Key
+                          type: string
+                        shareName:
+                          description: shareName is the azure share Name
+                          type: string
+                      required:
+                      - secretName
+                      - shareName
+                      type: object
+                    cephfs:
+                      description: cephFS represents a Ceph FS mount on the host that
+                        shares a pod's lifetime
+                      properties:
+                        monitors:
+                          description: |-
+                            monitors is Required: Monitors is a collection of Ceph monitors
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        path:
+                          description: 'path is Optional: Used as the mounted root,
+                            rather than the full Ceph tree, default is /'
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          type: boolean
+                        secretFile:
+                          description: |-
+                            secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          type: string
+                        secretRef:
+                          description: |-
+                            secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          description: |-
+                            user is optional: User is the rados user name, default is admin
+                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                          type: string
+                      required:
+                      - monitors
+                      type: object
+                    cinder:
+                      description: |-
+                        cinder represents a cinder volume attached and mounted on kubelets host machine.
+                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef is optional: points to a secret object containing parameters used to connect
+                            to OpenStack.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeID:
+                          description: |-
+                            volumeID used to identify the volume in cinder.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    configMap:
+                      description: configMap represents a configMap that should populate
+                        this volume
+                      properties:
+                        defaultMode:
+                          description: |-
+                            defaultMode is optional: mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                            Defaults to 0644.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        items:
+                          description: |-
+                            items if unspecified, each key-value pair in the Data field of the referenced
+                            ConfigMap will be projected into the volume as a file whose name is the
+                            key and content is the value. If specified, the listed keys will be
+                            projected into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in the ConfigMap,
+                            the volume setup will error unless it is marked optional. Paths must be
+                            relative and may not contain the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: key is the key to project.
+                                type: string
+                              mode:
+                                description: |-
+                                  mode is Optional: mode bits used to set permissions on this file.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  If not specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
+                                  May not start with the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        optional:
+                          description: optional specify whether the ConfigMap or its
+                            keys must be defined
+                          type: boolean
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    csi:
+                      description: csi (Container Storage Interface) represents ephemeral
+                        storage that is handled by certain external CSI drivers (Beta
+                        feature).
+                      properties:
+                        driver:
+                          description: |-
+                            driver is the name of the CSI driver that handles this volume.
+                            Consult with your admin for the correct name as registered in the cluster.
+                          type: string
+                        fsType:
+                          description: |-
+                            fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                            If not provided, the empty value is passed to the associated CSI driver
+                            which will determine the default filesystem to apply.
+                          type: string
+                        nodePublishSecretRef:
+                          description: |-
+                            nodePublishSecretRef is a reference to the secret object containing
+                            sensitive information to pass to the CSI driver to complete the CSI
+                            NodePublishVolume and NodeUnpublishVolume calls.
+                            This field is optional, and  may be empty if no secret is required. If the
+                            secret object contains more than one secret, all secret references are passed.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        readOnly:
+                          description: |-
+                            readOnly specifies a read-only configuration for the volume.
+                            Defaults to false (read/write).
+                          type: boolean
+                        volumeAttributes:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            volumeAttributes stores driver-specific properties that are passed to the CSI
+                            driver. Consult your driver's documentation for supported values.
+                          type: object
+                      required:
+                      - driver
+                      type: object
+                    downwardAPI:
+                      description: downwardAPI represents downward API about the pod
+                        that should populate this volume
+                      properties:
+                        defaultMode:
+                          description: |-
+                            Optional: mode bits to use on created files by default. Must be a
+                            Optional: mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                            Defaults to 0644.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        items:
+                          description: Items is a list of downward API volume file
+                          items:
+                            description: DownwardAPIVolumeFile represents information
+                              to create the file containing the pod field
+                            properties:
+                              fieldRef:
+                                description: 'Required: Selects a field of the pod:
+                                  only annotations, labels, name, namespace and uid
+                                  are supported.'
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              mode:
+                                description: |-
+                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                  between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  If not specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              path:
+                                description: 'Required: Path is  the relative path
+                                  name of the file to be created. Must not be absolute
+                                  or contain the ''..'' path. Must be utf-8 encoded.
+                                  The first item of the relative path must not start
+                                  with ''..'''
+                                type: string
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            required:
+                            - path
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    emptyDir:
+                      description: |-
+                        emptyDir represents a temporary directory that shares a pod's lifetime.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                      properties:
+                        medium:
+                          description: |-
+                            medium represents what type of storage medium should back this directory.
+                            The default is "" which means to use the node's default medium.
+                            Must be an empty string (default) or Memory.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                          type: string
+                        sizeLimit:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          description: |-
+                            sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                            The size limit is also applicable for memory medium.
+                            The maximum usage on memory medium EmptyDir would be the minimum value between
+                            the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                            The default is nil which means that the limit is undefined.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                      type: object
+                    ephemeral:
+                      description: |-
+                        ephemeral represents a volume that is handled by a cluster storage driver.
+                        The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                        and deleted when the pod is removed.
+
+                        Use this if:
+                        a) the volume is only needed while the pod runs,
+                        b) features of normal volumes like restoring from snapshot or capacity
+                           tracking are needed,
+                        c) the storage driver is specified through a storage class, and
+                        d) the storage driver supports dynamic volume provisioning through
+                           a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                           information on the connection between this volume type
+                           and PersistentVolumeClaim).
+
+                        Use PersistentVolumeClaim or one of the vendor-specific
+                        APIs for volumes that persist for longer than the lifecycle
+                        of an individual pod.
+
+                        Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                        be used that way - see the documentation of the driver for
+                        more information.
+
+                        A pod can use both types of ephemeral volumes and
+                        persistent volumes at the same time.
+                      properties:
+                        volumeClaimTemplate:
+                          description: |-
+                            Will be used to create a stand-alone PVC to provision the volume.
+                            The pod in which this EphemeralVolumeSource is embedded will be the
+                            owner of the PVC, i.e. the PVC will be deleted together with the
+                            pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                            `<volume name>` is the name from the `PodSpec.Volumes` array
+                            entry. Pod validation will reject the pod if the concatenated name
+                            is not valid for a PVC (for example, too long).
+
+                            An existing PVC with that name that is not owned by the pod
+                            will *not* be used for the pod to avoid using an unrelated
+                            volume by mistake. Starting the pod is then blocked until
+                            the unrelated PVC is removed. If such a pre-created PVC is
+                            meant to be used by the pod, the PVC has to updated with an
+                            owner reference to the pod once the pod exists. Normally
+                            this should not be necessary, but it may be useful when
+                            manually reconstructing a broken cluster.
+
+                            This field is read-only and no changes will be made by Kubernetes
+                            to the PVC after it has been created.
+
+                            Required, must not be nil.
+                          properties:
+                            metadata:
+                              description: |-
+                                May contain labels and annotations that will be copied into the PVC
+                                when creating it. No other fields are allowed and will be rejected during
+                                validation.
+                              type: object
+                            spec:
+                              description: |-
+                                The specification for the PersistentVolumeClaim. The entire content is
+                                copied unchanged into the PVC that gets created from this
+                                template. The same fields as in a PersistentVolumeClaim
+                                are also valid here.
+                              properties:
+                                accessModes:
+                                  description: |-
+                                    accessModes contains the desired access modes the volume should have.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                dataSource:
+                                  description: |-
+                                    dataSource field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                    * An existing PVC (PersistentVolumeClaim)
+                                    If the provisioner or an external controller can support the specified data source,
+                                    it will create a new volume based on the contents of the specified data source.
+                                    When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                    and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                    If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                  properties:
+                                    apiGroup:
+                                      description: |-
+                                        APIGroup is the group for the resource being referenced.
+                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                dataSourceRef:
+                                  description: |-
+                                    dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                    volume is desired. This may be any object from a non-empty API group (non
+                                    core object) or a PersistentVolumeClaim object.
+                                    When this field is specified, volume binding will only succeed if the type of
+                                    the specified object matches some installed volume populator or dynamic
+                                    provisioner.
+                                    This field will replace the functionality of the dataSource field and as such
+                                    if both fields are non-empty, they must have the same value. For backwards
+                                    compatibility, when namespace isn't specified in dataSourceRef,
+                                    both fields (dataSource and dataSourceRef) will be set to the same
+                                    value automatically if one of them is empty and the other is non-empty.
+                                    When namespace is specified in dataSourceRef,
+                                    dataSource isn't set to the same value and must be empty.
+                                    There are three important differences between dataSource and dataSourceRef:
+                                    * While dataSource only allows two specific types of objects, dataSourceRef
+                                      allows any non-core object, as well as PersistentVolumeClaim objects.
+                                    * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                      preserves all values, and generates an error if a disallowed value is
+                                      specified.
+                                    * While dataSource only allows local objects, dataSourceRef allows objects
+                                      in any namespaces.
+                                    (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                    (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                  properties:
+                                    apiGroup:
+                                      description: |-
+                                        APIGroup is the group for the resource being referenced.
+                                        If APIGroup is not specified, the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace of resource being referenced
+                                        Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                        (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                resources:
+                                  description: |-
+                                    resources represents the minimum resources the volume should have.
+                                    If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                    that are lower than previous value but must still be higher than capacity recorded in the
+                                    status field of the claim.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                  type: object
+                                selector:
+                                  description: selector is a label query over volumes
+                                    to consider for binding.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                storageClassName:
+                                  description: |-
+                                    storageClassName is the name of the StorageClass required by the claim.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                  type: string
+                                volumeAttributesClassName:
+                                  description: |-
+                                    volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                    If specified, the CSI driver will create or update the volume with the attributes defined
+                                    in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                    it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                    will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                    If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                    will be set by the persistentvolume controller if it exists.
+                                    If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                    set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                    exists.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                    (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                                  type: string
+                                volumeMode:
+                                  description: |-
+                                    volumeMode defines what type of volume is required by the claim.
+                                    Value of Filesystem is implied when not included in claim spec.
+                                  type: string
+                                volumeName:
+                                  description: volumeName is the binding reference
+                                    to the PersistentVolume backing this claim.
+                                  type: string
+                              type: object
+                          required:
+                          - spec
+                          type: object
+                      type: object
+                    fc:
+                      description: fc represents a Fibre Channel resource that is
+                        attached to a kubelet's host machine and then exposed to the
+                        pod.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        lun:
+                          description: 'lun is Optional: FC target lun number'
+                          format: int32
+                          type: integer
+                        readOnly:
+                          description: |-
+                            readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        targetWWNs:
+                          description: 'targetWWNs is Optional: FC target worldwide
+                            names (WWNs)'
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        wwids:
+                          description: |-
+                            wwids Optional: FC volume world wide identifiers (wwids)
+                            Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    flexVolume:
+                      description: |-
+                        flexVolume represents a generic volume resource that is
+                        provisioned/attached using an exec based plugin.
+                      properties:
+                        driver:
+                          description: driver is the name of the driver to use for
+                            this volume.
+                          type: string
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                          type: string
+                        options:
+                          additionalProperties:
+                            type: string
+                          description: 'options is Optional: this field holds extra
+                            command options if any.'
+                          type: object
+                        readOnly:
+                          description: |-
+                            readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef is Optional: secretRef is reference to the secret object containing
+                            sensitive information to pass to the plugin scripts. This may be
+                            empty if no secret object is specified. If the secret object
+                            contains more than one secret, all secrets are passed to the plugin
+                            scripts.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - driver
+                      type: object
+                    flocker:
+                      description: flocker represents a Flocker volume attached to
+                        a kubelet's host machine. This depends on the Flocker control
+                        service being running
+                      properties:
+                        datasetName:
+                          description: |-
+                            datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                            should be considered as deprecated
+                          type: string
+                        datasetUUID:
+                          description: datasetUUID is the UUID of the dataset. This
+                            is unique identifier of a Flocker dataset
+                          type: string
+                      type: object
+                    gcePersistentDisk:
+                      description: |-
+                        gcePersistentDisk represents a GCE Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          type: string
+                        partition:
+                          description: |-
+                            partition is the partition in the volume that you want to mount.
+                            If omitted, the default is to mount by volume name.
+                            Examples: For volume /dev/sda1, you specify the partition as "1".
+                            Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          format: int32
+                          type: integer
+                        pdName:
+                          description: |-
+                            pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          type: boolean
+                      required:
+                      - pdName
+                      type: object
+                    gitRepo:
+                      description: |-
+                        gitRepo represents a git repository at a particular revision.
+                        DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                        EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                        into the Pod's container.
+                      properties:
+                        directory:
+                          description: |-
+                            directory is the target directory name.
+                            Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                            git repository.  Otherwise, if specified, the volume will contain the git repository in
+                            the subdirectory with the given name.
+                          type: string
+                        repository:
+                          description: repository is the URL
+                          type: string
+                        revision:
+                          description: revision is the commit hash for the specified
+                            revision.
+                          type: string
+                      required:
+                      - repository
+                      type: object
+                    glusterfs:
+                      description: |-
+                        glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                        More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                      properties:
+                        endpoints:
+                          description: |-
+                            endpoints is the endpoint name that details Glusterfs topology.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                          type: string
+                        path:
+                          description: |-
+                            path is the Glusterfs volume path.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                            Defaults to false.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                          type: boolean
+                      required:
+                      - endpoints
+                      - path
+                      type: object
+                    hostPath:
+                      description: |-
+                        hostPath represents a pre-existing file or directory on the host
+                        machine that is directly exposed to the container. This is generally
+                        used for system agents or other privileged things that are allowed
+                        to see the host machine. Most containers will NOT need this.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                      properties:
+                        path:
+                          description: |-
+                            path of the directory on the host.
+                            If the path is a symlink, it will follow the link to the real path.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          type: string
+                        type:
+                          description: |-
+                            type for HostPath Volume
+                            Defaults to ""
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    image:
+                      description: |-
+                        image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                        The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                        - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                        - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                        - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                        The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                        A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                        The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                        The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                        The volume will be mounted read-only (ro) and non-executable files (noexec).
+                        Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                        The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                      properties:
+                        pullPolicy:
+                          description: |-
+                            Policy for pulling OCI objects. Possible values are:
+                            Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                            Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                            IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          type: string
+                        reference:
+                          description: |-
+                            Required: Image or artifact reference to be used.
+                            Behaves in the same way as pod.spec.containers[*].image.
+                            Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                            More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management to default or override
+                            container images in workload controllers like Deployments and StatefulSets.
+                          type: string
+                      type: object
+                    iscsi:
+                      description: |-
+                        iscsi represents an ISCSI Disk resource that is attached to a
+                        kubelet's host machine and then exposed to the pod.
+                        More info: https://examples.k8s.io/volumes/iscsi/README.md
+                      properties:
+                        chapAuthDiscovery:
+                          description: chapAuthDiscovery defines whether support iSCSI
+                            Discovery CHAP authentication
+                          type: boolean
+                        chapAuthSession:
+                          description: chapAuthSession defines whether support iSCSI
+                            Session CHAP authentication
+                          type: boolean
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                          type: string
+                        initiatorName:
+                          description: |-
+                            initiatorName is the custom iSCSI Initiator Name.
+                            If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                            <target portal>:<volume name> will be created for the connection.
+                          type: string
+                        iqn:
+                          description: iqn is the target iSCSI Qualified Name.
+                          type: string
+                        iscsiInterface:
+                          default: default
+                          description: |-
+                            iscsiInterface is the interface Name that uses an iSCSI transport.
+                            Defaults to 'default' (tcp).
+                          type: string
+                        lun:
+                          description: lun represents iSCSI Target Lun number.
+                          format: int32
+                          type: integer
+                        portals:
+                          description: |-
+                            portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                            is other than default (typically TCP ports 860 and 3260).
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                          type: boolean
+                        secretRef:
+                          description: secretRef is the CHAP Secret for iSCSI target
+                            and initiator authentication
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        targetPortal:
+                          description: |-
+                            targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                            is other than default (typically TCP ports 860 and 3260).
+                          type: string
+                      required:
+                      - iqn
+                      - lun
+                      - targetPortal
+                      type: object
+                    name:
+                      description: |-
+                        name of the volume.
+                        Must be a DNS_LABEL and unique within the pod.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    nfs:
+                      description: |-
+                        nfs represents an NFS mount on the host that shares a pod's lifetime
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                      properties:
+                        path:
+                          description: |-
+                            path that is exported by the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the NFS export to be mounted with read-only permissions.
+                            Defaults to false.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          type: boolean
+                        server:
+                          description: |-
+                            server is the hostname or IP address of the NFS server.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          type: string
+                      required:
+                      - path
+                      - server
+                      type: object
+                    persistentVolumeClaim:
+                      description: |-
+                        persistentVolumeClaimVolumeSource represents a reference to a
+                        PersistentVolumeClaim in the same namespace.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                      properties:
+                        claimName:
+                          description: |-
+                            claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly Will force the ReadOnly setting in VolumeMounts.
+                            Default false.
+                          type: boolean
+                      required:
+                      - claimName
+                      type: object
+                    photonPersistentDisk:
+                      description: photonPersistentDisk represents a PhotonController
+                        persistent disk attached and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        pdID:
+                          description: pdID is the ID that identifies Photon Controller
+                            persistent disk
+                          type: string
+                      required:
+                      - pdID
+                      type: object
+                    portworxVolume:
+                      description: portworxVolume represents a portworx volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: |-
+                            fSType represents the filesystem type to mount
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        volumeID:
+                          description: volumeID uniquely identifies a Portworx volume
+                          type: string
+                      required:
+                      - volumeID
+                      type: object
+                    projected:
+                      description: projected items for all in one resources secrets,
+                        configmaps, and downward API
+                      properties:
+                        defaultMode:
+                          description: |-
+                            defaultMode are the mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        sources:
+                          description: |-
+                            sources is the list of volume projections. Each entry in this list
+                            handles one source.
+                          items:
+                            description: |-
+                              Projection that may be projected along with other supported volume types.
+                              Exactly one of these fields must be set.
+                            properties:
+                              clusterTrustBundle:
+                                description: |-
+                                  ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                  of ClusterTrustBundle objects in an auto-updating file.
+
+                                  Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                  ClusterTrustBundle objects can either be selected by name, or by the
+                                  combination of signer name and a label selector.
+
+                                  Kubelet performs aggressive normalization of the PEM contents written
+                                  into the pod filesystem.  Esoteric PEM features such as inter-block
+                                  comments and block headers are stripped.  Certificates are deduplicated.
+                                  The ordering of certificates within the file is arbitrary, and Kubelet
+                                  may change the order over time.
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this label selector.  Only has
+                                      effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                      interpreted as "match nothing".  If set but empty, interpreted as "match
+                                      everything".
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  name:
+                                    description: |-
+                                      Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                      with signerName and labelSelector.
+                                    type: string
+                                  optional:
+                                    description: |-
+                                      If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                      aren't available.  If using name, then the named ClusterTrustBundle is
+                                      allowed not to exist.  If using signerName, then the combination of
+                                      signerName and labelSelector is allowed to match zero
+                                      ClusterTrustBundles.
+                                    type: boolean
+                                  path:
+                                    description: Relative path from the volume root
+                                      to write the bundle.
+                                    type: string
+                                  signerName:
+                                    description: |-
+                                      Select all ClusterTrustBundles that match this signer name.
+                                      Mutually-exclusive with name.  The contents of all selected
+                                      ClusterTrustBundles will be unified and deduplicated.
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              configMap:
+                                description: configMap information about the configMap
+                                  data to project
+                                properties:
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap
+                                      or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              downwardAPI:
+                                description: downwardAPI information about the downwardAPI
+                                  data to project
+                                properties:
+                                  items:
+                                    description: Items is a list of DownwardAPIVolume
+                                      file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents
+                                        information to create the file containing
+                                        the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field
+                                            of the pod: only annotations, labels,
+                                            name, namespace and uid are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          description: |-
+                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                            between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative
+                                            path name of the file to be created. Must
+                                            not be absolute or contain the ''..''
+                                            path. Must be utf-8 encoded. The first
+                                            item of the relative path must not start
+                                            with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              secret:
+                                description: secret information about the secret data
+                                  to project
+                                properties:
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within
+                                        a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: optional field specify whether the
+                                      Secret or its key must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              serviceAccountToken:
+                                description: serviceAccountToken is information about
+                                  the serviceAccountToken data to project
+                                properties:
+                                  audience:
+                                    description: |-
+                                      audience is the intended audience of the token. A recipient of a token
+                                      must identify itself with an identifier specified in the audience of the
+                                      token, and otherwise should reject the token. The audience defaults to the
+                                      identifier of the apiserver.
+                                    type: string
+                                  expirationSeconds:
+                                    description: |-
+                                      expirationSeconds is the requested duration of validity of the service
+                                      account token. As the token approaches expiration, the kubelet volume
+                                      plugin will proactively rotate the service account token. The kubelet will
+                                      start trying to rotate the token if the token is older than 80 percent of
+                                      its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                      and must be at least 10 minutes.
+                                    format: int64
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the path relative to the mount point of the file to project the
+                                      token into.
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      type: object
+                    quobyte:
+                      description: quobyte represents a Quobyte mount on the host
+                        that shares a pod's lifetime
+                      properties:
+                        group:
+                          description: |-
+                            group to map volume access to
+                            Default is no group
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                            Defaults to false.
+                          type: boolean
+                        registry:
+                          description: |-
+                            registry represents a single or multiple Quobyte Registry services
+                            specified as a string as host:port pair (multiple entries are separated with commas)
+                            which acts as the central registry for volumes
+                          type: string
+                        tenant:
+                          description: |-
+                            tenant owning the given Quobyte volume in the Backend
+                            Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                          type: string
+                        user:
+                          description: |-
+                            user to map volume access to
+                            Defaults to serivceaccount user
+                          type: string
+                        volume:
+                          description: volume is a string that references an already
+                            created Quobyte volume by name.
+                          type: string
+                      required:
+                      - registry
+                      - volume
+                      type: object
+                    rbd:
+                      description: |-
+                        rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                        More info: https://examples.k8s.io/volumes/rbd/README.md
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type of the volume that you want to mount.
+                            Tip: Ensure that the filesystem type is supported by the host operating system.
+                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                          type: string
+                        image:
+                          description: |-
+                            image is the rados image name.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                        keyring:
+                          default: /etc/ceph/keyring
+                          description: |-
+                            keyring is the path to key ring for RBDUser.
+                            Default is /etc/ceph/keyring.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                        monitors:
+                          description: |-
+                            monitors is a collection of Ceph monitors.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        pool:
+                          default: rbd
+                          description: |-
+                            pool is the rados pool name.
+                            Default is rbd.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly here will force the ReadOnly setting in VolumeMounts.
+                            Defaults to false.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef is name of the authentication secret for RBDUser. If provided
+                            overrides keyring.
+                            Default is nil.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        user:
+                          default: admin
+                          description: |-
+                            user is the rados user name.
+                            Default is admin.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                          type: string
+                      required:
+                      - image
+                      - monitors
+                      type: object
+                    scaleIO:
+                      description: scaleIO represents a ScaleIO persistent volume
+                        attached and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          default: xfs
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs".
+                            Default is "xfs".
+                          type: string
+                        gateway:
+                          description: gateway is the host address of the ScaleIO
+                            API Gateway.
+                          type: string
+                        protectionDomain:
+                          description: protectionDomain is the name of the ScaleIO
+                            Protection Domain for the configured storage.
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly Defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef references to the secret for ScaleIO user and other
+                            sensitive information. If this is not provided, Login operation will fail.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        sslEnabled:
+                          description: sslEnabled Flag enable/disable SSL communication
+                            with Gateway, default false
+                          type: boolean
+                        storageMode:
+                          default: ThinProvisioned
+                          description: |-
+                            storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                            Default is ThinProvisioned.
+                          type: string
+                        storagePool:
+                          description: storagePool is the ScaleIO Storage Pool associated
+                            with the protection domain.
+                          type: string
+                        system:
+                          description: system is the name of the storage system as
+                            configured in ScaleIO.
+                          type: string
+                        volumeName:
+                          description: |-
+                            volumeName is the name of a volume already created in the ScaleIO system
+                            that is associated with this volume source.
+                          type: string
+                      required:
+                      - gateway
+                      - secretRef
+                      - system
+                      type: object
+                    secret:
+                      description: |-
+                        secret represents a secret that should populate this volume.
+                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                      properties:
+                        defaultMode:
+                          description: |-
+                            defaultMode is Optional: mode bits used to set permissions on created files by default.
+                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                            YAML accepts both octal and decimal values, JSON requires decimal values
+                            for mode bits. Defaults to 0644.
+                            Directories within the path are not affected by this setting.
+                            This might be in conflict with other options that affect the file
+                            mode, like fsGroup, and the result can be other mode bits set.
+                          format: int32
+                          type: integer
+                        items:
+                          description: |-
+                            items If unspecified, each key-value pair in the Data field of the referenced
+                            Secret will be projected into the volume as a file whose name is the
+                            key and content is the value. If specified, the listed keys will be
+                            projected into the specified paths, and unlisted keys will not be
+                            present. If a key is specified which is not present in the Secret,
+                            the volume setup will error unless it is marked optional. Paths must be
+                            relative and may not contain the '..' path or start with '..'.
+                          items:
+                            description: Maps a string key to a path within a volume.
+                            properties:
+                              key:
+                                description: key is the key to project.
+                                type: string
+                              mode:
+                                description: |-
+                                  mode is Optional: mode bits used to set permissions on this file.
+                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                  If not specified, the volume defaultMode will be used.
+                                  This might be in conflict with other options that affect the file
+                                  mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              path:
+                                description: |-
+                                  path is the relative path of the file to map the key to.
+                                  May not be an absolute path.
+                                  May not contain the path element '..'.
+                                  May not start with the string '..'.
+                                type: string
+                            required:
+                            - key
+                            - path
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        optional:
+                          description: optional field specify whether the Secret or
+                            its keys must be defined
+                          type: boolean
+                        secretName:
+                          description: |-
+                            secretName is the name of the secret in the pod's namespace to use.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                          type: string
+                      type: object
+                    storageos:
+                      description: storageOS represents a StorageOS volume attached
+                        and mounted on Kubernetes nodes.
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is the filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        readOnly:
+                          description: |-
+                            readOnly defaults to false (read/write). ReadOnly here will force
+                            the ReadOnly setting in VolumeMounts.
+                          type: boolean
+                        secretRef:
+                          description: |-
+                            secretRef specifies the secret to use for obtaining the StorageOS API
+                            credentials.  If not specified, default values will be attempted.
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        volumeName:
+                          description: |-
+                            volumeName is the human-readable name of the StorageOS volume.  Volume
+                            names are only unique within a namespace.
+                          type: string
+                        volumeNamespace:
+                          description: |-
+                            volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                            namespace is specified then the Pod's namespace will be used.  This allows the
+                            Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                            Set VolumeName to any name to override the default behaviour.
+                            Set to "default" if you are not using namespaces within StorageOS.
+                            Namespaces that do not pre-exist within StorageOS will be created.
+                          type: string
+                      type: object
+                    vsphereVolume:
+                      description: vsphereVolume represents a vSphere volume attached
+                        and mounted on kubelets host machine
+                      properties:
+                        fsType:
+                          description: |-
+                            fsType is filesystem type to mount.
+                            Must be a filesystem type supported by the host operating system.
+                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                          type: string
+                        storagePolicyID:
+                          description: storagePolicyID is the storage Policy Based
+                            Management (SPBM) profile ID associated with the StoragePolicyName.
+                          type: string
+                        storagePolicyName:
+                          description: storagePolicyName is the storage Policy Based
+                            Management (SPBM) profile name.
+                          type: string
+                        volumePath:
+                          description: volumePath is the path that identifies vSphere
+                            volume vmdk
+                          type: string
+                      required:
+                      - volumePath
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              sidecars:
+                description: |-
+                  Sidecars is a list of additional sidecar containers to inject into the pod.
+                  Use this for custom sidecars like database proxies, log forwarders, or service meshes.
+                items:
+                  description: A single application container that you want to run
+                    within a pod.
+                  properties:
+                    args:
+                      description: |-
+                        Arguments to the entrypoint.
+                        The container image's CMD is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Cannot be updated.
+                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    command:
+                      description: |-
+                        Entrypoint array. Not executed within a shell.
+                        The container image's ENTRYPOINT is used if this is not provided.
+                        Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                        cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                        produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                        of whether the variable exists or not. Cannot be updated.
+                        More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                      items:
+                        type: string
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    env:
+                      description: |-
+                        List of environment variables to set in the container.
+                        Cannot be updated.
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be
+                              a C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any service environment variables. If a variable cannot be resolved,
+                              the reference in the input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                              Escaped references will never be expanded, regardless of whether the variable
+                              exists or not.
+                              Defaults to "".
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or
+                                      its key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: |-
+                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                      optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                    envFrom:
+                      description: |-
+                        List of sources to populate environment variables in the container.
+                        The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                        will be reported as an event when the container is starting. When a key exists in multiple
+                        sources, the value associated with the last source will take precedence.
+                        Values defined by an Env with a duplicate key will take precedence.
+                        Cannot be updated.
+                      items:
+                        description: EnvFromSource represents the source of a set
+                          of ConfigMaps
+                        properties:
+                          configMapRef:
+                            description: The ConfigMap to select from
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap must be
+                                  defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          prefix:
+                            description: An optional identifier to prepend to each
+                              key in the ConfigMap. Must be a C_IDENTIFIER.
+                            type: string
+                          secretRef:
+                            description: The Secret to select from
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret must be defined
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    image:
+                      description: |-
+                        Container image name.
+                        More info: https://kubernetes.io/docs/concepts/containers/images
+                        This field is optional to allow higher level config management to default or override
+                        container images in workload controllers like Deployments and StatefulSets.
+                      type: string
+                    imagePullPolicy:
+                      description: |-
+                        Image pull policy.
+                        One of Always, Never, IfNotPresent.
+                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                        Cannot be updated.
+                        More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                      type: string
+                    lifecycle:
+                      description: |-
+                        Actions that the management system should take in response to container lifecycle events.
+                        Cannot be updated.
+                      properties:
+                        postStart:
+                          description: |-
+                            PostStart is called immediately after a container is created. If the handler fails,
+                            the container is terminated and restarted according to its restart policy.
+                            Other management of the container blocks until the hook completes.
+                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            sleep:
+                              description: Sleep represents the duration that the
+                                container should sleep before being terminated.
+                              properties:
+                                seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - seconds
+                              type: object
+                            tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for the backward compatibility. There are no validation of this field and
+                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                          type: object
+                        preStop:
+                          description: |-
+                            PreStop is called immediately before a container is terminated due to an
+                            API request or management event such as liveness/startup probe failure,
+                            preemption, resource contention, etc. The handler is not called if the
+                            container crashes or exits. The Pod's termination grace period countdown begins before the
+                            PreStop hook is executed. Regardless of the outcome of the handler, the
+                            container will eventually terminate within the Pod's termination grace
+                            period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                            or until the termination grace period is reached.
+                            More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                          properties:
+                            exec:
+                              description: Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            sleep:
+                              description: Sleep represents the duration that the
+                                container should sleep before being terminated.
+                              properties:
+                                seconds:
+                                  description: Seconds is the number of seconds to
+                                    sleep.
+                                  format: int64
+                                  type: integer
+                              required:
+                              - seconds
+                              type: object
+                            tcpSocket:
+                              description: |-
+                                Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                for the backward compatibility. There are no validation of this field and
+                                lifecycle hooks will fail in runtime when tcp handler is specified.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                          type: object
+                      type: object
+                    livenessProbe:
+                      description: |-
+                        Periodic probe of container liveness.
+                        Container will be restarted if the probe fails.
+                        Cannot be updated.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                a shell, you need to explicitly call out to that shell.
+                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                If this is not specified, the default behavior is defined by gRPC.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: |-
+                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                            The grace period is the duration in seconds after the processes running in the pod are sent
+                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                            Set this value longer than the expected cleanup time for your process.
+                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                            value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates stop immediately via
+                            the kill signal (no opportunity to shut down).
+                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                      type: object
+                    name:
+                      description: |-
+                        Name of the container specified as a DNS_LABEL.
+                        Each container in a pod must have a unique name (DNS_LABEL).
+                        Cannot be updated.
+                      type: string
+                    ports:
+                      description: |-
+                        List of ports to expose from the container. Not specifying a port here
+                        DOES NOT prevent that port from being exposed. Any port which is
+                        listening on the default "0.0.0.0" address inside a container will be
+                        accessible from the network.
+                        Modifying this array with strategic merge patch may corrupt the data.
+                        For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                        Cannot be updated.
+                      items:
+                        description: ContainerPort represents a network port in a
+                          single container.
+                        properties:
+                          containerPort:
+                            description: |-
+                              Number of port to expose on the pod's IP address.
+                              This must be a valid port number, 0 < x < 65536.
+                            format: int32
+                            type: integer
+                          hostIP:
+                            description: What host IP to bind the external port to.
+                            type: string
+                          hostPort:
+                            description: |-
+                              Number of port to expose on the host.
+                              If specified, this must be a valid port number, 0 < x < 65536.
+                              If HostNetwork is specified, this must match ContainerPort.
+                              Most containers do not need this.
+                            format: int32
+                            type: integer
+                          name:
+                            description: |-
+                              If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                              named port in a pod must have a unique name. Name for the port that can be
+                              referred to by services.
+                            type: string
+                          protocol:
+                            default: TCP
+                            description: |-
+                              Protocol for port. Must be UDP, TCP, or SCTP.
+                              Defaults to "TCP".
+                            type: string
+                        required:
+                        - containerPort
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - containerPort
+                      - protocol
+                      x-kubernetes-list-type: map
+                    readinessProbe:
+                      description: |-
+                        Periodic probe of container service readiness.
+                        Container will be removed from service endpoints if the probe fails.
+                        Cannot be updated.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                a shell, you need to explicitly call out to that shell.
+                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                If this is not specified, the default behavior is defined by gRPC.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: |-
+                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                            The grace period is the duration in seconds after the processes running in the pod are sent
+                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                            Set this value longer than the expected cleanup time for your process.
+                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                            value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates stop immediately via
+                            the kill signal (no opportunity to shut down).
+                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                      type: object
+                    resizePolicy:
+                      description: Resources resize policy for the container.
+                      items:
+                        description: ContainerResizePolicy represents resource resize
+                          policy for the container.
+                        properties:
+                          resourceName:
+                            description: |-
+                              Name of the resource to which this resource resize policy applies.
+                              Supported values: cpu, memory.
+                            type: string
+                          restartPolicy:
+                            description: |-
+                              Restart policy to apply when specified resource is resized.
+                              If not specified, it defaults to NotRequired.
+                            type: string
+                        required:
+                        - resourceName
+                        - restartPolicy
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    resources:
+                      description: |-
+                        Compute Resources required by this container.
+                        Cannot be updated.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+
+                            This is an alpha field and requires enabling the
+                            DynamicResourceAllocation feature gate.
+
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                              request:
+                                description: |-
+                                  Request is the name chosen for a request in the referenced claim.
+                                  If empty, everything from the claim is made available, otherwise
+                                  only the result of this request.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                    restartPolicy:
+                      description: |-
+                        RestartPolicy defines the restart behavior of individual containers in a pod.
+                        This field may only be set for init containers, and the only allowed value is "Always".
+                        For non-init containers or when this field is not specified,
+                        the restart behavior is defined by the Pod's restart policy and the container type.
+                        Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                        this init container will be continually restarted on
+                        exit until all regular containers have terminated. Once all regular
+                        containers have completed, all init containers with restartPolicy "Always"
+                        will be shut down. This lifecycle differs from normal init containers and
+                        is often referred to as a "sidecar" container. Although this init
+                        container still starts in the init container sequence, it does not wait
+                        for the container to complete before proceeding to the next init
+                        container. Instead, the next init container starts immediately after this
+                        init container is started, or after any startupProbe has successfully
+                        completed.
+                      type: string
+                    securityContext:
+                      description: |-
+                        SecurityContext defines the security options the container should be run with.
+                        If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                      properties:
+                        allowPrivilegeEscalation:
+                          description: |-
+                            AllowPrivilegeEscalation controls whether a process can gain more
+                            privileges than its parent process. This bool directly controls if
+                            the no_new_privs flag will be set on the container process.
+                            AllowPrivilegeEscalation is true always when the container is:
+                            1) run as Privileged
+                            2) has CAP_SYS_ADMIN
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        appArmorProfile:
+                          description: |-
+                            appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                            overrides the pod's appArmorProfile.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile loaded on the node that should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must match the loaded name of the profile.
+                                Must be set if and only if type is "Localhost".
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of AppArmor profile will be applied.
+                                Valid options are:
+                                  Localhost - a profile pre-loaded on the node.
+                                  RuntimeDefault - the container runtime's default profile.
+                                  Unconfined - no AppArmor enforcement.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        capabilities:
+                          description: |-
+                            The capabilities to add/drop when running containers.
+                            Defaults to the default set of capabilities granted by the container runtime.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            add:
+                              description: Added capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            drop:
+                              description: Removed capabilities
+                              items:
+                                description: Capability represent POSIX capabilities
+                                  type
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        privileged:
+                          description: |-
+                            Run container in privileged mode.
+                            Processes in privileged containers are essentially equivalent to root on the host.
+                            Defaults to false.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        procMount:
+                          description: |-
+                            procMount denotes the type of proc mount to use for the containers.
+                            The default value is Default which uses the container runtime defaults for
+                            readonly paths and masked paths.
+                            This requires the ProcMountType feature flag to be enabled.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        readOnlyRootFilesystem:
+                          description: |-
+                            Whether this container has a read-only root filesystem.
+                            Default is false.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: boolean
+                        runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: |-
+                            Indicates that the container must run as a non-root user.
+                            If true, the Kubelet will validate the image at runtime to ensure that it
+                            does not run as UID 0 (root) and fail to start the container if it does.
+                            If unset or false, no such validation will be performed.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: |-
+                            The SELinux context to be applied to the container.
+                            If unspecified, the container runtime will allocate a random SELinux context for each
+                            container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: |-
+                            The seccomp options to use by this container. If seccomp options are
+                            provided at both the pod & container level, the container options
+                            override the pod options.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied.
+                                Valid options are:
+
+                                Localhost - a profile defined in a file on the node should be used.
+                                RuntimeDefault - the container runtime default profile should be used.
+                                Unconfined - no profile should be applied.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options from the PodSecurityContext will be used.
+                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                GMSA credential spec named by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: |-
+                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                All of a Pod's containers must have the same effective HostProcess value
+                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: |-
+                                The UserName in Windows to run the entrypoint of the container process.
+                                Defaults to the user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    startupProbe:
+                      description: |-
+                        StartupProbe indicates that the Pod has successfully initialized.
+                        If specified, no other probes are executed until this completes successfully.
+                        If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                        This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                        when it might take a long time to load data or warm a cache, than during steady-state operation.
+                        This cannot be updated.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                      properties:
+                        exec:
+                          description: Exec specifies the action to take.
+                          properties:
+                            command:
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                a shell, you need to explicitly call out to that shell.
+                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        failureThreshold:
+                          description: |-
+                            Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                            Defaults to 3. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        grpc:
+                          description: GRPC specifies an action involving a GRPC port.
+                          properties:
+                            port:
+                              description: Port number of the gRPC service. Number
+                                must be in the range 1 to 65535.
+                              format: int32
+                              type: integer
+                            service:
+                              default: ""
+                              description: |-
+                                Service is the name of the service to place in the gRPC HealthCheckRequest
+                                (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                If this is not specified, the default behavior is defined by gRPC.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        httpGet:
+                          description: HTTPGet specifies the http request to perform.
+                          properties:
+                            host:
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
+                              type: string
+                            httpHeaders:
+                              description: Custom headers to set in the request. HTTP
+                                allows repeated headers.
+                              items:
+                                description: HTTPHeader describes a custom header
+                                  to be used in HTTP probes
+                                properties:
+                                  name:
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                    type: string
+                                  value:
+                                    description: The header field value
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            path:
+                              description: Path to access on the HTTP server.
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                            scheme:
+                              description: |-
+                                Scheme to use for connecting to the host.
+                                Defaults to HTTP.
+                              type: string
+                          required:
+                          - port
+                          type: object
+                        initialDelaySeconds:
+                          description: |-
+                            Number of seconds after the container has started before liveness probes are initiated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                        periodSeconds:
+                          description: |-
+                            How often (in seconds) to perform the probe.
+                            Default to 10 seconds. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        successThreshold:
+                          description: |-
+                            Minimum consecutive successes for the probe to be considered successful after having failed.
+                            Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                          format: int32
+                          type: integer
+                        tcpSocket:
+                          description: TCPSocket specifies an action involving a TCP
+                            port.
+                          properties:
+                            host:
+                              description: 'Optional: Host name to connect to, defaults
+                                to the pod IP.'
+                              type: string
+                            port:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
+                              x-kubernetes-int-or-string: true
+                          required:
+                          - port
+                          type: object
+                        terminationGracePeriodSeconds:
+                          description: |-
+                            Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                            The grace period is the duration in seconds after the processes running in the pod are sent
+                            a termination signal and the time when the processes are forcibly halted with a kill signal.
+                            Set this value longer than the expected cleanup time for your process.
+                            If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                            value overrides the value provided by the pod spec.
+                            Value must be non-negative integer. The value zero indicates stop immediately via
+                            the kill signal (no opportunity to shut down).
+                            This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                            Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                          format: int64
+                          type: integer
+                        timeoutSeconds:
+                          description: |-
+                            Number of seconds after which the probe times out.
+                            Defaults to 1 second. Minimum value is 1.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          format: int32
+                          type: integer
+                      type: object
+                    stdin:
+                      description: |-
+                        Whether this container should allocate a buffer for stdin in the container runtime. If this
+                        is not set, reads from stdin in the container will always result in EOF.
+                        Default is false.
+                      type: boolean
+                    stdinOnce:
+                      description: |-
+                        Whether the container runtime should close the stdin channel after it has been opened by
+                        a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                        sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                        first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                        at which time stdin is closed and remains closed until the container is restarted. If this
+                        flag is false, a container processes that reads from stdin will never receive an EOF.
+                        Default is false
+                      type: boolean
+                    terminationMessagePath:
+                      description: |-
+                        Optional: Path at which the file to which the container's termination message
+                        will be written is mounted into the container's filesystem.
+                        Message written is intended to be brief final status, such as an assertion failure message.
+                        Will be truncated by the node if greater than 4096 bytes. The total message length across
+                        all containers will be limited to 12kb.
+                        Defaults to /dev/termination-log.
+                        Cannot be updated.
+                      type: string
+                    terminationMessagePolicy:
+                      description: |-
+                        Indicate how the termination message should be populated. File will use the contents of
+                        terminationMessagePath to populate the container status message on both success and failure.
+                        FallbackToLogsOnError will use the last chunk of container log output if the termination
+                        message file is empty and the container exited with an error.
+                        The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                        Defaults to File.
+                        Cannot be updated.
+                      type: string
+                    tty:
+                      description: |-
+                        Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                        Default is false.
+                      type: boolean
+                    volumeDevices:
+                      description: volumeDevices is the list of block devices to be
+                        used by the container.
+                      items:
+                        description: volumeDevice describes a mapping of a raw block
+                          device within a container.
+                        properties:
+                          devicePath:
+                            description: devicePath is the path inside of the container
+                              that the device will be mapped to.
+                            type: string
+                          name:
+                            description: name must match the name of a persistentVolumeClaim
+                              in the pod
+                            type: string
+                        required:
+                        - devicePath
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - devicePath
+                      x-kubernetes-list-type: map
+                    volumeMounts:
+                      description: |-
+                        Pod volumes to mount into the container's filesystem.
+                        Cannot be updated.
+                      items:
+                        description: VolumeMount describes a mounting of a Volume
+                          within a container.
+                        properties:
+                          mountPath:
+                            description: |-
+                              Path within the container at which the volume should be mounted.  Must
+                              not contain ':'.
+                            type: string
+                          mountPropagation:
+                            description: |-
+                              mountPropagation determines how mounts are propagated from the host
+                              to container and the other way around.
+                              When not set, MountPropagationNone is used.
+                              This field is beta in 1.10.
+                              When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                              (which defaults to None).
+                            type: string
+                          name:
+                            description: This must match the Name of a Volume.
+                            type: string
+                          readOnly:
+                            description: |-
+                              Mounted read-only if true, read-write otherwise (false or unspecified).
+                              Defaults to false.
+                            type: boolean
+                          recursiveReadOnly:
+                            description: |-
+                              RecursiveReadOnly specifies whether read-only mounts should be handled
+                              recursively.
+
+                              If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                              If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                              recursively read-only.  If this field is set to IfPossible, the mount is made
+                              recursively read-only, if it is supported by the container runtime.  If this
+                              field is set to Enabled, the mount is made recursively read-only if it is
+                              supported by the container runtime, otherwise the pod will not be started and
+                              an error will be generated to indicate the reason.
+
+                              If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                              None (or be unspecified, which defaults to None).
+
+                              If this field is not specified, it is treated as an equivalent of Disabled.
+                            type: string
+                          subPath:
+                            description: |-
+                              Path within the volume from which the container's volume should be mounted.
+                              Defaults to "" (volume's root).
+                            type: string
+                          subPathExpr:
+                            description: |-
+                              Expanded path within the volume from which the container's volume should be mounted.
+                              Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                              Defaults to "" (volume's root).
+                              SubPathExpr and SubPath are mutually exclusive.
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - mountPath
+                      x-kubernetes-list-type: map
+                    workingDir:
+                      description: |-
+                        Container's working directory.
+                        If not specified, the container runtime's default will be used, which
+                        might be configured in the container image.
+                        Cannot be updated.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              skillPackUpdatePolicy:
+                default: Replace
+                description: |-
+                  SkillPackUpdatePolicy controls how workspace files seeded from "pack:"
+                  skill entries are reconciled on pod start.
+
+                  "Replace" (default) converges seeded pack files to the declared pack
+                  revision on every pod start: changed files are overwritten and files that
+                  were seeded by a previous revision but are no longer part of any declared
+                  pack are removed. The operator tracks the seeded file set in a manifest
+                  at /data/.skillpack-manifest on the data volume.
+
+                  "CreateOnly" preserves the legacy behavior: pack files are only copied
+                  when absent and never overwritten or removed, so updating a pinned pack
+                  revision does not refresh already-seeded contents (see #564).
+
+                  Only files at paths declared by pack: entries are affected; files from
+                  spec.workspace.initialFiles are always seeded create-only.
+                enum:
+                - Replace
+                - CreateOnly
+                type: string
+              skills:
+                description: |-
+                  Skills is a list of skills to install via init container.
+                  Each entry is either a ClawHub skill identifier (e.g., "@anthropic/mcp-server-fetch")
+                  or an npm package prefixed with "npm:" (e.g., "npm:@openclaw/matrix").
+                  npm lifecycle scripts are disabled for security (see #91).
+                items:
+                  type: string
+                maxItems: 20
+                type: array
+                x-kubernetes-list-type: set
+              storage:
+                description: Storage specifies persistent storage configuration
+                properties:
+                  persistence:
+                    description: Persistence configures the PersistentVolumeClaim
+                    properties:
+                      accessModes:
+                        default:
+                        - ReadWriteOnce
+                        description: AccessModes contains the desired access modes
+                          for the PVC
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        default: true
+                        description: Enabled enables persistent storage
+                        type: boolean
+                      existingClaim:
+                        description: ExistingClaim is the name of an existing PVC
+                          to use
+                        type: string
+                      orphan:
+                        default: true
+                        description: |-
+                          Orphan controls whether the PVC is retained when the OpenClawInstance is deleted.
+                          When true (the default), the operator removes the owner reference from the PVC
+                          before deleting the CR so Kubernetes does not garbage-collect it.
+                          Set to false if you want the PVC deleted together with the CR.
+                        type: boolean
+                      size:
+                        default: 10Gi
+                        description: Size is the size of the PVC (e.g., "10Gi")
+                        type: string
+                      storageClass:
+                        description: StorageClass is the name of the StorageClass
+                          to use
+                        type: string
+                    type: object
+                type: object
+              suspended:
+                default: false
+                description: |-
+                  Suspended scales the workload to zero replicas when true.
+                  Non-runtime resources (Service, ConfigMap, RBAC, NetworkPolicy, PVC)
+                  remain fully managed. Set to false to resume normal operation.
+                type: boolean
+              tailscale:
+                description: Tailscale configures Tailscale integration for tailnet
+                  access and HTTPS
+                properties:
+                  authKeySecretKey:
+                    default: authkey
+                    description: AuthKeySecretKey is the key in the referenced Secret.
+                    type: string
+                  authKeySecretRef:
+                    description: |-
+                      AuthKeySecretRef references a Secret containing the Tailscale auth key.
+                      The Secret must have a key matching AuthKeySecretKey (default: "authkey").
+                      Use ephemeral+reusable keys from the Tailscale admin console.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  authSSO:
+                    default: false
+                    description: |-
+                      AuthSSO enables passwordless login for tailnet members.
+                      Sets gateway.auth.allowTailscale=true in the OpenClaw config.
+                    type: boolean
+                  enabled:
+                    default: false
+                    description: Enabled enables Tailscale integration
+                    type: boolean
+                  hostname:
+                    description: Hostname sets the Tailscale device name (defaults
+                      to instance name).
+                    type: string
+                  image:
+                    description: |-
+                      Image configures the Tailscale sidecar container image.
+                      The same image is used for the sidecar and the init container that
+                      copies the tailscale CLI binary.
+                    properties:
+                      digest:
+                        description: Digest is the container image digest for supply
+                          chain security
+                        type: string
+                      repository:
+                        default: ghcr.io/tailscale/tailscale
+                        description: Repository is the container image repository
+                        type: string
+                      tag:
+                        default: latest
+                        description: Tag is the container image tag
+                        type: string
+                    type: object
+                  mode:
+                    default: serve
+                    description: |-
+                      Mode selects the Tailscale mode.
+                      "serve" exposes the instance to tailnet members only (default).
+                      "funnel" exposes the instance to the public internet via Tailscale Funnel.
+                    enum:
+                    - serve
+                    - funnel
+                    type: string
+                  resources:
+                    description: Resources specifies compute resources for the Tailscale
+                      sidecar container.
+                    properties:
+                      limits:
+                        description: Limits describes the maximum amount of compute
+                          resources allowed
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                      requests:
+                        description: Requests describes the minimum amount of compute
+                          resources required
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              webTerminal:
+                description: WebTerminal enables a browser-based terminal (ttyd) sidecar
+                  for debugging
+                properties:
+                  credential:
+                    description: |-
+                      Credential configures basic auth for the web terminal via a Secret.
+                      The Secret must have "username" and "password" keys.
+                    properties:
+                      secretRef:
+                        description: SecretRef references a Secret containing "username"
+                          and "password" keys
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - secretRef
+                    type: object
+                  enabled:
+                    default: false
+                    description: Enabled enables the ttyd web terminal sidecar for
+                      browser-based shell access
+                    type: boolean
+                  image:
+                    description: Image configures the ttyd container image
+                    properties:
+                      digest:
+                        description: Digest is the container image digest for supply
+                          chain security
+                        type: string
+                      repository:
+                        default: docker.io/tsl0922/ttyd
+                        description: Repository is the container image repository
+                        type: string
+                      tag:
+                        default: latest
+                        description: Tag is the container image tag
+                        type: string
+                    type: object
+                  readOnly:
+                    default: false
+                    description: ReadOnly starts ttyd in read-only mode (view-only,
+                      no input)
+                    type: boolean
+                  resources:
+                    description: Resources specifies compute resources for the ttyd
+                      container
+                    properties:
+                      limits:
+                        description: Limits describes the maximum amount of compute
+                          resources allowed
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                      requests:
+                        description: Requests describes the minimum amount of compute
+                          resources required
+                        properties:
+                          cpu:
+                            description: CPU resource (e.g., "500m", "2")
+                            type: string
+                          memory:
+                            description: Memory resource (e.g., "512Mi", "2Gi")
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              workspace:
+                description: |-
+                  Workspace configures initial workspace files seeded into the instance.
+                  Files are copied once on first boot and never overwritten, so agent
+                  modifications survive pod restarts.
+                properties:
+                  additionalWorkspaces:
+                    description: |-
+                      AdditionalWorkspaces configures workspace files for secondary agents.
+                      Each entry seeds files to ~/.openclaw/workspace-<name>/, matching the
+                      workspace path configured in spec.config.raw.agents.list[].workspace.
+                    items:
+                      description: |-
+                        AdditionalWorkspace defines a named workspace for a secondary agent.
+                        The operator seeds files to ~/.openclaw/workspace-<name>/.
+                      properties:
+                        configMapRef:
+                          description: ConfigMapRef references an external ConfigMap
+                            whose keys become workspace files.
+                          properties:
+                            name:
+                              description: Name is the name of the ConfigMap to reference.
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        fileUpdatePolicy:
+                          description: |-
+                            FileUpdatePolicy is the default update policy for files seeded into this
+                            workspace. When unset it inherits spec.workspace.fileUpdatePolicy, so the
+                            default workspace and its secondaries cannot silently drift apart.
+                          enum:
+                          - CreateOnly
+                          - Replace
+                          type: string
+                        initialDirectories:
+                          description: InitialDirectories is a list of directories
+                            to create inside this workspace.
+                          items:
+                            type: string
+                          maxItems: 20
+                          type: array
+                        initialFiles:
+                          additionalProperties:
+                            type: string
+                          description: InitialFiles maps filenames to their content
+                            (same as spec.workspace.initialFiles).
+                          maxProperties: 50
+                          type: object
+                        managedFiles:
+                          description: |-
+                            ManagedFiles declares per-path update policies for this workspace,
+                            overriding its effective FileUpdatePolicy for the listed paths.
+                          items:
+                            description: ManagedWorkspaceFile declares the update
+                              policy for a single workspace file.
+                            properties:
+                              path:
+                                description: |-
+                                  Path is the workspace-relative destination path, e.g. "AGENTS.md" or
+                                  "docs/BOUNDARIES.md". Absolute paths and ".." traversal are rejected.
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[^/].*$
+                                type: string
+                              updatePolicy:
+                                default: Replace
+                                description: |-
+                                  UpdatePolicy overrides the workspace-level FileUpdatePolicy for this path.
+                                  Defaults to Replace, since listing a path here is an explicit statement
+                                  that the operator owns it.
+                                enum:
+                                - CreateOnly
+                                - Replace
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          maxItems: 50
+                          type: array
+                        name:
+                          description: |-
+                            Name identifies this workspace. The operator seeds files to
+                            ~/.openclaw/workspace-<name>/. Must match the workspace path
+                            configured in spec.config.raw.agents.list[].workspace.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]+(-[a-z0-9]+)*$
+                          type: string
+                        skills:
+                          description: |-
+                            Skills is a list of skills to install scoped to this workspace, using the
+                            same reference formats as the top-level spec.skills: a ClawHub skill
+                            identifier (installed into workspace-<name>/skills/ via clawhub's
+                            --workdir), an npm package prefixed with "npm:" (npm binaries are
+                            installed globally and shared across workspaces), or a GitHub-hosted
+                            skill pack prefixed with "pack:" (resolved files are seeded into
+                            workspace-<name>/ and reconciled per spec.skillPackUpdatePolicy).
+                          items:
+                            type: string
+                          maxItems: 20
+                          type: array
+                          x-kubernetes-list-type: set
+                      required:
+                      - name
+                      type: object
+                    maxItems: 10
+                    type: array
+                  bootstrap:
+                    description: |-
+                      Bootstrap controls the operator-managed BOOTSTRAP.md file injected into
+                      the default workspace to guide first-run agent onboarding.
+                    properties:
+                      enabled:
+                        default: true
+                        description: |-
+                          Enabled controls whether the operator injects its BOOTSTRAP.md into the
+                          default workspace. When true (the default), the init container seeds
+                          BOOTSTRAP.md on pod start if the file is not present on the PVC.
+
+                          Set to false if the agent has already completed bootstrap and you don't
+                          want the operator to recreate the file on pod restart or config change.
+                          OpenClaw deletes BOOTSTRAP.md after applying it, so without this flag
+                          every restart would cause the agent to re-run bootstrap. See #463.
+                        type: boolean
+                    type: object
+                  configMapRef:
+                    description: |-
+                      ConfigMapRef references an external ConfigMap whose keys become workspace files.
+                      All keys in the referenced ConfigMap are included as workspace files.
+                      This is useful for GitOps workflows where workspace files (AGENT.md, SOUL.md, etc.)
+                      are managed as standalone files and bundled via Kustomize configMapGenerator or similar.
+
+                      Merge priority (highest wins):
+                      1. Operator-injected files (ENVIRONMENT.md, BOOTSTRAP.md, SELFCONFIG.md, selfconfig.sh)
+                      2. Inline initialFiles
+                      3. External configMapRef entries
+                      4. Skill pack files
+                    properties:
+                      name:
+                        description: Name is the name of the ConfigMap to reference.
+                        minLength: 1
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  fileUpdatePolicy:
+                    default: CreateOnly
+                    description: |-
+                      FileUpdatePolicy is the default update policy for every file seeded into
+                      this workspace. CreateOnly (the default) keeps the seed-once behavior:
+                      once a destination file exists on persistent storage, later source
+                      changes never replace it. Replace makes files converge whenever their
+                      source content changes.
+
+                      Per-path overrides live in ManagedFiles.
+                    enum:
+                    - CreateOnly
+                    - Replace
+                    type: string
+                  initialDirectories:
+                    description: |-
+                      InitialDirectories is a list of directories to create (mkdir -p)
+                      inside the workspace directory. Nested paths like "tools/scripts" are allowed.
+                    items:
+                      type: string
+                    maxItems: 20
+                    type: array
+                  initialFiles:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      InitialFiles maps filenames to their content. Each file is written
+                      to the workspace directory only if it does not already exist.
+                    maxProperties: 50
+                    type: object
+                  managedFiles:
+                    description: |-
+                      ManagedFiles declares per-path update policies, overriding
+                      FileUpdatePolicy for the listed paths.
+
+                      A path listed here is managed even if no source currently provides it, so
+                      adding the file to a configMapRef later does not require a CR change.
+                    items:
+                      description: ManagedWorkspaceFile declares the update policy
+                        for a single workspace file.
+                      properties:
+                        path:
+                          description: |-
+                            Path is the workspace-relative destination path, e.g. "AGENTS.md" or
+                            "docs/BOUNDARIES.md". Absolute paths and ".." traversal are rejected.
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[^/].*$
+                          type: string
+                        updatePolicy:
+                          default: Replace
+                          description: |-
+                            UpdatePolicy overrides the workspace-level FileUpdatePolicy for this path.
+                            Defaults to Replace, since listing a path here is an explicit statement
+                            that the operator owns it.
+                          enum:
+                          - CreateOnly
+                          - Replace
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    maxItems: 50
+                    type: array
+                type: object
+            type: object
+          status:
+            description: OpenClawInstanceStatus defines the observed state of OpenClawInstance
+            properties:
+              autoUpdate:
+                description: AutoUpdate tracks the state of automatic version updates
+                properties:
+                  currentVersion:
+                    description: CurrentVersion is the version currently running
+                    type: string
+                  failedVersion:
+                    description: |-
+                      FailedVersion is a version that failed health checks and will be skipped in future checks
+                      Cleared when a newer version becomes available
+                    type: string
+                  lastCheckTime:
+                    description: LastCheckTime is when the registry was last checked
+                      for new versions
+                    format: date-time
+                    type: string
+                  lastUpdateError:
+                    description: LastUpdateError records the error from the last failed
+                      update attempt
+                    type: string
+                  lastUpdateTime:
+                    description: LastUpdateTime is when the last successful update
+                      was applied
+                    format: date-time
+                    type: string
+                  latestVersion:
+                    description: LatestVersion is the latest version available in
+                      the registry
+                    type: string
+                  pendingVersion:
+                    description: PendingVersion is set during an in-flight update
+                    type: string
+                  preUpdateBackupPath:
+                    description: PreUpdateBackupPath is the S3 path of the pre-update
+                      backup (used for rollback restore)
+                    type: string
+                  previousVersion:
+                    description: PreviousVersion is the version before the last update
+                      (used for rollback)
+                    type: string
+                  rollbackCount:
+                    description: |-
+                      RollbackCount tracks consecutive rollbacks; auto-update pauses after 3
+                      Reset to 0 on any successful update
+                    format: int32
+                    type: integer
+                  updatePhase:
+                    description: UpdatePhase tracks progress of an in-flight update
+                    enum:
+                    - ""
+                    - BackingUp
+                    - ApplyingUpdate
+                    - HealthCheck
+                    - RollingBack
+                    type: string
+                type: object
+              backingUpSince:
+                description: |-
+                  BackingUpSince is the timestamp when the instance entered the BackingUp phase.
+                  Used to enforce spec.backup.timeout. Set once when the phase transitions to BackingUp
+                  and cleared when the phase changes.
+                format: date-time
+                type: string
+              backupJobName:
+                description: BackupJobName is the name of the active backup Job
+                type: string
+              canvasEndpoint:
+                description: CanvasEndpoint is the endpoint for the OpenClaw canvas
+                type: string
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the instance's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              gatewayEndpoint:
+                description: GatewayEndpoint is the endpoint for the OpenClaw gateway
+                type: string
+              lastBackupPath:
+                description: LastBackupPath is the S3 path of the last successful
+                  backup
+                type: string
+              lastBackupTime:
+                description: LastBackupTime is the timestamp of the last successful
+                  backup
+                format: date-time
+                type: string
+              lastReconcileTime:
+                description: LastReconcileTime is the timestamp of the last reconciliation
+                format: date-time
+                type: string
+              managedResources:
+                description: ManagedResources tracks the resources created by the
+                  operator
+                properties:
+                  backupCronJob:
+                    description: BackupCronJob is the name of the managed periodic
+                      backup CronJob
+                    type: string
+                  basicAuthSecret:
+                    description: BasicAuthSecret is the name of the auto-generated
+                      Ingress Basic Auth htpasswd Secret
+                    type: string
+                  chromiumPVC:
+                    description: ChromiumPVC is the name of the managed Chromium browser
+                      profile PVC
+                    type: string
+                  configMap:
+                    description: ConfigMap is the name of the managed ConfigMap
+                    type: string
+                  deployment:
+                    description: Deployment is the name of the legacy Deployment (deprecated,
+                      used during migration)
+                    type: string
+                  gatewayTokenSecret:
+                    description: GatewayTokenSecret is the name of the auto-generated
+                      gateway token Secret
+                    type: string
+                  grafanaDashboardInstance:
+                    description: GrafanaDashboardInstance is the name of the instance
+                      detail dashboard ConfigMap
+                    type: string
+                  grafanaDashboardOperator:
+                    description: GrafanaDashboardOperator is the name of the operator
+                      overview dashboard ConfigMap
+                    type: string
+                  horizontalPodAutoscaler:
+                    description: HorizontalPodAutoscaler is the name of the managed
+                      HPA
+                    type: string
+                  httpRoute:
+                    description: HTTPRoute is the name of the managed Gateway API
+                      HTTPRoute
+                    type: string
+                  networkPolicy:
+                    description: NetworkPolicy is the name of the managed NetworkPolicy
+                    type: string
+                  podDisruptionBudget:
+                    description: PodDisruptionBudget is the name of the managed PDB
+                    type: string
+                  prometheusRule:
+                    description: PrometheusRule is the name of the managed PrometheusRule
+                    type: string
+                  pvc:
+                    description: PVC is the name of the managed PersistentVolumeClaim
+                    type: string
+                  role:
+                    description: Role is the name of the managed Role
+                    type: string
+                  roleBinding:
+                    description: RoleBinding is the name of the managed RoleBinding
+                    type: string
+                  service:
+                    description: Service is the name of the managed Service
+                    type: string
+                  serviceAccount:
+                    description: ServiceAccount is the name of the managed ServiceAccount
+                    type: string
+                  serviceMonitor:
+                    description: ServiceMonitor is the name of the managed ServiceMonitor
+                    type: string
+                  statefulSet:
+                    description: StatefulSet is the name of the managed StatefulSet
+                    type: string
+                  tailscaleStateSecret:
+                    description: |-
+                      TailscaleStateSecret is the name of the Secret used to persist Tailscale
+                      node identity and TLS certificate state across pod restarts
+                    type: string
+                  workspaceFiles:
+                    description: |-
+                      WorkspaceFiles reports the resolved update policy and applied source hash
+                      for each declaratively managed workspace file, so it is visible why a
+                      file was or was not rewritten.
+                    items:
+                      description: |-
+                        ManagedWorkspaceFileStatus reports the state of one declaratively managed
+                        workspace file.
+                      properties:
+                        path:
+                          description: Path is the workspace-relative destination
+                            path.
+                          type: string
+                        sourceHash:
+                          description: |-
+                            SourceHash is the SHA-256 of the source content the operator currently
+                            declares for this path. The pod rewrites the destination when this value
+                            moves; while it holds steady, local edits are left alone.
+
+                            Empty when no source currently provides the path -- the path stays
+                            managed so a later source addition takes effect without a CR change.
+                          type: string
+                        updatePolicy:
+                          description: UpdatePolicy is the resolved policy for this
+                            path.
+                          enum:
+                          - CreateOnly
+                          - Replace
+                          type: string
+                        workspace:
+                          description: Workspace is the additional workspace name,
+                            or empty for the default workspace.
+                          type: string
+                      required:
+                      - path
+                      - updatePolicy
+                      type: object
+                    type: array
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  by the controller
+                format: int64
+                type: integer
+              phase:
+                description: Phase represents the current lifecycle phase of the instance
+                enum:
+                - Pending
+                - Provisioning
+                - Running
+                - Degraded
+                - Failed
+                - Terminating
+                - BackingUp
+                - Restoring
+                - Updating
+                - Suspended
+                type: string
+              restoreJobName:
+                description: RestoreJobName is the name of the active restore Job
+                type: string
+              restoredFrom:
+                description: RestoredFrom is the S3 path this instance was restored
+                  from
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/openclaw-operator/0.40.0/manifests/openclaw.rocks_openclawselfconfigs.yaml
+++ b/operators/openclaw-operator/0.40.0/manifests/openclaw.rocks_openclawselfconfigs.yaml
@@ -1,0 +1,148 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: openclawselfconfigs.openclaw.rocks
+spec:
+  group: openclaw.rocks
+  names:
+    kind: OpenClawSelfConfig
+    listKind: OpenClawSelfConfigList
+    plural: openclawselfconfigs
+    shortNames:
+    - ocsc
+    singular: openclawselfconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.instanceRef
+      name: Instance
+      type: string
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          OpenClawSelfConfig is the Schema for the openclawselfconfigs API.
+          It represents a request from an agent to modify its own OpenClawInstance spec.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OpenClawSelfConfigSpec defines the desired changes to an
+              OpenClawInstance.
+            properties:
+              addEnvVars:
+                description: AddEnvVars is a list of environment variables to add
+                  (plain values only).
+                items:
+                  description: SelfConfigEnvVar defines a plain-value environment
+                    variable (no secret refs).
+                  properties:
+                    name:
+                      description: Name of the environment variable.
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Value of the environment variable.
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                maxItems: 10
+                type: array
+              addSkills:
+                description: AddSkills is a list of skills to add to the instance.
+                items:
+                  type: string
+                maxItems: 10
+                type: array
+              addWorkspaceFiles:
+                additionalProperties:
+                  type: string
+                description: AddWorkspaceFiles maps filenames to content to add to
+                  the workspace.
+                maxProperties: 10
+                type: object
+              configPatch:
+                description: ConfigPatch is a partial JSON configuration to deep-merge
+                  into the instance config.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              instanceRef:
+                description: InstanceRef is the name of the parent OpenClawInstance
+                  in the same namespace.
+                minLength: 1
+                type: string
+              removeEnvVars:
+                description: RemoveEnvVars is a list of environment variable names
+                  to remove.
+                items:
+                  type: string
+                maxItems: 10
+                type: array
+              removeSkills:
+                description: RemoveSkills is a list of skills to remove from the instance.
+                items:
+                  type: string
+                maxItems: 10
+                type: array
+              removeWorkspaceFiles:
+                description: RemoveWorkspaceFiles is a list of workspace filenames
+                  to remove.
+                items:
+                  type: string
+                maxItems: 10
+                type: array
+            required:
+            - instanceRef
+            type: object
+          status:
+            description: OpenClawSelfConfigStatus defines the observed state of OpenClawSelfConfig.
+            properties:
+              completionTime:
+                description: CompletionTime is when the request reached a terminal
+                  phase.
+                format: date-time
+                type: string
+              message:
+                description: Message provides human-readable details about the current
+                  phase.
+                type: string
+              phase:
+                description: Phase is the processing state of this request.
+                enum:
+                - Pending
+                - Applied
+                - Failed
+                - Denied
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/operators/openclaw-operator/0.40.0/metadata/annotations.yaml
+++ b/operators/openclaw-operator/0.40.0/metadata/annotations.yaml
@@ -1,0 +1,8 @@
+annotations:
+  operators.operatorframework.io.bundle.mediatype.v1: "registry+v1"
+  operators.operatorframework.io.bundle.manifests.v1: "manifests/"
+  operators.operatorframework.io.bundle.metadata.v1: "metadata/"
+  operators.operatorframework.io.bundle.package.v1: "openclaw-operator"
+  operators.operatorframework.io.bundle.channels.v1: "stable"
+  operators.operatorframework.io.bundle.channel.default.v1: "stable"
+  com.redhat.openshift.versions: "v4.15"


### PR DESCRIPTION
### Update to openclaw-operator

**Version:** 0.40.0
**Operator:** [OpenClaw Kubernetes Operator](https://github.com/paperclipinc/openclaw-operator)

#### Changes
See [release notes](https://github.com/paperclipinc/openclaw-operator/releases/tag/v0.40.0).

#### Testing
- CI tests pass on the source repository
- Container image is published and signed at `ghcr.io/paperclipinc/openclaw-operator:v0.40.0`