### PR TITLE
operator libredb-studio-operator (0.14.1)

### DIFF
--- a/operators/libredb-studio-operator/0.14.1/manifests/libredb-studio-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/operators/libredb-studio-operator/0.14.1/manifests/libredb-studio-operator-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: libredb-studio-operator
+    control-plane: controller-manager
+  name: libredb-studio-operator-controller-manager-metrics-service
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: libredb-studio-operator
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/operators/libredb-studio-operator/0.14.1/manifests/libredb-studio-operator-libredbstudio-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/libredb-studio-operator/0.14.1/manifests/libredb-studio-operator-libredbstudio-admin-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,21 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: libredb-studio-operator
+  name: libredb-studio-operator-libredbstudio-admin-role
+rules:
+- apiGroups:
+  - studio.libredb.org
+  resources:
+  - libredbstudios
+  verbs:
+  - '*'
+- apiGroups:
+  - studio.libredb.org
+  resources:
+  - libredbstudios/status
+  verbs:
+  - get

--- a/operators/libredb-studio-operator/0.14.1/manifests/libredb-studio-operator-libredbstudio-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/libredb-studio-operator/0.14.1/manifests/libredb-studio-operator-libredbstudio-editor-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: libredb-studio-operator
+  name: libredb-studio-operator-libredbstudio-editor-role
+rules:
+- apiGroups:
+  - studio.libredb.org
+  resources:
+  - libredbstudios
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - studio.libredb.org
+  resources:
+  - libredbstudios/status
+  verbs:
+  - get

--- a/operators/libredb-studio-operator/0.14.1/manifests/libredb-studio-operator-libredbstudio-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/libredb-studio-operator/0.14.1/manifests/libredb-studio-operator-libredbstudio-viewer-role_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: libredb-studio-operator
+  name: libredb-studio-operator-libredbstudio-viewer-role
+rules:
+- apiGroups:
+  - studio.libredb.org
+  resources:
+  - libredbstudios
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - studio.libredb.org
+  resources:
+  - libredbstudios/status
+  verbs:
+  - get

--- a/operators/libredb-studio-operator/0.14.1/manifests/libredb-studio-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/operators/libredb-studio-operator/0.14.1/manifests/libredb-studio-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,10 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: libredb-studio-operator-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/operators/libredb-studio-operator/0.14.1/manifests/libredb-studio-operator.clusterserviceversion.yaml
+++ b/operators/libredb-studio-operator/0.14.1/manifests/libredb-studio-operator.clusterserviceversion.yaml
@@ -1,0 +1,379 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "studio.libredb.org/v1alpha1",
+          "kind": "LibreDBStudio",
+          "metadata": {
+            "name": "libredbstudio-sample"
+          },
+          "spec": {
+            "persistence": {
+              "enabled": true,
+              "size": "1Gi"
+            },
+            "replicaCount": 1
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Database, Developer Tools
+    containerImage: ghcr.io/libredb/libredb-studio-operator:0.14.1
+    createdAt: "2026-09-08T14:52:40Z"
+    description: Open-source web-based SQL IDE for sixteen engines - PostgreSQL, MySQL,
+      Oracle, SQL Server, SQLite, DuckDB, MongoDB, Redis, Couchbase, ClickHouse, Apache
+      Druid, Elasticsearch, OpenSearch, Apache Trino, Apache Cassandra and libSQL
+      - with AI-powered query assistance.
+    olm.skipRange: '>=0.0.0 <0.14.1'
+    operators.operatorframework.io/builder: operator-sdk-v1.42.3
+    operators.operatorframework.io/project_layout: helm.sdk.operatorframework.io/v1
+    repository: https://github.com/libredb/libredb-studio
+    support: LibreDB
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/os.linux: supported
+  name: libredb-studio-operator.v0.14.1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: A LibreDB Studio instance managed by the operator. The spec mirrors
+        the Helm chart values; every field left unset falls back to the chart defaults.
+      displayName: LibreDB Studio
+      kind: LibreDBStudio
+      name: libredbstudios.studio.libredb.org
+      version: v1alpha1
+  description: |
+    LibreDB Studio is an open-source, web-based SQL IDE. Query PostgreSQL,
+    MySQL, Oracle, SQL Server, SQLite, libSQL, DuckDB, MongoDB, Redis, Couchbase,
+    ClickHouse, Apache Druid, Elasticsearch, OpenSearch, Apache Trino and Apache
+    Cassandra from the browser —
+    with AI-powered query assistance (natural-language-to-SQL, explain, fix),
+    an ERD viewer, schema diff and a data profiler. No desktop client required.
+
+    This Helm-based operator installs and manages LibreDB Studio through the
+    `LibreDBStudio` custom resource, which exposes the full Helm chart
+    configuration. With no credentials provided, the instance starts in
+    zero-config bootstrap mode: a JWT secret is generated automatically and a
+    first-run admin account is created. For production, switch
+    `config.authBootstrap` to `"off"` and supply an existing Secret.
+
+    ### Usage
+
+    Create a `LibreDBStudio` resource; every field left unset falls back to
+    the chart defaults. See the sample on this page for a minimal start.
+  displayName: LibreDB Studio
+  icon:
+  - base64data: PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjIwMCIgdmlld0JveD0iMCAwIDIwMCAyMDAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPGRlZnM+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImxvZ28tZ3JhZGllbnQiIHgxPSIwJSIgeTE9IjAlIiB4Mj0iMTAwJSIgeTI9IjEwMCUiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjNEY0NkU1IiAvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiM5MzMzRUEiIC8+CiAgICA8L2xpbmVhckdyYWRpZW50PgogICAgPGxpbmVhckdyYWRpZW50IGlkPSJjb2RlLWdyYWRpZW50IiB4MT0iMCUiIHkxPSIwJSIgeDI9IjEwMCUiIHkyPSIxMDAlIj4KICAgICAgPHN0b3Agb2Zmc2V0PSIwJSIgc3RvcC1jb2xvcj0iIzEwQjk4MSIgLz4KICAgICAgPHN0b3Agb2Zmc2V0PSIxMDAlIiBzdG9wLWNvbG9yPSIjM0I4MkY2IiAvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICAgIDxmaWx0ZXIgaWQ9Imdsb3ciIHg9Ii0yMCUiIHk9Ii0yMCUiIHdpZHRoPSIxNDAlIiBoZWlnaHQ9IjE0MCUiPgogICAgICA8ZmVHYXVzc2lhbkJsdXIgc3RkRGV2aWF0aW9uPSIzIiByZXN1bHQ9ImJsdXIiIC8+CiAgICAgIDxmZUNvbXBvc2l0ZSBpbj0iU291cmNlR3JhcGhpYyIgaW4yPSJibHVyIiBvcGVyYXRvcj0ib3ZlciIgLz4KICAgIDwvZmlsdGVyPgogIDwvZGVmcz4KICAKICA8IS0tIEJhY2tncm91bmQgU2hhcGUgLS0+CiAgPHBhdGggZD0iTTEwMCAyMEwxNjkuMjgyIDYwVjE0MEwxMDAgMTgwTDMwLjcxOCAxNDBWNjBMMTAwIDIwWiIgZmlsbD0idXJsKCNsb2dvLWdyYWRpZW50KSIgZmlsbC1vcGFjaXR5PSIwLjA1IiBzdHJva2U9InVybCgjbG9nby1ncmFkaWVudCkiIHN0cm9rZS13aWR0aD0iMS41Ii8+CiAgCiAgPCEtLSBEYXRhYmFzZSBMYXllcnMgKERlLWVtcGhhc2l6ZWQpIC0tPgogIDxnIG9wYWNpdHk9IjAuMyI+CiAgICA8cmVjdCB4PSI3MCIgeT0iODAiIHdpZHRoPSI2MCIgaGVpZ2h0PSIxMCIgcng9IjIiIGZpbGw9InVybCgjbG9nby1ncmFkaWVudCkiIC8+CiAgICA8cmVjdCB4PSI3MCIgeT0iOTUiIHdpZHRoPSI2MCIgaGVpZ2h0PSIxMCIgcng9IjIiIGZpbGw9InVybCgjbG9nby1ncmFkaWVudCkiIC8+CiAgICA8cmVjdCB4PSI3MCIgeT0iMTEwIiB3aWR0aD0iNjAiIGhlaWdodD0iMTAiIHJ4PSIyIiBmaWxsPSJ1cmwoI2xvZ28tZ3JhZGllbnQpIiAvPgogIDwvZz4KICAKICA8IS0tIENvZGluZyBCcmFja2V0cyAoRW1waGFzaXplZCkgLS0+CiAgPGcgZmlsdGVyPSJ1cmwoI2dsb3cpIj4KICAgIDxwYXRoIGQ9Ik01NSA3MEwzNSAxMDBMNTUgMTMwIiBzdHJva2U9InVybCgjY29kZS1ncmFkaWVudCkiIHN0cm9rZS13aWR0aD0iNiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiAvPgogICAgPHBhdGggZD0iTTE0NSA3MEwxNjUgMTAwTDE0NSAxMzAiIHN0cm9rZT0idXJsKCNjb2RlLWdyYWRpZW50KSIgc3Ryb2tlLXdpZHRoPSI2IiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIC8+CiAgPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          - studio.libredb.org
+          resources:
+          - libredbstudios
+          - libredbstudios/status
+          - libredbstudios/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          - networkpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          - cronjobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: libredb-studio-operator-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: kustomize
+          app.kubernetes.io/name: libredb-studio-operator
+          control-plane: controller-manager
+        name: libredb-studio-operator-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/name: libredb-studio-operator
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                app.kubernetes.io/name: libredb-studio-operator
+                control-plane: controller-manager
+            spec:
+              containers:
+              - args:
+                - --metrics-require-rbac
+                - --metrics-secure
+                - --metrics-bind-address=:8443
+                - --leader-elect
+                - --leader-election-id=libredb-studio-operator
+                - --health-probe-bind-address=:8081
+                image: ghcr.io/libredb/libredb-studio-operator:0.14.1
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: libredb-studio-operator-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: libredb-studio-operator-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - sql
+  - database
+  - ide
+  - sql-editor
+  - postgresql
+  - mysql
+  - mongodb
+  - redis
+  - oracle
+  - sql-server
+  - sqlite
+  - couchbase
+  - clickhouse
+  - druid
+  - elasticsearch
+  - opensearch
+  - trino
+  - cassandra
+  - libsql
+  - turso
+  - duckdb
+  links:
+  - name: Website
+    url: https://libredb.org
+  - name: Source Code
+    url: https://github.com/libredb/libredb-studio
+  - name: Helm Chart
+    url: https://libredb.org/libredb-studio/
+  maintainers:
+  - email: yusuf.gundogdu@sekoya.tech
+    name: Yusuf Gündoğdu
+  - email: cevheri.bozoglan@sekoya.tech
+    name: Mehmet Cevheri Bozoğlan
+  maturity: alpha
+  minKubeVersion: 1.26.0
+  provider:
+    name: LibreDB
+    url: https://libredb.org
+  replaces: libredb-studio-operator.v0.9.59
+  version: 0.14.1

--- a/operators/libredb-studio-operator/0.14.1/manifests/studio.libredb.org_libredbstudios.yaml
+++ b/operators/libredb-studio-operator/0.14.1/manifests/studio.libredb.org_libredbstudios.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: libredbstudios.studio.libredb.org
+spec:
+  group: studio.libredb.org
+  names:
+    kind: LibreDBStudio
+    listKind: LibreDBStudioList
+    plural: libredbstudios
+    singular: libredbstudio
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LibreDBStudio is the Schema for the libredbstudios API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Spec defines the desired state of LibreDBStudio
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status defines the observed state of LibreDBStudio
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/libredb-studio-operator/0.14.1/metadata/annotations.yaml
+++ b/operators/libredb-studio-operator/0.14.1/metadata/annotations.yaml
@@ -1,0 +1,14 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: libredb-studio-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.3
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: helm.sdk.operatorframework.io/v1
+
+  # Annotations for testing.
+  operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+  operators.operatorframework.io.test.config.v1: tests/scorecard/

--- a/operators/libredb-studio-operator/0.14.1/tests/scorecard/config.yaml
+++ b/operators/libredb-studio-operator/0.14.1/tests/scorecard/config.yaml
@@ -1,0 +1,70 @@
+apiVersion: scorecard.operatorframework.io/v1alpha3
+kind: Configuration
+metadata:
+  name: config
+stages:
+- parallel: true
+  tests:
+  - entrypoint:
+    - scorecard-test
+    - basic-check-spec
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: basic
+      test: basic-check-spec-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-bundle-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-bundle-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-validation
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-crds-have-validation-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-crds-have-resources
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-crds-have-resources-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-spec-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-spec-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+  - entrypoint:
+    - scorecard-test
+    - olm-status-descriptors
+    image: quay.io/operator-framework/scorecard-test:v1.42.3
+    labels:
+      suite: olm
+      test: olm-status-descriptors-test
+    storage:
+      spec:
+        mountPath: {}
+storage:
+  spec:
+    mountPath: {}


### PR DESCRIPTION
Update libredb-studio-operator from 0.9.59 to 0.14.1.

Release notes: https://github.com/libredb/libredb-studio/releases/tag/0.14.1
Controller image: `ghcr.io/libredb/libredb-studio-operator:0.14.1`, public, linux/amd64 and linux/arm64.

Reopened from #9218, which I closed by mistake while fixing its bundle.
That one failed the deploy jobs because the CSV had only an `olm.skipRange` and no `replaces`, so `opm index add --mode replaces` pruned 0.9.59 out of the channel.
The CSV now carries `replaces: libredb-studio-operator.v0.9.59` as well, which I checked locally with the same command and a local registry.

The skip range stays for the direct upgrade path.
0.14.0 was never submitted here, which the range covers.

Bundle validated with the operatorframework suite.
One signed commit, nothing outside the new bundle directory.
