### PR TITLE
operator [N] [CI] k8boss-operator (0.1.0)

### DIFF
--- a/operators/k8boss-operator/0.1.0/manifests/k8boss-operator.clusterserviceversion.yaml
+++ b/operators/k8boss-operator/0.1.0/manifests/k8boss-operator.clusterserviceversion.yaml
@@ -1,0 +1,459 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "k8boss.io/v1alpha1",
+          "kind": "PlatformConfig",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "flowProvider": "Hubble",
+            "paused": false
+          }
+        },
+        {
+          "apiVersion": "k8boss.io/v1alpha1",
+          "kind": "RuntimeSecurityPolicy",
+          "metadata": {
+            "name": "payments-api-runtime"
+          },
+          "spec": {
+            "deniedBinaries": [
+              "/bin/sh",
+              "/bin/bash",
+              "/usr/bin/nc"
+            ],
+            "selector": {
+              "matchLabels": {
+                "app.kubernetes.io/name": "payments-api"
+              }
+            },
+            "tracingPolicyRef": "block-shell-exec"
+          }
+        },
+        {
+          "apiVersion": "k8boss.io/v1alpha1",
+          "kind": "SegmentationPolicy",
+          "metadata": {
+            "name": "payments-api-segmentation"
+          },
+          "spec": {
+            "egress": [
+              {
+                "peerSelector": {
+                  "app.kubernetes.io/name": "payments-db"
+                },
+                "ports": [
+                  5432
+                ]
+              }
+            ],
+            "ingress": [
+              {
+                "peerNamespace": "storefront",
+                "peerSelector": {
+                  "app.kubernetes.io/name": "checkout-web"
+                },
+                "ports": [
+                  8443
+                ]
+              }
+            ],
+            "providerRef": "Hubble",
+            "selector": {
+              "matchLabels": {
+                "app.kubernetes.io/name": "payments-api"
+              }
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Security,Networking,Monitoring
+    containerImage: ghcr.io/aesaganda/k8boss-operator@sha256:4fffce07f23a34b3291caf32c51bec38032ff46f29bf846b57284263ca8c5f43
+    createdAt: "2026-09-10T00:00:00Z"
+    description: Reconciles Kubernetes-native segmentation and runtime-security intent
+      into the K8Boss Knowledge Graph, with evidence.
+    operators.operatorframework.io/builder: operator-sdk-v1.42.3
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/aesaganda/k8boss-operator
+    support: https://github.com/aesaganda/k8boss-operator/issues
+  labels:
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "true"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/os.linux: supported
+  name: k8boss-operator.v0.1.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: 'Cluster-wide K8Boss operator configuration. Exactly one instance,
+        named "default", governs the cluster: it selects the flow-telemetry provider
+        and holds the kill switch that halts every K8Boss reconciler. An instance
+        under any other name reports NotSingleton and governs nothing.'
+      displayName: Platform Config
+      kind: PlatformConfig
+      name: platformconfigs.k8boss.io
+      resources:
+      - kind: SegmentationPolicy
+        name: ""
+        version: v1alpha1
+      - kind: RuntimeSecurityPolicy
+        name: ""
+        version: v1alpha1
+      specDescriptors:
+      - description: Which FlowProvider backs flow telemetry for this cluster. This
+          is observability only — enforcement is the CNI's job, and K8Boss does not
+          claim to observe enforcement.
+        displayName: Flow Provider
+        path: flowProvider
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:select:RHNO
+        - urn:alm:descriptor:com.tectonic.ui:select:Hubble
+        - urn:alm:descriptor:com.tectonic.ui:select:Calico
+        - urn:alm:descriptor:com.tectonic.ui:select:Goldmane
+        - urn:alm:descriptor:com.tectonic.ui:select:Mock
+      - description: Halts every K8Boss reconciler without deleting or deregistering
+          anything already reconciled. Defaults to TRUE so that a freshly installed
+          operator cannot silently begin mutating cluster state.
+        displayName: Paused
+        path: paused
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      - description: One entry per provider the control plane reported, including
+          providers whose health could NOT be determined (health=Unknown with a reason).
+          A missing entry never means healthy.
+        displayName: Provider Health
+        path: providerHealth
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Provider Health
+      - displayName: Observed Generation
+        path: observedGeneration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      version: v1alpha1
+    - description: Attaches K8Boss Knowledge Graph evidence to an EXISTING Tetragon
+        TracingPolicy for a set of workloads. It does not replace, generate or install
+        Tetragon policy — K8Boss verifies what Tetragon reports.
+      displayName: Runtime Security Policy
+      kind: RuntimeSecurityPolicy
+      name: runtimesecuritypolicies.k8boss.io
+      specDescriptors:
+      - displayName: Workload Selector
+        path: selector.matchLabels
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Pod
+      - description: Name of an existing Tetragon TracingPolicy in this namespace.
+          K8Boss correlates evidence against it; it does not create it.
+        displayName: Tetragon TracingPolicy
+        path: tracingPolicyRef
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - description: Absolute paths whose execution K8Boss treats as a violation when
+          correlating runtime evidence for the selected workloads.
+        displayName: Denied Binaries
+        path: deniedBinaries
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:text
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      - displayName: Observed Generation
+        path: observedGeneration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      version: v1alpha1
+    - description: Declares network segmentation intent for a set of workloads in
+        one namespace. K8Boss reconciles that intent through its control-plane API
+        and records it in the Knowledge Graph with evidence; it does not itself program
+        the data plane.
+      displayName: Segmentation Policy
+      kind: SegmentationPolicy
+      name: segmentationpolicies.k8boss.io
+      specDescriptors:
+      - description: Labels selecting the workloads this policy governs, within its
+          own namespace.
+        displayName: Workload Selector
+        path: selector.matchLabels
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Pod
+      - displayName: Ingress Rules
+        path: ingress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Ingress
+      - displayName: Egress Rules
+        path: egress
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Egress
+      - description: Overrides PlatformConfig.spec.flowProvider for this policy only.
+          Empty uses the cluster default.
+        displayName: Flow Provider Override
+        path: providerRef
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+      statusDescriptors:
+      - displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes.conditions
+      - description: Which FlowProvider this policy was reconciled under. NOT a claim
+          that anything is enforcing the policy — it is set only on the confirmed-success
+          path.
+        displayName: Resolved Flow Provider
+        path: resolvedFlowProvider
+        x-descriptors:
+        - urn:alm:descriptor:text
+      - displayName: Observed Generation
+        path: observedGeneration
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:hidden
+      version: v1alpha1
+  description: |
+    K8Boss gives you visibility into Kubernetes network policy, service-mesh
+    posture, runtime process activity and GitOps delivery. It reads clusters,
+    correlates what it finds, and routes every mutation through governance.
+
+    This operator is the **Kubernetes-native intent layer** for that platform.
+    It turns three CRDs into reconciled, evidence-backed facts in the K8Boss
+    Knowledge Graph:
+
+    * **SegmentationPolicy** — network segmentation intent for a set of
+      workloads in a namespace.
+    * **RuntimeSecurityPolicy** — attaches Knowledge Graph evidence to an
+      existing Tetragon `TracingPolicy`.
+    * **PlatformConfig** — a cluster-scoped singleton that selects the flow
+      telemetry provider and holds the kill switch.
+
+    ### Requires a K8Boss control plane — this operator does not install one
+
+    This operator is a **bridge**, not an installer. Every reconcile is an
+    authenticated call to a K8Boss backend that must already be running, and
+    the operator writes nothing to a database directly. The operator is open
+    source (Apache-2.0); the K8Boss control plane it talks to is a separate,
+    commercially licensed product and is **not** installed by this operator.
+    Before it can do any work you need:
+
+    1. A K8Boss control plane, deployed separately via its Helm chart.
+    2. This cluster registered in that control plane, which yields a numeric
+       cluster id.
+    3. An operator API token that matches `OPERATOR_API_TOKEN` on the backend.
+
+    Installed without those, the operator comes up **healthy and idle** and
+    says so on the CR status conditions rather than pretending to work. It
+    deliberately distinguishes "nobody has told us where the backend is" from
+    "the backend is down" — reporting the second as the first would be a claim
+    the system cannot support.
+
+    ### Design commitments
+
+    * **No edge without evidence.** Every graph edge the operator creates
+      records why it exists, where that came from and how sure it is.
+    * **Time is a property of the edge.** Deleting a CR *closes* its edges
+      through a finalizer; nothing is hard-deleted, so history stays queryable.
+    * **Paused by default.** `PlatformConfig.spec.paused` defaults to `true`,
+      so an operator with no configuration applied cannot silently start
+      mutating cluster state.
+
+    ### Licence
+
+    This operator is licensed under the Apache License 2.0. The K8Boss control
+    plane is a separate commercial product under its own terms.
+  displayName: K8Boss
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzMiAzMiI+CiAgPGRlZnM+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImciIHgxPSIwJSIgeTE9IjAlIiB4Mj0iMTAwJSIgeTI9IjEwMCUiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdHlsZT0ic3RvcC1jb2xvcjojM2I4MmY2Ii8+CiAgICAgIDxzdG9wIG9mZnNldD0iMTAwJSIgc3R5bGU9InN0b3AtY29sb3I6IzYzNjZmMSIvPgogICAgPC9saW5lYXJHcmFkaWVudD4KICA8L2RlZnM+CiAgPHJlY3Qgd2lkdGg9IjMyIiBoZWlnaHQ9IjMyIiByeD0iNiIgZmlsbD0idXJsKCNnKSIvPgogIDx0ZXh0IHg9IjE2IiB5PSIyMiIgdGV4dC1hbmNob3I9Im1pZGRsZSIgZm9udC1mYW1pbHk9IkFyaWFsIiBmb250LXdlaWdodD0iYm9sZCIgZm9udC1zaXplPSIxNiIgZmlsbD0id2hpdGUiPks4PC90ZXh0Pgo8L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - k8boss.io
+          resources:
+          - platformconfigs
+          - runtimesecuritypolicies
+          - segmentationpolicies
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - k8boss.io
+          resources:
+          - platformconfigs/status
+          - runtimesecuritypolicies/status
+          - segmentationpolicies/status
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - k8boss.io
+          resources:
+          - runtimesecuritypolicies/finalizers
+          - segmentationpolicies/finalizers
+          verbs:
+          - update
+        serviceAccountName: k8boss-operator
+      deployments:
+      - label:
+          app.kubernetes.io/component: operator
+          app.kubernetes.io/name: k8boss-operator
+        name: k8boss-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/component: operator
+              app.kubernetes.io/name: k8boss-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: operator
+                app.kubernetes.io/name: k8boss-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - arm64
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                        - linux
+              containers:
+              - args:
+                - --leader-elect=true
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=127.0.0.1:8080
+                env:
+                - name: K8BOSS_CLUSTER_ID
+                - name: K8BOSS_BACKEND_URL
+                  value: http://k8boss-backend.k8boss-system.svc:8010
+                - name: K8BOSS_OPERATOR_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: token
+                      name: k8boss-operator
+                      optional: true
+                image: ghcr.io/aesaganda/k8boss-operator@sha256:4fffce07f23a34b3291caf32c51bec38032ff46f29bf846b57284263ca8c5f43
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: probes
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 8081
+                  name: probes
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: probes
+                  initialDelaySeconds: 5
+                  periodSeconds: 20
+                  timeoutSeconds: 5
+                resources:
+                  limits:
+                    memory: 256Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
+              securityContext:
+                runAsNonRoot: true
+                seccompProfile:
+                  type: RuntimeDefault
+              serviceAccountName: k8boss-operator
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - create
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        serviceAccountName: k8boss-operator
+    strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - networkpolicy
+  - segmentation
+  - zero-trust
+  - service-mesh
+  - tetragon
+  - runtime-security
+  - knowledge-graph
+  - gitops
+  links:
+  - name: Source
+    url: https://github.com/aesaganda/k8boss-operator
+  - name: Documentation
+    url: https://github.com/aesaganda/k8boss-operator#readme
+  - name: Issues
+    url: https://github.com/aesaganda/k8boss-operator/issues
+  maintainers:
+  - email: erensaganda@gmail.com
+    name: Eren Saganda
+  maturity: alpha
+  minKubeVersion: 1.25.0
+  provider:
+    name: Eren Saganda
+    url: https://github.com/aesaganda/k8boss-operator
+  relatedImages:
+  - image: ghcr.io/aesaganda/k8boss-operator@sha256:4fffce07f23a34b3291caf32c51bec38032ff46f29bf846b57284263ca8c5f43
+    name: manager
+  version: 0.1.0

--- a/operators/k8boss-operator/0.1.0/manifests/k8boss.io_platformconfigs.yaml
+++ b/operators/k8boss-operator/0.1.0/manifests/k8boss.io_platformconfigs.yaml
@@ -1,0 +1,188 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  creationTimestamp: null
+  name: platformconfigs.k8boss.io
+spec:
+  group: k8boss.io
+  names:
+    kind: PlatformConfig
+    listKind: PlatformConfigList
+    plural: platformconfigs
+    singular: platformconfig
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              PlatformConfigSpec is cluster-wide K8Boss operator configuration. There is
+              exactly one PlatformConfig per cluster (name: "default", enforced by
+              Phase 1's admission webhook, not by this type).
+            properties:
+              flowProvider:
+                description: FlowProvider selects which FlowProvider backs flow telemetry
+                  for this cluster.
+                enum:
+                - RHNO
+                - Hubble
+                - Calico
+                - Goldmane
+                - Mock
+                type: string
+              paused:
+                default: true
+                description: |-
+                  Paused halts every reconciler this operator runs (SegmentationPolicy,
+                  RuntimeSecurityPolicy) without deleting or deregistering anything they
+                  already reconciled. This is the CRD-native half of the previously
+                  deferred delivery kill switch. Defaults true: an
+                  operator with no PlatformConfig applied yet must not silently start
+                  mutating cluster state.
+                type: boolean
+            required:
+            - flowProvider
+            - paused
+            type: object
+          status:
+            properties:
+              conditions:
+                description: |-
+                  Conditions surfaces reconcile outcome, e.g. Type=Ready, Type=Paused.
+                  Every reconcile path — including early-return error paths — sets a
+                  condition here; none may exit silently (ADR-0003).
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+              providerHealth:
+                items:
+                  description: |-
+                    ProviderHealthStatus mirrors the existing FlowProvider/RuntimeSecurityProvider
+                    health_check()/last_query_error contract (docs/runbook-unverified-changes.md)
+                    as a k8s status condition — it is a read-back of that contract, not a new one.
+                  properties:
+                    health:
+                      default: Unknown
+                      description: |-
+                        Health is tri-state on purpose. A plain bool cannot say "we could not
+                        look", which would force an undetermined provider to assert Unknown as
+                        False — the exact conflation this repo separates elsewhere as
+                        no_flow_observed vs no_flow_provider_available. Unknown is also the
+                        zero value, so a half-populated entry reads as "unknown", never as
+                        "healthy".
+                      enum:
+                      - Unknown
+                      - "True"
+                      - "False"
+                      type: string
+                    lastQueryError:
+                      description: |-
+                        LastQueryError is empty only when Health is True and a query has
+                        actually succeeded — never a default-empty value for "haven't checked
+                        yet" (ADR-0003 / no-confident-conclusion-from-insufficient-evidence).
+                      type: string
+                    name:
+                      type: string
+                    observedAt:
+                      format: date-time
+                      type: string
+                    reason:
+                      description: |-
+                        Reason explains a Health of Unknown or False: which query failed, or
+                        why the control plane could not be asked. Required for both — a
+                        non-True health with no reason is a verdict with no evidence.
+                      type: string
+                  required:
+                  - health
+                  - name
+                  - observedAt
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/k8boss-operator/0.1.0/manifests/k8boss.io_runtimesecuritypolicies.yaml
+++ b/operators/k8boss-operator/0.1.0/manifests/k8boss.io_runtimesecuritypolicies.yaml
@@ -1,0 +1,154 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  creationTimestamp: null
+  name: runtimesecuritypolicies.k8boss.io
+spec:
+  group: k8boss.io
+  names:
+    kind: RuntimeSecurityPolicy
+    listKind: RuntimeSecurityPolicyList
+    plural: runtimesecuritypolicies
+    singular: runtimesecuritypolicy
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              RuntimeSecurityPolicySpec deliberately does not reimplement Tetragon's
+              policy language. The K8Boss control plane's RuntimeSecurityProvider stays
+              the sole contract for runtime enforcement (ADR-0003, mirrors the
+              FlowProvider/RuntimeSecurityProvider separation invariant) — this CRD
+              attaches K8Boss Knowledge Graph evidence to an existing Tetragon
+              TracingPolicy, it does not replace it. This reconciler must never import
+              or call anything under the FlowProvider path.
+            properties:
+              deniedBinaries:
+                description: |-
+                  DeniedBinaries is a minimal inline rule for the common case —
+                  forwarded to RuntimeSecurityProvider as-is, not interpreted here.
+                items:
+                  type: string
+                type: array
+              selector:
+                description: WorkloadSelector picks the workloads a policy governs,
+                  within the CR's own namespace.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              tracingPolicyRef:
+                description: |-
+                  TracingPolicyRef names an existing Tetragon TracingPolicy in this
+                  namespace that this CR correlates Knowledge Graph evidence against.
+                type: string
+            required:
+            - selector
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions surfaces reconcile outcome on every path,
+                  including errors.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              correlatedEvidenceCount:
+                description: |-
+                  CorrelatedEvidenceCount is how many runtime events the backend has
+                  actually attached to this CR's Knowledge Graph edges so far — 0 means
+                  either "none yet" or "correlation is failing"; Conditions must say
+                  which (no-confident-conclusion-from-insufficient-evidence).
+                format: int64
+                type: integer
+              observedGeneration:
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/k8boss-operator/0.1.0/manifests/k8boss.io_segmentationpolicies.yaml
+++ b/operators/k8boss-operator/0.1.0/manifests/k8boss.io_segmentationpolicies.yaml
@@ -1,0 +1,201 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.5
+  creationTimestamp: null
+  name: segmentationpolicies.k8boss.io
+spec:
+  group: k8boss.io
+  names:
+    kind: SegmentationPolicy
+    listKind: SegmentationPolicyList
+    plural: segmentationpolicies
+    singular: segmentationpolicy
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              egress:
+                items:
+                  description: |-
+                    SegmentationRule is a minimal representative shape, not a NetworkPolicy
+                    reimplementation — Phase 1 (teammate-api) is expected to revisit field
+                    coverage against real product requirements; this is a compilable contract,
+                    not a final API (ADR-0003).
+                  properties:
+                    peerNamespace:
+                      description: PeerNamespace scopes PeerSelector; empty means
+                        the policy's own namespace.
+                      type: string
+                    peerSelector:
+                      additionalProperties:
+                        type: string
+                      description: PeerSelector selects the workloads this rule allows
+                        traffic to/from.
+                      type: object
+                    ports:
+                      description: Ports this rule applies to; empty means all ports.
+                      items:
+                        format: int32
+                        type: integer
+                      type: array
+                  type: object
+                type: array
+              ingress:
+                items:
+                  description: |-
+                    SegmentationRule is a minimal representative shape, not a NetworkPolicy
+                    reimplementation — Phase 1 (teammate-api) is expected to revisit field
+                    coverage against real product requirements; this is a compilable contract,
+                    not a final API (ADR-0003).
+                  properties:
+                    peerNamespace:
+                      description: PeerNamespace scopes PeerSelector; empty means
+                        the policy's own namespace.
+                      type: string
+                    peerSelector:
+                      additionalProperties:
+                        type: string
+                      description: PeerSelector selects the workloads this rule allows
+                        traffic to/from.
+                      type: object
+                    ports:
+                      description: Ports this rule applies to; empty means all ports.
+                      items:
+                        format: int32
+                        type: integer
+                      type: array
+                  type: object
+                type: array
+              providerRef:
+                description: |-
+                  ProviderRef overrides the cluster's PlatformConfig.spec.flowProvider
+                  for this policy; empty means use the cluster default.
+                type: string
+              selector:
+                description: WorkloadSelector picks the workloads a policy governs,
+                  within the CR's own namespace.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+            required:
+            - selector
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions surfaces reconcile outcome on every path,
+                  including errors.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+              resolvedFlowProvider:
+                description: |-
+                  ResolvedFlowProvider records which FlowProvider this policy was
+                  reconciled under: spec.providerRef when set, otherwise the cluster
+                  default read from PlatformConfig at reconcile time. That last part is
+                  why it is worth a status field at all rather than being derivable from
+                  the spec — editing PlatformConfig later does not rewrite it, so it says
+                  what was in effect for THIS reconcile.
+
+                  It is NOT a claim that anything is enforcing this policy. A FlowProvider
+                  is flow *telemetry* (Hubble/Calico/RHNO); enforcement is the CNI's job
+                  and K8Boss does not observe it. This field was called `enforcedProvider`
+                  and did read as that claim; confirming real enforcement would mean
+                  observing the CNI's own programmed state, which K8Boss does not do.
+
+                  Set only on the confirmed-success path, so an unverified write leaves it
+                  empty rather than stamping intent (ADR-0003).
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/operators/k8boss-operator/0.1.0/metadata/annotations.yaml
+++ b/operators/k8boss-operator/0.1.0/metadata/annotations.yaml
@@ -1,0 +1,12 @@
+annotations:
+  # Core bundle annotations.
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: k8boss-operator
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.3
+  operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
+  operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
+  com.redhat.openshift.versions: "v4.14"

--- a/operators/k8boss-operator/ci.yaml
+++ b/operators/k8boss-operator/ci.yaml
@@ -1,0 +1,8 @@
+---
+# Use `replaces-mode` or `semver-mode`. Once you switch to `semver-mode`, there is no easy way back.
+# replaces-mode is the default and is reversible; semver-mode is a one-way door.
+# The API is v1alpha1 and the bundle ships maturity: alpha, so the upgrade graph
+# is stated explicitly per release rather than inferred from version ordering.
+updateGraph: replaces-mode
+reviewers:
+  - aesaganda


### PR DESCRIPTION
### New Submissions

- [x] Are you familiar with our [contribution guidelines](https://github.com/k8s-operatorhub/community-operators/blob/main/docs/contributing-prerequisites.md)?
- [x] Have you [packaged and deployed your Operator for Operator Framework](https://github.com/k8s-operatorhub/community-operators/blob/main/docs/packaging-operator.md)?
- [x] Have you [reviewed your submission](https://github.com/k8s-operatorhub/community-operators/blob/main/docs/packaging-required-criteria-ocp.md)?
- [x] Are all images used by your Operator available and referenced by digest?
- [x] Does your submission contain a single operator and nothing outside `operators/`?

---

## What this operator is

K8Boss reconciles Kubernetes-native segmentation and runtime-security **intent** — `SegmentationPolicy`, `RuntimeSecurityPolicy`, `PlatformConfig` — into the K8Boss Knowledge Graph.

It is a **bridge, not an installer**. Every reconcile is one authenticated HTTP call to a K8Boss control plane that must already exist. It creates no workloads and holds no RBAC to do so, and **it never enforces network policy** — enforcement is the CNI's job.

Source: [aesaganda/k8boss-operator](https://github.com/aesaganda/k8boss-operator), Apache-2.0.

## It installs clean with no configuration

An OLM install carries no user input by construction, so the operator deliberately starts **unconfigured** rather than crash-looping:

- the backend client becomes a stub that fails every call **without putting a request on the wire** — a leaked request would surface as "backend unreachable", which is the wrong answer;
- readiness **passes**, because there is no outage to report. A *configured* backend that cannot be reached still fails readiness loudly;
- every CR reports `Ready=False` with reason `AwaitingConfiguration`, naming the variables to set via `Subscription.spec.config.env`;
- the finalizer releases when unconfigured, so an uninstall cannot wedge CRs in `Terminating`.

Verified end-to-end on kind + OLM via the real catalog/Subscription/InstallPlan path: CSV reaches `Succeeded`, manager `Ready=true` with **0 restarts**.

## Honest metadata

- `capabilities: Basic Install` — it does no lifecycle management of an operand it owns, no backup/restore, no auto-tuning.
- `maturity: alpha`, channel `alpha`, API `v1alpha1` — the CRD field shapes are a contract, not a final API.
- `installModes: AllNamespaces` **only**. `PlatformConfig` is cluster-scoped and the manager has no per-namespace watch handling, so advertising `SingleNamespace` would claim a confinement the operator does not honour.

## Image

Pinned by digest, multi-arch (`linux/amd64`, `linux/arm64`), anonymously pullable:

```
ghcr.io/aesaganda/k8boss-operator@sha256:4fffce07f23a34b3291caf32c51bec38032ff46f29bf846b57284263ca8c5f43
```

The same digest appears in `containerImage`, the Deployment, and `spec.relatedImages`. All three are stamped from one variable, and the build refuses to produce a submission bundle from a floating tag.

Opened as a **draft** so the pipeline can run before a human spends time on it.