### PR TITLE
operator [CI] datadog-operator

### DIFF
--- a/operators/datadog-operator/ci.yaml
+++ b/operators/datadog-operator/ci.yaml
@@ -17,3 +17,8 @@ reviewers:
   - tbavelier
   - swang392
   - Eokye
+  - sabrina-datadog
+  - FlorentClarret
+  - avonengel
+  - AliDatadog
+  - kacper-murzyn


### PR DESCRIPTION
Adding new Datadog teammates to the `reviewers` list in `operators/datadog-operator/ci.yaml` so they can review/merge future operator updates.

Recreates #9259 with DCO sign-off (that PR was closed because it was created via the UI without a signed-off commit).

### Updates to existing Operators

- [x] Did you create a `ci.yaml` file according to the [update instructions](https://github.com/operator-framework/community-operators/blob/master/docs/operator-ci-yaml.md)?
- [x] Is your submission [signed](https://github.com/operator-framework/community-operators/blob/master/docs/contributing-prerequisites.md#sign-your-work)?

### Your submission should not

- [x] Modify more than one operator
- [x] Modify an Operator you don't own
- [x] Rename an operator
- [x] Modify any files outside the above mentioned folders
- [x] Contain more than one commit.